### PR TITLE
Gets gradle serve to also serve transpiled JS, adds gradle tasks for building react ui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ compileKotlinJs {
 }
 
 jsProcessResources { t ->
-    t.from('build/webpack')
+    t.from('build/processedResources/js/main/webpack')
     t.from('build/classes/kotlin/js/main')
 }
 
@@ -80,6 +80,21 @@ task serve << {
     HttpFileServer server = factory.start(new File("build/processedResources/js/main"), 8001)
     println("Server Started on http://localhost:${server.port}/index.html ctrc+c to kill it")
     java.lang.Thread.sleep(Long.MAX_VALUE);
+}
+
+task installReactUImodules(type: Exec) {
+    commandLine "npm", "install"
+}
+
+task buildReactUI(type: Exec) {
+    inputs.file("package-lock.json").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file("webpack.config.js").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir("src/jsMain/js").withPathSensitivity(PathSensitivity.RELATIVE)
+    
+    outputs.dir("$buildDir/processedResources/js/main/webpack")
+    outputs.cacheIf { true }
+    
+    commandLine "$projectDir/node_modules/.bin/webpack-cli", "--config", "$projectDir/webpack.config.js", "--mode", "production"
 }
 
 //task assembleWeb(type: Sync) {

--- a/build.gradle
+++ b/build.gradle
@@ -100,5 +100,5 @@ task buildReactUI(type: Exec) {
     outputs.dir("$buildDir/webpack")
     outputs.cacheIf { true }
 
-    commandLine "$projectDir/node_modules/.bin/webpack-cli", "--config", "$projectDir/webpack.config.js", "--mode", "production"
+    commandLine "$projectDir/node_modules/.bin/webpack-cli", "--config", "$projectDir/webpack.config.js", "--mode", "development", "--color"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.cache=true

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div id="react-app"></div>
-<script type="application/javascript" src="app.js"></script>
+<script type="application/javascript" src="webpack/react_app.js"></script>
 <div id="sheepView"></div>
 
 <div id="simulatorView">
@@ -51,13 +51,13 @@
 <select id="panelSelect"></select>
 <div id="info"></div>
 <div id="info2"></div>
-<script type="text/javascript" src="lib/kotlin.js"></script>
-<script type="text/javascript" src="lib/kotlinx-coroutines-core.js"></script>
+<script type="application/javascript" src="lib/kotlin.js"></script>
+<script type="application/javascript" src="lib/kotlinx-coroutines-core.js"></script>
 
-<script type="text/javascript" src="lib/three.js"></script>
-<script type="text/javascript" src="lib/OrbitControls.js"></script>
+<script type="application/javascript" src="lib/three.js"></script>
+<script type="application/javascript" src="lib/OrbitControls.js"></script>
 
-<script type="text/javascript">
+<script type="application/javascript">
   // cache busting
   const cacheBustStr = 2 || new Date().getTime();
   [
@@ -68,7 +68,7 @@
   });
 </script>
 
-<script type="text/javascript">
+<script type="application/javascript">
   let sheepSimulator = new sparklemotion.baaahs.SheepSimulator();
   sheepSimulator.start();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,9 +23,9 @@ module.exports = {
         extensions: ['*', '.js', '.jsx']
     },
     output: {
-        path: __dirname + '/build/webpack/',
+        path: __dirname + '/build/processedResources/js/main/webpack/',
         publicPath: '/js/',
-        filename: 'app.js'
+        filename: 'react_app.js'
     },
     devtool: false,
     plugins: [


### PR DESCRIPTION
I added some gradle tasks for doing common JS workflow stuff:

- `npm install` -> `./gradlew installReactUImodules`
- `npm run build` -> `./gradlew buildReactUI`

I also moved the transpiled JS so it would get served by `./gradlew serve`. I wasn't able to figure out how to get `./gradlew serve` to serve two root directories. I'm not sure what the best practice is, so I figured it would be easier to move `/build/webpack/app.js` to `/build/processedResources/js/main/webpack/react_app.js`