### PR TITLE
Refactor Color to hold value as Int ARGB

### DIFF
--- a/src/commonMain/kotlin/baaahs/Color.kt
+++ b/src/commonMain/kotlin/baaahs/Color.kt
@@ -16,11 +16,7 @@ data class Color(val argb: Int) {
     /** Values are bounded at `0f..1f`. */
     constructor(red: Int, green: Int, blue: Int, alpha: Int = 255) : this(asArgb(red, green, blue, alpha))
 
-    fun serialize(writer: ByteArrayWriter) {
-        writer.writeByte(redI.toByte())
-        writer.writeByte(greenI.toByte())
-        writer.writeByte(blueI.toByte())
-    }
+    fun serialize(writer: ByteArrayWriter) = writer.writeInt(argb)
 
     @Transient val alphaI: Int get() = alphaI(argb)
     @Transient val redI: Int get() = redI(argb)
@@ -63,7 +59,8 @@ data class Color(val argb: Int) {
         return Color(
             redF + (1 - redF) * desaturation,
             greenF + (1 - greenF) * desaturation,
-            blueF + (1 - blueF) * desaturation
+            blueF + (1 - blueF) * desaturation,
+            alphaF
         )
     }
 
@@ -113,11 +110,7 @@ data class Color(val argb: Int) {
             Random.nextInt() and 0xff
         )
 
-        fun parse(reader: ByteArrayReader) = Color(
-            reader.readByte().toInt() and 0xff,
-            reader.readByte().toInt() and 0xff,
-            reader.readByte().toInt() and 0xff
-        )
+        fun parse(reader: ByteArrayReader) = Color(reader.readInt())
 
         @JsName("fromInts")
         fun from(i: Int) = Color(i)

--- a/src/commonMain/kotlin/baaahs/Color.kt
+++ b/src/commonMain/kotlin/baaahs/Color.kt
@@ -3,36 +3,47 @@ package baaahs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlin.js.JsName
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.sqrt
 import kotlin.random.Random
 
 @Serializable
-data class Color(val red: Int, val green: Int, val blue: Int) {
+data class Color(val argb: Int) {
+    /** Values are bounded at `0..255`. */
+    constructor(red: Float, green: Float, blue: Float, alpha: Float = 1f) : this(asArgb(red, green, blue, alpha))
+
+    /** Values are bounded at `0f..1f`. */
+    constructor(red: Int, green: Int, blue: Int, alpha: Int = 255) : this(asArgb(red, green, blue, alpha))
+
     fun serialize(writer: ByteArrayWriter) {
-        writer.writeByte((red and 0xff).toByte())
-        writer.writeByte((green and 0xff).toByte())
-        writer.writeByte((blue and 0xff).toByte())
+        writer.writeByte(redI.toByte())
+        writer.writeByte(greenI.toByte())
+        writer.writeByte(blueI.toByte())
     }
 
-    @Transient
-    val redF: Float
-        get() = red.toFloat() / 255
-    @Transient
-    val greenF: Float
-        get() = green.toFloat() / 255
-    @Transient
-    val blueF: Float
-        get() = blue.toFloat() / 255
+    @Transient val alphaI: Int get() = alphaI(argb)
+    @Transient val redI: Int get() = redI(argb)
+    @Transient val greenI: Int get() = greenI(argb)
+    @Transient val blueI: Int get() = blueI(argb)
 
-    fun toInt(): Int =
-        (red shl 16 and 0xff0000)
-            .or(green shl 8 and 0xff00)
-            .or(blue and 0xff)
+    @Transient val alphaF: Float get() = alphaI.toFloat() / 255
+    @Transient val redF: Float get() = redI.toFloat() / 255
+    @Transient val greenF: Float get() = greenI.toFloat() / 255
+    @Transient val blueF: Float get() = blueI.toFloat() / 255
+
+    fun alphaI(value: Int) = value shr 24 and 0xff
+    fun redI(value: Int) = value shr 16 and 0xff
+    fun greenI(value: Int) = value shr 8 and 0xff
+    fun blueI(value: Int) = value and 0xff
+
+    fun toInt(): Int = argb
 
     @JsName("toHexString")
     fun toHexString() =
-        "#" + red.toHexString() + green.toHexString() + blue.toHexString()
+        "#" + maybe(alphaI) + redI.toHexString() + greenI.toHexString() + blueI.toHexString()
+
+    private fun maybe(alphaI: Int): String = if (alphaI == 255) "" else alphaI.toHexString()
 
     fun Int.toHexString(): String {
         if (this < 0) {
@@ -46,12 +57,13 @@ data class Color(val red: Int, val green: Int, val blue: Int) {
         }
     }
 
+    /** Super-naive approximation of desaturation. */
     fun withSaturation(saturation: Float): Color {
         val desaturation = 1 - saturation
         return Color(
-            min(255, red + ((255 - red) * desaturation).toInt()),
-            min(255, green + ((255 - green) * desaturation).toInt()),
-            min(255, blue + ((255 - blue) * desaturation).toInt())
+            redF + (1 - redF) * desaturation,
+            greenF + (1 - greenF) * desaturation,
+            blueF + (1 - blueF) * desaturation
         )
     }
 
@@ -64,19 +76,25 @@ data class Color(val red: Int, val green: Int, val blue: Int) {
 
     fun plus(other: Color): Color =
         Color(
-            min(red + other.red, 255),
-            min(green + other.green, 255),
-            min(blue + other.blue, 255)
+            alphaI
+                    or min(255, redI + other.redI)
+                    or min(255, greenI + other.greenI)
+                    or min(255, blueI + other.blueI)
         )
 
     fun fade(other: Color, amount: Float = 0.5f): Color {
         val amountThis = 1 - amount
 
         return Color(
-            min((red * amountThis + other.red * amount).toInt(), 255),
-            min((green * amountThis + other.green * amount).toInt(), 255),
-            min((blue * amountThis + other.blue * amount).toInt(), 255)
+            redF * amountThis + other.redF * amount,
+            greenF * amountThis + other.greenF * amount,
+            blueF * amountThis + other.blueF * amount,
+            alphaF * amountThis + other.alphaF * amount
         )
+    }
+
+    override fun toString(): String {
+        return "Color(${toHexString()})"
     }
 
     companion object {
@@ -102,24 +120,33 @@ data class Color(val red: Int, val green: Int, val blue: Int) {
         )
 
         @JsName("fromInts")
-        fun from(i: Int) =
-            Color(
-                i shr 16 and 0xff,
-                i shr 8 and 0xff,
-                i and 0xff
-            )
+        fun from(i: Int) = Color(i)
 
         @JsName("fromString")
         fun from(hex: String): Color {
             val hexDigits = hex.trimStart('#')
             if (hexDigits.length == 6) {
-                return Color(
-                    hexDigits.substring(0, 2).toInt(16),
-                    hexDigits.substring(2, 4).toInt(16),
-                    hexDigits.substring(4, 6).toInt(16)
-                )
+                val l: Int = 0xff000000.toInt()
+                // huh? that's not an Int already? I'm supposed to do twos-complement math and negate? blech Kotlin.
+                return Color((l or hexDigits.toInt(16)).toInt())
             }
             throw IllegalArgumentException("unknown color \"$hex\"")
         }
+
+        private fun asArgb(red: Float, green: Float, blue: Float, alpha: Float = 1f): Int {
+            val asArgb = asArgb(asInt(red), asInt(green), asInt(blue), asInt(alpha))
+            return asArgb
+        }
+
+        private fun asArgb(red: Int, green: Int, blue: Int, alpha: Int = 255): Int {
+            return ((bounded(alpha) shl 24)
+                    or (bounded(red) shl 16)
+                    or (bounded(green) shl 8)
+                    or (bounded(blue)))
+        }
+
+        private fun bounded(i: Int): Int = max(0, min(255, i))
+        private fun bounded(f: Float): Float = max(0f, min(1f, f))
+        private fun asInt(f: Float): Int = (bounded(f) * 255).toInt()
     }
 }

--- a/src/commonTest/kotlin/baaahs/ColorTest.kt
+++ b/src/commonTest/kotlin/baaahs/ColorTest.kt
@@ -5,15 +5,28 @@ import kotlin.test.assertEquals
 
 public class ColorTest {
     @Test
+    fun testBounds() {
+        Color.WHITE
+        assertEquals(Color(255, 255, 0, 255),
+            Color(266, 1024, -17, 350))
+
+        assertEquals(Color(255, 255, 0, 255),
+            Color(26.6f, 10.24f, -17f, 350f))
+
+        assertEquals(Color(1f, 1f, 0f, 1f),
+            Color(26.6f, 10.24f, -17f, 350f))
+    }
+
+    @Test
     fun testFromInt() {
         val white = Color.from(0xfefdff)
-        assertEquals(listOf(254, 253, 255), listOf(white.red, white.green, white.blue))
+        assertEquals(listOf(254, 253, 255), listOf(white.redI, white.greenI, white.blueI))
     }
 
     @Test
     fun testFromString() {
         val white = Color.from("#fefdff")
-        assertEquals(listOf(254, 253, 255), listOf(white.red, white.green, white.blue))
+        assertEquals(listOf(254, 253, 255), listOf(white.redI, white.greenI, white.blueI))
     }
 
     @Test

--- a/src/commonTest/kotlin/baaahs/ColorTest.kt
+++ b/src/commonTest/kotlin/baaahs/ColorTest.kt
@@ -21,4 +21,23 @@ public class ColorTest {
         assertEquals(1f, Color.WHITE.distanceTo(Color.BLACK))
         assertEquals(0f, Color.WHITE.distanceTo(Color.WHITE))
     }
+
+    @Test
+    fun testToHexString() {
+        assertEquals("#fefdff", Color.from("#fefdff").toHexString())
+    }
+
+    @Test
+    fun testWithSaturation() {
+        val red = Color.from("#ff0000")
+        assertEquals(red, red.withSaturation(1f))
+        assertEquals(Color.from("#ff7f7f"), red.withSaturation(.5f))
+    }
+
+    @Test
+    fun testFade() {
+        assertEquals(Color.RED, Color.RED.fade(Color.GREEN, 0f))
+        assertEquals(Color.GREEN, Color.RED.fade(Color.GREEN, 1f))
+        assertEquals(Color.from("#7f7f00"), Color.RED.fade(Color.GREEN, 0.5f))
+    }
 }


### PR DESCRIPTION
* Reduces storage from three ints to one.
* Nicer interface for performing calculations using int or float values.
* Network representation now includes alpha.

Apart from [`0xff000000` being a `Long`](https://github.com/baaahs/sparklemotion/pull/26/files#diff-a666129101121db60159e642edb1dfc1R122), pretty pleased with Kotlin on this.