### PR TITLE
Refactor show/shader API

### DIFF
--- a/src/commonMain/kotlin/baaahs/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/Shaders.kt
@@ -4,7 +4,7 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import baaahs.shaders.*
 
-enum class ShaderType(val parser: (reader: ByteArrayReader) -> Shader) {
+enum class ShaderId(val parser: (reader: ByteArrayReader) -> Shader) {
     SOLID({ reader -> SolidShader.parse(reader) }),
     PIXEL({ reader -> PixelShader.parse(reader) }),
     SINE_WAVE({ reader -> SineWaveShader.parse(reader) }),
@@ -13,20 +13,20 @@ enum class ShaderType(val parser: (reader: ByteArrayReader) -> Shader) {
 
     companion object {
         val values = values()
-        fun get(i: Byte): ShaderType {
+        fun get(i: Byte): ShaderId {
             if (i > values.size || i < 0) {
-                throw Throwable("bad index for ShaderType: ${i}")
+                throw Throwable("bad index for ShaderId: ${i}")
             }
             return values[i.toInt()]
         }
     }
 }
 
-abstract class Shader(val type: ShaderType) {
+abstract class Shader(val id: ShaderId) {
     abstract val buffer: ShaderBuffer
 
     open fun serialize(writer: ByteArrayWriter) {
-        writer.writeByte(type.ordinal.toByte())
+        writer.writeByte(id.ordinal.toByte())
     }
 
     open fun serializeBuffer(writer: ByteArrayWriter) {
@@ -42,7 +42,7 @@ abstract class Shader(val type: ShaderType) {
     companion object {
         fun parse(reader: ByteArrayReader): Shader {
             val shaderTypeI = reader.readByte()
-            val shaderType = ShaderType.get(shaderTypeI)
+            val shaderType = ShaderId.get(shaderTypeI)
             return shaderType.parser(reader)
         }
     }

--- a/src/commonMain/kotlin/baaahs/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/Shaders.kt
@@ -4,7 +4,7 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import baaahs.shaders.*
 
-enum class ShaderId(val parser: (reader: ByteArrayReader) -> Shader) {
+enum class ShaderId(val parser: (reader: ByteArrayReader) -> Shader<*>) {
     SOLID({ reader -> SolidShader.parse(reader) }),
     PIXEL({ reader -> PixelShader.parse(reader) }),
     SINE_WAVE({ reader -> SineWaveShader.parse(reader) }),
@@ -22,25 +22,36 @@ enum class ShaderId(val parser: (reader: ByteArrayReader) -> Shader) {
     }
 }
 
-abstract class Shader(val id: ShaderId) {
-    abstract val buffer: ShaderBuffer
+interface Surface {
+    val pixelCount: Int
+}
 
-    open fun serialize(writer: ByteArrayWriter) {
+abstract class Shader<B : ShaderBuffer>(val id: ShaderId) {
+    abstract fun createImpl(pixels: Pixels): ShaderImpl<B>
+
+    abstract fun createBuffer(surface: Surface): B
+
+    val descriptorBytes: ByteArray by lazy { toBytes() }
+
+    fun serialize(writer: ByteArrayWriter) {
         writer.writeByte(id.ordinal.toByte())
+        serializeConfig(writer)
     }
 
-    open fun serializeBuffer(writer: ByteArrayWriter) {
-        buffer.serialize(writer)
+    /** Override if your shader has static configuration that needs to be shared with the ShaderImpl. */
+    open fun serializeConfig(writer: ByteArrayWriter) {
     }
 
-    abstract fun createImpl(pixels: Pixels): ShaderImpl
-
-    open fun readBuffer(reader: ByteArrayReader) {
-        buffer.read(reader)
+    private fun toBytes(): ByteArray {
+        val writer = ByteArrayWriter()
+        serialize(writer)
+        return writer.toBytes()
     }
+
+    abstract fun readBuffer(reader: ByteArrayReader): B
 
     companion object {
-        fun parse(reader: ByteArrayReader): Shader {
+        fun parse(reader: ByteArrayReader): Shader<*> {
             val shaderTypeI = reader.readByte()
             val shaderType = ShaderId.get(shaderTypeI)
             return shaderType.parser(reader)
@@ -49,13 +60,18 @@ abstract class Shader(val id: ShaderId) {
 }
 
 interface ShaderBuffer {
+    val shader: Shader<*>
+
     fun serialize(writer: ByteArrayWriter)
 
+    /**
+     * Read new data into an existing buffer (as efficiently as possible).
+     */
     fun read(reader: ByteArrayReader)
 }
 
-interface ShaderImpl {
-    fun draw()
+interface ShaderImpl<B : ShaderBuffer> {
+    fun draw(buffer: B)
 }
 
 interface Pixels {

--- a/src/commonMain/kotlin/baaahs/SheepModel.kt
+++ b/src/commonMain/kotlin/baaahs/SheepModel.kt
@@ -75,7 +75,9 @@ class SheepModel {
         val faces: MutableList<Face> = mutableListOf()
     }
 
-    class Panel(val name: String) {
+    class Panel(val name: String) : Surface {
+        override val pixelCount = SparkleMotion.DEFAULT_PIXEL_COUNT // todo: not this
+
         val faces = Faces()
         val lines = mutableListOf<Line>()
     }

--- a/src/commonMain/kotlin/baaahs/SparkleMotion.kt
+++ b/src/commonMain/kotlin/baaahs/SparkleMotion.kt
@@ -1,0 +1,5 @@
+package baaahs
+
+object SparkleMotion {
+    const val DEFAULT_PIXEL_COUNT = 2048
+}

--- a/src/commonMain/kotlin/baaahs/io/ByteArrayReader.kt
+++ b/src/commonMain/kotlin/baaahs/io/ByteArrayReader.kt
@@ -1,6 +1,13 @@
 package baaahs.io
 
-class ByteArrayReader(val bytes: ByteArray, var offset: Int = 0) {
+class ByteArrayReader(val bytes: ByteArray, offset: Int = 0) {
+    var offset = offset
+        set(value) {
+            if (value > bytes.size) {
+                throw IllegalStateException("array index out of bounds")
+            }
+            field = value
+        }
     fun readBoolean(): Boolean = bytes[offset] != 0.toByte()
 
     fun readByte(): Byte = bytes[offset++]

--- a/src/commonMain/kotlin/baaahs/proto/Protocol.kt
+++ b/src/commonMain/kotlin/baaahs/proto/Protocol.kt
@@ -1,6 +1,7 @@
 package baaahs.proto
 
 import baaahs.Shader
+import baaahs.ShaderBuffer
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
@@ -51,18 +52,22 @@ class BrainHelloMessage(val panelName: String) : Message(Type.BRAIN_HELLO) {
     }
 }
 
-class BrainShaderMessage(val shader: Shader) : Message(Type.BRAIN_PANEL_SHADE) {
+class BrainShaderMessage(val shader: Shader<*>, val buffer: ShaderBuffer) : Message(Type.BRAIN_PANEL_SHADE) {
     companion object {
+        /**
+         * Suboptimal parser; on the Brain we'll do better than this.
+         */
         fun parse(reader: ByteArrayReader): BrainShaderMessage {
-            val shader = Shader.parse(reader)
-            shader.readBuffer(reader)
-            return BrainShaderMessage(shader)
+            val shaderDesc = reader.readBytes()
+            val shader = Shader.parse(ByteArrayReader(shaderDesc))
+            val buffer = shader.readBuffer(reader)
+            return BrainShaderMessage(shader, buffer)
         }
     }
 
     override fun serialize(writer: ByteArrayWriter) {
-        shader.serialize(writer)
-        shader.serializeBuffer(writer)
+        writer.writeBytes(shader.descriptorBytes)
+        buffer.serialize(writer)
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
@@ -4,7 +4,7 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
-class CompositorShader(val aShader: Shader, val bShader: Shader) : Shader(ShaderType.COMPOSITOR) {
+class CompositorShader(val aShader: Shader, val bShader: Shader) : Shader(ShaderId.COMPOSITOR) {
     override val buffer = CompositorShaderBuffer()
 
     override fun serialize(writer: ByteArrayWriter) {

--- a/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
@@ -4,29 +4,28 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
-class CompositorShader(val aShader: Shader, val bShader: Shader) : Shader(ShaderId.COMPOSITOR) {
-    override val buffer = CompositorShaderBuffer()
+class CompositorShader(val aShader: Shader<*>, val bShader: Shader<*>) :
+    Shader<CompositorShader.Buffer>(ShaderId.COMPOSITOR) {
 
-    override fun serialize(writer: ByteArrayWriter) {
-        super.serialize(writer)
+    override fun createBuffer(surface: Surface) = Buffer(aShader.createBuffer(surface), bShader.createBuffer(surface))
+
+    override fun serializeConfig(writer: ByteArrayWriter) {
         aShader.serialize(writer)
         bShader.serialize(writer)
     }
 
-    override fun serializeBuffer(writer: ByteArrayWriter) {
-        super.serializeBuffer(writer)
-        aShader.serializeBuffer(writer)
-        bShader.serializeBuffer(writer)
-    }
+    override fun createImpl(pixels: Pixels): ShaderImpl<Buffer> = Impl(aShader, bShader, pixels)
 
-    override fun createImpl(pixels: Pixels): ShaderImpl =
-        CompositorShaderImpl(aShader, bShader, buffer, pixels)
+    override fun readBuffer(reader: ByteArrayReader): Buffer =
+        Buffer(
+            aShader.readBuffer(reader),
+            bShader.readBuffer(reader),
+            CompositingMode.get(reader.readByte()),
+            reader.readFloat()
+        )
 
-    override fun readBuffer(reader: ByteArrayReader) {
-        super.readBuffer(reader)
-        aShader.readBuffer(reader)
-        bShader.readBuffer(reader)
-    }
+    fun createBuffer(aShaderBuffer: ShaderBuffer, bShaderBuffer: ShaderBuffer): Buffer =
+        Buffer(aShaderBuffer, bShaderBuffer)
 
     companion object {
         fun parse(reader: ByteArrayReader): CompositorShader {
@@ -35,69 +34,74 @@ class CompositorShader(val aShader: Shader, val bShader: Shader) : Shader(Shader
             return CompositorShader(shaderA, shaderB)
         }
     }
-}
 
-class CompositorShaderImpl(
-    aShader: Shader,
-    bShader: Shader,
-    val buffer: CompositorShaderBuffer,
-    val pixels: Pixels
-) : ShaderImpl {
-    private val colors = Array(pixels.count) { Color.WHITE }
-    private val aPixels = PixelBuf(pixels.count)
-    private val bPixels = PixelBuf(pixels.count)
-    private val shaderAImpl: ShaderImpl = aShader.createImpl(aPixels)
-    private val shaderBImpl: ShaderImpl = bShader.createImpl(bPixels)
+    inner class Buffer(
+        val aShaderBuffer: ShaderBuffer, val bShaderBuffer: ShaderBuffer,
+        var mode: CompositingMode = CompositingMode.OVERLAY,
+        var fade: Float = 0.5f
+    ) : ShaderBuffer {
+        override val shader: Shader<*> = this@CompositorShader
 
-    override fun draw() {
-        shaderAImpl.draw()
-        shaderBImpl.draw()
-
-        val operation: (aColor: Color, bColor: Color) -> Color
-        operation = when (buffer.mode) {
-            CompositingMode.ADD -> { a, b -> a.plus(b) }
-            CompositingMode.OVERLAY -> { a, b -> b }
+        override fun serialize(writer: ByteArrayWriter) {
+            aShaderBuffer.serialize(writer)
+            bShaderBuffer.serialize(writer)
+            writer.writeByte(mode.ordinal.toByte())
+            writer.writeFloat(fade)
         }
 
-        for (i in colors.indices) {
-            val aColor = aPixels.colors[i]
-            val bColor = bPixels.colors[i]
-
-            colors[i] = aColor.fade(operation(aColor, bColor), buffer.fade)
+        override fun read(reader: ByteArrayReader) {
+            aShaderBuffer.read(reader)
+            bShaderBuffer.read(reader)
+            mode = CompositingMode.get(reader.readByte())
+            fade = reader.readFloat()
         }
-        pixels.set(colors)
-    }
-}
-
-class PixelBuf(override val count: Int) : Pixels {
-    val colors = Array(count) { Color.WHITE }
-
-    override fun set(colors: Array<Color>) {
-        colors.copyInto(this.colors)
-    }
-}
-
-class CompositorShaderBuffer(
-    var mode: CompositingMode = CompositingMode.OVERLAY,
-    var fade: Float = 0.5f
-) : ShaderBuffer {
-    override fun serialize(writer: ByteArrayWriter) {
-        writer.writeByte(mode.ordinal.toByte())
-        writer.writeFloat(fade)
     }
 
-    override fun read(reader: ByteArrayReader) {
-        mode = CompositingMode.get(reader.readByte())
-        fade = reader.readFloat()
+    class Impl<A : ShaderBuffer, B : ShaderBuffer>(
+        aShader: Shader<A>,
+        bShader: Shader<B>,
+        val pixels: Pixels
+    ) : ShaderImpl<Buffer> {
+        private val colors = Array(pixels.count) { Color.WHITE }
+        private val aPixels = PixelBuf(pixels.count)
+        private val bPixels = PixelBuf(pixels.count)
+        private val shaderAImpl: ShaderImpl<A> = aShader.createImpl(aPixels)
+        private val shaderBImpl: ShaderImpl<B> = bShader.createImpl(bPixels)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun draw(buffer: Buffer) {
+            shaderAImpl.draw(buffer.aShaderBuffer as A)
+            shaderBImpl.draw(buffer.bShaderBuffer as B)
+
+            val mode = buffer.mode
+            for (i in colors.indices) {
+                val aColor = aPixels.colors[i]
+                val bColor = bPixels.colors[i]
+                colors[i] = aColor.fade(mode.composite(aColor, bColor), buffer.fade)
+            }
+            pixels.set(colors)
+        }
+
+        class PixelBuf(override val count: Int) : Pixels {
+            val colors = Array(count) { Color.WHITE }
+
+            override fun set(colors: Array<Color>) {
+                colors.copyInto(this.colors)
+            }
+        }
     }
 }
 
 enum class CompositingMode {
-    OVERLAY,
-    ADD;
+    OVERLAY { override fun composite(src: Color, dest: Color) = src },
+    ADD { override fun composite(src: Color, dest: Color) = dest.plus(src) };
+
+    abstract fun composite(src: Color, dest: Color): Color
 
     companion object {
         val values = values()
-        fun get(i: Byte) = values[i.toInt()]
+        fun get(i: Byte): CompositingMode {
+            return values[i.toInt()]
+        }
     }
 }

--- a/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
@@ -5,43 +5,53 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import kotlin.math.min
 
-class PixelShader : Shader(ShaderId.PIXEL) {
-    override val buffer = PixelShaderBuffer()
+class PixelShader() : Shader<PixelShader.Buffer>(ShaderId.PIXEL) {
 
-    override fun createImpl(pixels: Pixels): ShaderImpl = PixelShaderImpl(buffer, pixels)
+    override fun createBuffer(surface: Surface): Buffer = Buffer(surface.pixelCount)
+
+    override fun createImpl(pixels: Pixels): ShaderImpl<Buffer> = Impl(pixels)
+
+    override fun readBuffer(reader: ByteArrayReader): Buffer {
+        val incomingColorCount = reader.readInt()
+        val buf = Buffer(incomingColorCount)
+        (0 until incomingColorCount).forEach { index -> buf.colors[index] = Color.parse(reader) }
+        return buf
+    }
 
     companion object {
         fun parse(reader: ByteArrayReader) = PixelShader()
     }
-}
 
-class PixelShaderImpl(val buffer: PixelShaderBuffer, val pixels: Pixels) : ShaderImpl {
-    private val colors = Array(pixels.count) { Color.WHITE }
+    inner class Buffer(pixelCount: Int) : ShaderBuffer {
+        override val shader: Shader<*>
+            get() = this@PixelShader
 
-    override fun draw() {
-        val pixCount = min(buffer.colors.size, colors.size)
-        for (i in 0 until pixCount) {
-            colors[i] = buffer.colors[i]
+        var colors: Array<Color> = Array(pixelCount) { Color.WHITE }
+
+        override fun serialize(writer: ByteArrayWriter) {
+            writer.writeInt(colors.size)
+            colors.forEach { color -> color.serialize(writer) }
         }
-        pixels.set(colors)
-    }
-}
 
-class PixelShaderBuffer : ShaderBuffer {
-    private var fakeyTerribleHardCodedNumberOfPixels: Int = 1337
-    var colors: Array<Color> = Array(fakeyTerribleHardCodedNumberOfPixels) { Color.WHITE }
+        override fun read(reader: ByteArrayReader) {
+            val incomingColorCount = reader.readInt()
+            if (incomingColorCount != colors.size) {
+                throw IllegalStateException("incoming color count ($incomingColorCount) doesn't match buffer (${colors.size}")
+            }
+            (0 until incomingColorCount).forEach { index -> colors[index] = Color.parse(reader) }
+        }
 
-    override fun serialize(writer: ByteArrayWriter) {
-        writer.writeInt(colors.size)
-        colors.forEach { color -> color.serialize(writer) }
-    }
-
-    override fun read(reader: ByteArrayReader) {
-        val incomingColorCount = reader.readInt()
-        (0 until incomingColorCount).forEach { index -> colors[index] = Color.parse(reader) }
+        fun setAll(color: Color) {
+            for (i in colors.indices) {
+                colors[i] = color
+            }
+        }
     }
 
-    fun setAll(color: Color) {
-        for (i in colors.indices) { colors[i] = color }
+    class Impl(val pixels: Pixels) : ShaderImpl<Buffer> {
+        override fun draw(buffer: Buffer) {
+            pixels.set(buffer.colors)
+        }
     }
+
 }

--- a/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
@@ -5,7 +5,7 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import kotlin.math.min
 
-class PixelShader : Shader(ShaderType.PIXEL) {
+class PixelShader : Shader(ShaderId.PIXEL) {
     override val buffer = PixelShaderBuffer()
 
     override fun createImpl(pixels: Pixels): ShaderImpl = PixelShaderImpl(buffer, pixels)

--- a/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
@@ -6,7 +6,7 @@ import baaahs.io.ByteArrayWriter
 import kotlin.math.PI
 import kotlin.math.sin
 
-class SineWaveShader : Shader(ShaderType.SINE_WAVE) {
+class SineWaveShader : Shader(ShaderId.SINE_WAVE) {
     override val buffer = SineWaveShaderBuffer()
 
     override fun createImpl(pixels: Pixels): ShaderImpl =

--- a/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
@@ -6,60 +6,51 @@ import baaahs.io.ByteArrayWriter
 import kotlin.math.PI
 import kotlin.math.sin
 
-class SineWaveShader : Shader(ShaderId.SINE_WAVE) {
-    override val buffer = SineWaveShaderBuffer()
+class SineWaveShader() : Shader<SineWaveShader.Buffer>(ShaderId.SINE_WAVE) {
+    override fun createBuffer(surface: Surface): Buffer = Buffer()
 
-    override fun createImpl(pixels: Pixels): ShaderImpl =
-        SineWaveShaderImpl(buffer, pixels)
+    override fun readBuffer(reader: ByteArrayReader): Buffer = Buffer().apply { read(reader) }
+
+    override fun createImpl(pixels: Pixels): ShaderImpl<Buffer> = Impl(pixels)
 
     companion object {
         fun parse(reader: ByteArrayReader) = SineWaveShader()
     }
-}
 
-class SineWaveShaderImpl(
-    val buffer: SineWaveShaderBuffer,
-    val pixels: Pixels
-) : ShaderImpl {
-    private val colors = Array(pixels.count) { Color.WHITE }
+    inner class Buffer : ShaderBuffer {
+        override val shader: Shader<*>
+            get() = this@SineWaveShader
 
-    override fun draw() {
-        val theta = buffer.theta
-        val pixelCount = pixels.count.toFloat()
-        val density = buffer.density
+        var color: Color = Color.WHITE
+        var theta: Float = 0f
+        var density: Float = 1f
 
-        for (i in colors.indices) {
-            val v = sin(theta + 2 * PI * (i / pixelCount * density)) / 2 + .5
-            colors[i] = Color.BLACK.fade(buffer.color, v.toFloat())
+        override fun serialize(writer: ByteArrayWriter) {
+            color.serialize(writer)
+            writer.writeFloat(theta)
+            writer.writeFloat(density)
         }
-        pixels.set(colors)
-    }
-}
 
-class SineWaveShaderBuffer : ShaderBuffer {
-    var color: Color = Color.WHITE
-    var theta: Float = 0f
-    var density: Float = 1f
-
-    override fun serialize(writer: ByteArrayWriter) {
-        color.serialize(writer)
-        writer.writeFloat(theta)
-        writer.writeFloat(density)
+        override fun read(reader: ByteArrayReader) {
+            color = Color.parse(reader)
+            theta = reader.readFloat()
+            density = reader.readFloat()
+        }
     }
 
-    override fun read(reader: ByteArrayReader) {
-        color = Color.parse(reader)
-        theta = reader.readFloat()
-        density = reader.readFloat()
-    }
+    class Impl(val pixels: Pixels) : ShaderImpl<Buffer> {
+        private val colors = Array(pixels.count) { Color.WHITE }
 
-    companion object {
-        fun parse(reader: ByteArrayReader): SineWaveShaderBuffer {
-            val buf = SineWaveShaderBuffer()
-            buf.color = Color.parse(reader)
-            buf.theta = reader.readFloat()
-            buf.density = reader.readFloat()
-            return buf
+        override fun draw(buffer: Buffer) {
+            val theta = buffer.theta
+            val pixelCount = pixels.count.toFloat()
+            val density = buffer.density
+
+            for (i in colors.indices) {
+                val v = sin(theta + 2 * PI * (i / pixelCount * density)) / 2 + .5
+                colors[i] = Color.BLACK.fade(buffer.color, v.toFloat())
+            }
+            pixels.set(colors)
         }
     }
 }

--- a/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
@@ -4,7 +4,7 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
-class SolidShader : Shader(ShaderType.SOLID) {
+class SolidShader : Shader(ShaderId.SOLID) {
     override val buffer = SolidShaderBuffer()
 
     override fun createImpl(pixels: Pixels): ShaderImpl = SolidShaderImpl(buffer, pixels)

--- a/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
@@ -4,35 +4,40 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
-class SolidShader : Shader(ShaderId.SOLID) {
-    override val buffer = SolidShaderBuffer()
+class SolidShader() : Shader<SolidShader.Buffer>(ShaderId.SOLID) {
+    override fun createBuffer(surface: Surface): Buffer = Buffer()
 
-    override fun createImpl(pixels: Pixels): ShaderImpl = SolidShaderImpl(buffer, pixels)
+    override fun readBuffer(reader: ByteArrayReader): Buffer = Buffer().apply { read(reader) }
+
+    override fun createImpl(pixels: Pixels): Impl = Impl(pixels)
 
     companion object {
         fun parse(reader: ByteArrayReader) = SolidShader()
     }
-}
 
-class SolidShaderImpl(val buffer: SolidShaderBuffer, val pixels: Pixels) : ShaderImpl {
-    private val colors = Array(pixels.count) { Color.WHITE }
+    inner class Buffer : ShaderBuffer {
+        override val shader: Shader<*>
+            get() = this@SolidShader
 
-    override fun draw() {
-        for (i in colors.indices) {
-            colors[i] = buffer.color
+        var color: Color = Color.WHITE
+
+        override fun serialize(writer: ByteArrayWriter) {
+            color.serialize(writer)
         }
-        pixels.set(colors)
-    }
-}
 
-class SolidShaderBuffer : ShaderBuffer {
-    var color: Color = Color.WHITE
-
-    override fun serialize(writer: ByteArrayWriter) {
-        color.serialize(writer)
+        override fun read(reader: ByteArrayReader) {
+            color = Color.parse(reader)
+        }
     }
 
-    override fun read(reader: ByteArrayReader) {
-        color = Color.parse(reader)
+    class Impl(val pixels: Pixels) : ShaderImpl<Buffer> {
+        private val colors = Array(pixels.count) { Color.WHITE }
+
+        override fun draw(buffer: Buffer) {
+            for (i in colors.indices) {
+                colors[i] = buffer.color
+            }
+            pixels.set(colors)
+        }
     }
 }

--- a/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
@@ -5,39 +5,43 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import kotlin.random.Random
 
-class SparkleShader : Shader(ShaderType.SPARKLE) {
-    override val buffer = SparkleShaderBuffer()
+class SparkleShader : Shader<SparkleShader.Buffer>(ShaderId.SPARKLE) {
+    override fun createBuffer(surface: Surface): Buffer = Buffer()
 
-    override fun createImpl(pixels: Pixels): ShaderImpl = SparkleShaderImpl(buffer, pixels)
+    override fun readBuffer(reader: ByteArrayReader): Buffer = Buffer().apply { read(reader) }
+
+    override fun createImpl(pixels: Pixels): ShaderImpl<Buffer> = Impl(pixels)
 
     companion object {
         fun parse(reader: ByteArrayReader) = SparkleShader()
     }
-}
 
-class SparkleShaderImpl(val buffer: SparkleShaderBuffer, val pixels: Pixels) : ShaderImpl {
-    private val colors = Array(pixels.count) { Color.WHITE }
+    inner class Buffer : ShaderBuffer {
+        override val shader: Shader<*> = this@SparkleShader
 
-    override fun draw() {
-        for (i in colors.indices) {
-            colors[i] = if (Random.nextFloat() < buffer.sparkliness ) { buffer.color } else { Color.BLACK }
+        var color: Color = Color.WHITE
+        var sparkliness: Float = .1F
+
+        override fun serialize(writer: ByteArrayWriter) {
+            color.serialize(writer)
+            writer.writeFloat(sparkliness)
         }
-        pixels.set(colors)
-    }
-}
 
-class SparkleShaderBuffer : ShaderBuffer {
-    var color: Color = Color.WHITE
-    var sparkliness: Float = .1F
-
-    override fun serialize(writer: ByteArrayWriter) {
-        color.serialize(writer)
-        writer.writeFloat(sparkliness)
+        override fun read(reader: ByteArrayReader) {
+            color = Color.parse(reader)
+            sparkliness = reader.readFloat()
+        }
     }
 
-    override fun read(reader: ByteArrayReader) {
-        color = Color.parse(reader)
-        sparkliness = reader.readFloat()
+    class Impl(val pixels: Pixels) : ShaderImpl<Buffer> {
+        private val colors = Array(pixels.count) { Color.WHITE }
+
+        override fun draw(buffer: Buffer) {
+            for (i in colors.indices) {
+                colors[i] = if (Random.nextFloat() < buffer.sparkliness ) { buffer.color } else { Color.BLACK }
+            }
+            pixels.set(colors)
+        }
     }
 
 }

--- a/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
@@ -19,12 +19,17 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
         return object : Show {
             val slider = showRunner.getSlider()
 
-            val shaders = sheepModel.allPanels.associateWith { panel ->
-                val solidShader = showRunner.getSolidShader(panel)
-                val sparkleShader = showRunner.getSparkleShader(panel)
-                val compositorShader = showRunner.getCompositorShader(panel, solidShader, sparkleShader)
+            val solidShader = SolidShader()
+            val sparkleShader = SparkleShader()
+            val compositorShader = CompositorShader(solidShader, sparkleShader)
 
-                Shaders(solidShader, sparkleShader, compositorShader)
+            val shaders = sheepModel.allPanels.associateWith { panel ->
+                val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
+                val sparkleShaderBuffer = showRunner.getShaderBuffer(panel, sparkleShader)
+                val compositorShaderBuffer =
+                    showRunner.getCompositorBuffer(panel, solidShaderBuffer, sparkleShaderBuffer)
+
+                Shaders(solidShaderBuffer, sparkleShaderBuffer, compositorShaderBuffer)
             }
             val fadeTimeMs = 500
 
@@ -38,13 +43,13 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
                         val tweenedColor = startColor.fade(endColor, (now % fadeTimeMs) / fadeTimeMs.toFloat())
 
                         val shaderSet = shaders[panel]!!
-                        shaderSet.solidShader.buffer.color = tweenedColor
+                        shaderSet.solidShader.color = tweenedColor
 
-                        shaderSet.sparkleShader.buffer.color = Color.WHITE
-                        shaderSet.sparkleShader.buffer.sparkliness = slider.value
+                        shaderSet.sparkleShader.color = Color.WHITE
+                        shaderSet.sparkleShader.sparkliness = slider.value
 
-                        shaderSet.compositorShader.buffer.mode = CompositingMode.ADD
-                        shaderSet.compositorShader.buffer.fade = 1f
+                        shaderSet.compositorShader.mode = CompositingMode.ADD
+                        shaderSet.compositorShader.fade = 1f
                     }
                 }
             }
@@ -52,9 +57,9 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
     }
 
     class Shaders(
-        val solidShader: SolidShader,
-        val sparkleShader: SparkleShader,
-        val compositorShader: CompositorShader
+        val solidShader: SolidShader.Buffer,
+        val sparkleShader: SparkleShader.Buffer,
+        val compositorShader: CompositorShader.Buffer
     )
 
     val SheepModel.Panel.number : Int

--- a/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
@@ -1,6 +1,7 @@
 package baaahs.shows
 
 import baaahs.*
+import baaahs.shaders.PixelShader
 import kotlin.random.Random
 
 object PixelTweenShow : Show.MetaData("PixelTweenShow") {
@@ -14,9 +15,10 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
         )
 
         return object : Show {
-            val shaders = sheepModel.allPanels.associateWith { panel ->
-                showRunner.getPixelShader(panel)
-            }
+            val shaders =
+                sheepModel.allPanels.associateWith { panel ->
+                    showRunner.getShaderBuffer(panel, PixelShader())
+                }
             val fadeTimeMs = 1000
 
             override fun nextFrame() {
@@ -27,12 +29,13 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
                         val startColor = colorArray[colorIndex]
                         val endColor = colorArray[(colorIndex + 1) % colorArray.size]
 
-                        val colors = shaders[panel]!!.buffer.colors
+                        val colors = shaders[panel]!!.colors
                         colors.forEachIndexed { index, color ->
                             if (Random.nextFloat() < .1) {
                                 colors[index] = Color.WHITE
                             } else {
-                                val tweenedColor = startColor.fade(endColor, ((now + index) % fadeTimeMs) / fadeTimeMs.toFloat())
+                                val tweenedColor =
+                                    startColor.fade(endColor, ((now + index) % fadeTimeMs) / fadeTimeMs.toFloat())
                                 colors[index] = tweenedColor
                             }
                         }
@@ -42,7 +45,7 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
         }
     }
 
-    val SheepModel.Panel.number : Int
+    val SheepModel.Panel.number: Int
         get() = Regex("\\d+").find(name)?.value?.toInt() ?: -1
 
 }

--- a/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
@@ -1,11 +1,14 @@
 package baaahs.shows
 
 import baaahs.*
+import baaahs.shaders.PixelShader
 import kotlin.random.Random
 
 val RandomShow = object : Show.MetaData("Random") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
-        val pixelShaderBuffers = sheepModel.allPanels.map { showRunner.getPixelShader(it).buffer }
+        val pixelShaderBuffers = sheepModel.allPanels.map { panel ->
+            showRunner.getShaderBuffer(panel, PixelShader())
+        }
         val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 
         override fun nextFrame() {

--- a/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
@@ -1,6 +1,7 @@
 package baaahs.shows
 
 import baaahs.*
+import baaahs.shaders.PixelShader
 import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.random.Random
@@ -8,8 +9,9 @@ import kotlin.random.Random
 val SomeDumbShow = object : Show.MetaData("SomeDumbShow") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         val colorPicker = showRunner.getColorPicker()
+        val pixelShader = PixelShader()
         //    val panelShaderBuffers = sheepModel.allPanels.map { showRunner.getSolidShader(it) }
-        val pixelShaderBuffers = sheepModel.allPanels.map { showRunner.getPixelShader(it).buffer }
+        val pixelShaderBuffers = sheepModel.allPanels.map { panel -> showRunner.getShaderBuffer(panel, pixelShader) }
         val movingHeads = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 
         init {

--- a/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
@@ -2,9 +2,9 @@ package baaahs.shows
 
 import baaahs.*
 import baaahs.shaders.CompositingMode
-import baaahs.shaders.CompositorShaderBuffer
-import baaahs.shaders.SineWaveShaderBuffer
-import baaahs.shaders.SolidShaderBuffer
+import baaahs.shaders.CompositorShader
+import baaahs.shaders.SineWaveShader
+import baaahs.shaders.SolidShader
 import kotlin.math.PI
 import kotlin.random.Random
 
@@ -13,21 +13,21 @@ val ThumpShow = object : Show.MetaData("Thump") {
         private val beatProvider = showRunner.getBeatProvider()
         private val colorPicker = showRunner.getColorPicker()
 
+        val solidShader = SolidShader()
+        val sineWaveShader = SineWaveShader()
+        val compositorShader = CompositorShader(solidShader, sineWaveShader)
+
         private val shaderBufs = sheepModel.allPanels.map { panel ->
-            val solidShader = showRunner.getSolidShader(panel)
+            val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
 
-            val sineWaveShader = showRunner.getSineWaveShader(panel).apply {
-                buffer.density = Random.nextFloat() * 20
+            val sineWaveShaderBuffer = showRunner.getShaderBuffer(panel, sineWaveShader).apply {
+                density = Random.nextFloat() * 20
             }
 
-            val compositorShader = showRunner.getCompositorShader(panel, solidShader, sineWaveShader)
+            val compositorShaderBuffer =
+                showRunner.getCompositorBuffer(panel, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD, 1f)
 
-            compositorShader.buffer.apply {
-                mode = CompositingMode.ADD
-                fade = 1f
-            }
-
-            ShaderBufs(solidShader.buffer, sineWaveShader.buffer, compositorShader.buffer)
+            ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }
 
         private val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
@@ -58,8 +58,8 @@ val ThumpShow = object : Show.MetaData("Thump") {
     }
 
     inner class ShaderBufs(
-        val solidShaderBuffer: SolidShaderBuffer,
-        val sineWaveShaderBuffer: SineWaveShaderBuffer,
-        val compositorShaderBuffer: CompositorShaderBuffer
+        val solidShaderBuffer: SolidShader.Buffer,
+        val sineWaveShaderBuffer: SineWaveShader.Buffer,
+        val compositorShaderBuffer: CompositorShader.Buffer
     )
 }

--- a/src/commonMain/kotlin/baaahs/util.kt
+++ b/src/commonMain/kotlin/baaahs/util.kt
@@ -19,6 +19,10 @@ class logger {
         fun debug(message: String) {
             println("DEBUG: $message")
         }
+
+        fun warn(message: String) {
+            println("WARN: $message")
+        }
     }
 }
 

--- a/src/jsMain/kotlin/baaahs/SheepSimulator.kt
+++ b/src/jsMain/kotlin/baaahs/SheepSimulator.kt
@@ -10,7 +10,7 @@ class SheepSimulator {
     var network = FakeNetwork(display = display.forNetwork())
 
     var dmxUniverse = FakeDmxUniverse()
-    var sheepModel = SheepModel()
+    var sheepModel = SheepModel().apply { load() }
 
     val showMetas = AllShows.allShows
 
@@ -35,8 +35,6 @@ class SheepSimulator {
     val pinky = Pinky(sheepModel, showMetas, network, dmxUniverse, display.forPinky())
 
     fun start() = doRunBlocking {
-        sheepModel.load()
-
         pinkyScope.launch { pinky.run() }
 
         visualizer.start()

--- a/src/jvmMain/kotlin/baaahs/BrainMain.kt
+++ b/src/jvmMain/kotlin/baaahs/BrainMain.kt
@@ -13,6 +13,7 @@ import java.awt.Frame
 import java.awt.Graphics
 import java.util.concurrent.TimeUnit
 import kotlin.math.ceil
+import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
@@ -79,9 +80,8 @@ class JvmPixelsDisplay(pixelCount: Int) : Pixels {
     }
 
     override fun set(colors: Array<Color>) {
-        for ((i, color) in colors.withIndex()) {
-            this.colors[i] = color
-        }
+        val pixCount = min(colors.size, count)
+        colors.copyInto(this.colors, 0, 0, pixCount)
         canvas.repaint()
     }
 }


### PR DESCRIPTION
More closely implements the API described at `/show_api.md`.

Shader buffers are now obtained by calling:
```kotlin
showRunner.getShaderBuffer(surface, shader)
```

Compositor shader buffers are now obtained by calling:
```kotlin
showRunner.getCompositorShaderBuffer(surface, shaderBufferA, shaderBufferB)
```

`BrainShaderMessage` now facilitates easy reuse of Shader objects between frames on the Brain side.

Brain message parsing is inlined so we can optimize memory allocation.