### PR TITLE
Support rendering to unmapped surfaces as well as mapped panels

### DIFF
--- a/show_api.md
+++ b/show_api.md
@@ -43,7 +43,7 @@ At the code level, shows acquire inputs and shader outputs during an initializat
 
 Shows are permitted to retain state between frames.
 
-### Acquiring Gadgets
+### Selecting Gadgets
 
 Shows may request input from any of
 [several types of gadgets](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs.gadgets/index.html). Shows
@@ -72,11 +72,7 @@ fun nextFrame() {
 - geocompass / accelerometer
 
 
-### Drawing Onto Surfaces
-
-
-
-#### Acquiring Shaders
+### Selecting Shaders
 
 Shows may specify a shader (or an composition of shaders) for each surface. Every type of shader has a corresponding
 `ShaderBuffer` type, used to communicate from shows to shaders. Find
@@ -116,7 +112,8 @@ rendering pass.
 
 Sparkle Motion currently uses a 3D model of BAAAHS, but in the future it will support arbitrary models.
 
-Many shows may not particularly care where in the model any given surface lives.
+Many shows may not particularly care where in the model any given surface lives. For those that do, you can access
+surfaces via the model, and you'll get additional functionality, e.g. finding surfaces' neighbors. 
 
 More words TBD.
 

--- a/show_api.md
+++ b/show_api.md
@@ -45,8 +45,9 @@ Shows are permitted to retain state between frames.
 
 ### Acquiring Gadgets
 
-Shows may request input from any of several types of gadgets. Shows may optionally provide a description of the
-gadget's purpose.
+Shows may request input from any of
+[several types of gadgets](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs.gadgets/index.html). Shows
+may optionally provide a description of the gadget's purpose.
 
 ```kotlin
 val primaryColorBuf = showRunner.getGadgetBuffer(SingleColorGadget("Primary Color"))
@@ -71,10 +72,16 @@ fun nextFrame() {
 - geocompass / accelerometer
 
 
-### Acquiring Shaders
+### Drawing Onto Surfaces
 
-Shows may specify a shader (or an arrangement of shaders) for each surface. Every type of shader has a corresponding
-`ShaderBuffer` type, used to communicate from shows to shaders.
+
+
+#### Acquiring Shaders
+
+Shows may specify a shader (or an composition of shaders) for each surface. Every type of shader has a corresponding
+`ShaderBuffer` type, used to communicate from shows to shaders. Find
+[existing shaders](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs.shaders/index.html) you like, or
+[write your own](#writing-a-shader)!
 
 ```kotlin
 val shaderBuffers = model.allSurfaces.map { surface -> showRunner.getShaderBuffer(surface, SolidColorShader()) } 
@@ -105,25 +112,32 @@ val shaderBuffers = sheepModel.allSurfaces.map { surface ->
 Compositing shaders can be arranged recursively, allowing for an arbitrary number of shaders to contribute to a
 rendering pass.
 
-#### Shader Types
+## Models, Geometry, Surfaces, and Moving Heads
 
-## Geometry
+Sparkle Motion currently uses a 3D model of BAAAHS, but in the future it will support arbitrary models.
 
-TBD
+Many shows may not particularly care where in the model any given surface lives.
+
+More words TBD.
 
 ## Writing a Gadget
 
 Gadgets represent an external data source, often user-controllable.
 
-In code, a gadget extends the `Gadget` class, adding data values and implementing serialization/deserialization methods
-for transferring data between UI and Pinky instances.
+In code, a gadget extends the
+[`Gadget`](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs/-gadget/index.html) class, adding data values
+and implementing serialization/deserialization methods for transferring data between UI instances and Pinky.
 
 ## Writing a Shader
 
 A shader takes configuration data from a show and uses it to render colors to the array of pixels it controls.
 
-In code, a shader comprises three classes: the `Shader` itself (representing its platonic ideal), and a corresponding
-`Shader.Buffer` (holding data transferred from the show to the shader for every frame) and a `Shader.Renderer` (which
+In code, a shader comprises three classes: the
+[`Shader`](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs/-shader/index.html) itself (representing its
+platonic ideal), and a corresponding
+[`Shader.Buffer`](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs/-shader/-buffer/index.html) (holding
+data transferred from the show to the shader for every frame) and a
+[`Shader.Renderer`](https://baaahs.github.io/sparklemotion/doc/sparklemotion/baaahs/-shader/-renderer/index.html) (which
 performs the actual work of rendering pixels on a Brain).
 
 When a show requests a shader, Pinky creates an appropriate buffer and renderer instance on the associated Brain.

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -2,7 +2,10 @@ package baaahs
 
 import baaahs.net.FragmentingUdpLink
 import baaahs.net.Network
-import baaahs.proto.*
+import baaahs.proto.BrainHelloMessage
+import baaahs.proto.MapperHelloMessage
+import baaahs.proto.Ports
+import baaahs.proto.parse
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -105,14 +108,21 @@ class Pinky(
         val message = parse(bytes)
         when (message) {
             is BrainHelloMessage -> {
-                foundBrain(RemoteBrain(fromAddress, surfacesByName[message.panelName]!!))
+                val surfaceName = message.surfaceName
+                val surface = surfacesByName[surfaceName] ?: unknownSurface()
+                foundBrain(RemoteBrain(fromAddress, surface))
             }
 
             is MapperHelloMessage -> {
                 mapperIsRunning = message.isRunning
             }
         }
+    }
 
+    private fun unknownSurface(): Surface {
+        return object : Surface {
+            override val pixelCount = SparkleMotion.DEFAULT_PIXEL_COUNT
+        }
     }
 
     private fun foundBrain(remoteBrain: RemoteBrain) {

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -12,6 +12,9 @@ class ShowRunner(
     private val beatProvider: Pinky.BeatProvider,
     private val dmxUniverse: Dmx.Universe
 ) {
+    val allSurfaces: List<Surface> get() = brainsBySurface.keys.toList()
+    val allUnusedSurfaces: List<Surface> get() = brainsBySurface.keys.toList().minus(shaderBuffers.keys)
+
     private val brainsBySurface = brains.groupBy { it.surface }
     private val shaderBuffers: MutableMap<Surface, MutableList<Shader.Buffer>> = hashMapOf()
 

--- a/src/commonMain/kotlin/baaahs/io/ByteArrayReader.kt
+++ b/src/commonMain/kotlin/baaahs/io/ByteArrayReader.kt
@@ -8,7 +8,8 @@ class ByteArrayReader(val bytes: ByteArray, offset: Int = 0) {
             }
             field = value
         }
-    fun readBoolean(): Boolean = bytes[offset] != 0.toByte()
+
+    fun readBoolean(): Boolean = bytes[offset++].toInt() != 0
 
     fun readByte(): Byte = bytes[offset++]
 

--- a/src/commonMain/kotlin/baaahs/proto/Protocol.kt
+++ b/src/commonMain/kotlin/baaahs/proto/Protocol.kt
@@ -41,13 +41,17 @@ fun parse(bytes: ByteArray): Message {
     }
 }
 
-class BrainHelloMessage(val panelName: String) : Message(Type.BRAIN_HELLO) {
+class BrainHelloMessage(val surfaceName: String?) : Message(Type.BRAIN_HELLO) {
     companion object {
-        fun parse(reader: ByteArrayReader) = BrainHelloMessage(reader.readString())
+        fun parse(reader: ByteArrayReader): BrainHelloMessage {
+            val surfaceName = if (reader.readBoolean()) reader.readString() else null
+            return BrainHelloMessage(surfaceName)
+        }
     }
 
     override fun serialize(writer: ByteArrayWriter) {
-        writer.writeString(panelName)
+        writer.writeBoolean(surfaceName != null)
+        surfaceName?.let { writer.writeString(it) }
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
@@ -4,6 +4,10 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
+/**
+ * A shader which combines the results of two sub-shaders according to a specified compositing mode and cross-fade
+ * value.
+ */
 class CompositorShader(val aShader: Shader<*>, val bShader: Shader<*>) :
     Shader<CompositorShader.Buffer>(ShaderId.COMPOSITOR) {
 

--- a/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
@@ -4,6 +4,11 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
+/**
+ * A shader that allows control of individual pixels' colors directly from a show.
+ *
+ * This is a suboptimal shader for most purposes, consider writing a custom shader instead!
+ */
 class PixelShader() : Shader<PixelShader.Buffer>(ShaderId.PIXEL) {
 
     override fun createBuffer(surface: Surface): Buffer = Buffer(surface.pixelCount)

--- a/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
@@ -6,6 +6,9 @@ import baaahs.io.ByteArrayWriter
 import kotlin.math.PI
 import kotlin.math.sin
 
+/**
+ * A shader that treats a surface's pixels as a linear strip and applies a configurable sine wave along the strip.
+ */
 class SineWaveShader() : Shader<SineWaveShader.Buffer>(ShaderId.SINE_WAVE) {
     override fun createBuffer(surface: Surface): Buffer = Buffer()
 

--- a/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
@@ -4,6 +4,9 @@ import baaahs.*
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 
+/**
+ * A shader that sets all pixels to a single color.
+ */
 class SolidShader() : Shader<SolidShader.Buffer>(ShaderId.SOLID) {
     override fun createBuffer(surface: Surface): Buffer = Buffer()
 

--- a/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
@@ -5,6 +5,9 @@ import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import kotlin.random.Random
 
+/**
+ * A shader that randomly sets some pixels to white, changing with each frame.
+ */
 class SparkleShader : Shader<SparkleShader.Buffer>(ShaderId.SPARKLE) {
     override fun createBuffer(surface: Surface): Buffer = Buffer()
 

--- a/src/commonMain/kotlin/baaahs/shows/AllShows.kt
+++ b/src/commonMain/kotlin/baaahs/shows/AllShows.kt
@@ -9,7 +9,8 @@ class AllShows {
             CompositeShow,
             ThumpShow,
             PanelTweenShow,
-            PixelTweenShow
+            PixelTweenShow,
+            LifeyShow
         )
     }
 }

--- a/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
@@ -9,31 +9,26 @@ import baaahs.shaders.SolidShader
 import kotlin.math.PI
 import kotlin.random.Random
 
-val CompositeShow = object : Show.MetaData("Composite") {
+object CompositeShow : Show.MetaData("Composite") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
 
         val solidShader = SolidShader()
         val sineWaveShader = SineWaveShader()
-        val compositorShader = CompositorShader(solidShader, sineWaveShader)
 
-        private val shaderBufs = sheepModel.allPanels.map { panel ->
-            val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
-            val sineWaveShaderBuffer = showRunner.getShaderBuffer(panel, sineWaveShader).apply {
+        private val shaderBufs = showRunner.allSurfaces.map { surface ->
+            val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
+            val sineWaveShaderBuffer = showRunner.getShaderBuffer(surface, sineWaveShader).apply {
                 density = Random.nextFloat() * 20
             }
 
             val compositorShaderBuffer =
-                showRunner.getCompositorBuffer(panel, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD)
+                showRunner.getCompositorBuffer(surface, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD)
 
             ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }
 
         private val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
-
-        init {
-//        println("Created new CompositeShow, we have ${shaderBufs.size} buffers")
-        }
 
         override fun nextFrame() {
             val theta = ((getTimeMillis() % 10000 / 1000f) % (2 * PI)).toFloat()
@@ -55,7 +50,7 @@ val CompositeShow = object : Show.MetaData("Composite") {
         }
     }
 
-    inner class ShaderBufs(
+    class ShaderBufs(
         val solidShaderBuffer: SolidShader.Buffer,
         val sineWaveShaderBuffer: SineWaveShader.Buffer,
         val compositorShaderBuffer: CompositorShader.Buffer

--- a/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
@@ -1,11 +1,14 @@
 package baaahs.shows
 
 import baaahs.*
+import baaahs.gadgets.Slider
 import baaahs.shaders.SolidShader
 import kotlin.random.Random
 
 object LifeyShow : Show.MetaData("Lifey") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+        val speedSlider = showRunner.getGadget(Slider("Speed", .25f))
+
         val shader = SolidShader()
         val shaderBuffers = sheepModel.allPanels.associateWith {
             showRunner.getShaderBuffer(it, shader).apply { color = Color.WHITE }
@@ -13,7 +16,6 @@ object LifeyShow : Show.MetaData("Lifey") {
 
         val selectedPanels = mutableListOf<SheepModel.Panel>()
         var lastUpdateMs : Long = 0
-        var intervalMs : Long = 250
 
         fun SheepModel.Panel.neighbors() = sheepModel.neighborsOf(this)
         fun SheepModel.Panel.isSelected() = selectedPanels.contains(this)
@@ -22,6 +24,7 @@ object LifeyShow : Show.MetaData("Lifey") {
         return object : Show {
             override fun nextFrame() {
                 val nowMs = getTimeMillis()
+                val intervalMs = (speedSlider.value * 1000).toLong()
                 if (nowMs > lastUpdateMs + intervalMs) {
                     if (selectedPanels.isEmpty()) {
                         selectedPanels.addAll(sheepModel.allPanels.filter { Random.nextFloat() < .5 })

--- a/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
@@ -1,0 +1,73 @@
+package baaahs.shows
+
+import baaahs.*
+import baaahs.shaders.SolidShader
+import kotlin.random.Random
+
+object LifeyShow : Show.MetaData("Lifey") {
+    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+        val shader = SolidShader()
+        val shaderBuffers = sheepModel.allPanels.associateWith {
+            showRunner.getShaderBuffer(it, shader).apply { color = Color.WHITE }
+        }
+
+        val selectedPanels = mutableListOf<SheepModel.Panel>()
+        var lastUpdateMs : Long = 0
+        var intervalMs : Long = 250
+
+        fun SheepModel.Panel.neighbors() = sheepModel.neighborsOf(this)
+        fun SheepModel.Panel.isSelected() = selectedPanels.contains(this)
+        fun SheepModel.Panel.neighborsSelected() = neighbors().filter { selectedPanels.contains(it) }.count()
+
+        return object : Show {
+            override fun nextFrame() {
+                val nowMs = getTimeMillis()
+                if (nowMs > lastUpdateMs + intervalMs) {
+                    if (selectedPanels.isEmpty()) {
+                        selectedPanels.addAll(sheepModel.allPanels.filter { Random.nextFloat() < .5 })
+                    } else {
+                        val newSelectedPanels = mutableListOf<SheepModel.Panel>()
+                        selectedPanels.forEach { panel ->
+                            var living = panel.isSelected()
+
+                            val neighborsSelected = panel.neighborsSelected()
+                            if (living) {
+                                if (neighborsSelected < 1 || neighborsSelected > 3) {
+                                    living = false
+
+                                    // super-lonely panels will move next door instead of dying...
+                                    if (neighborsSelected == 0) {
+                                        val moveToNeighbor = panel.neighbors().random()
+                                        moveToNeighbor?.let { newSelectedPanels.add(it) }
+                                        living = false
+                                    }
+                                }
+                            } else {
+                                if (neighborsSelected == 2 || neighborsSelected == 3) {
+                                    living = true
+                                }
+                            }
+
+                            // sometimes panels spontaneously become alive or die...
+                            if (Random.nextFloat() < .1) {
+                                living = !living
+                            }
+
+                            if (living) {
+                                newSelectedPanels.add(panel)
+                            }
+                        }
+                        selectedPanels.clear()
+                        selectedPanels.addAll(newSelectedPanels)
+                    }
+
+                    lastUpdateMs = nowMs
+                }
+
+                shaderBuffers.forEach { (panel, buffer) ->
+                    buffer.color = if (selectedPanels.contains(panel)) Color.WHITE else Color.BLACK
+                }
+            }
+        }
+    }
+}

--- a/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
@@ -22,13 +22,12 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
 
             val solidShader = SolidShader()
             val sparkleShader = SparkleShader()
-            val compositorShader = CompositorShader(solidShader, sparkleShader)
 
-            val shaders = sheepModel.allPanels.associateWith { panel ->
-                val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
-                val sparkleShaderBuffer = showRunner.getShaderBuffer(panel, sparkleShader)
+            val shaders = sheepModel.allPanels.associateWith { surface ->
+                val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
+                val sparkleShaderBuffer = showRunner.getShaderBuffer(surface, sparkleShader)
                 val compositorShaderBuffer =
-                    showRunner.getCompositorBuffer(panel, solidShaderBuffer, sparkleShaderBuffer)
+                    showRunner.getCompositorBuffer(surface, solidShaderBuffer, sparkleShaderBuffer)
 
                 Shaders(solidShaderBuffer, sparkleShaderBuffer, compositorShaderBuffer)
             }
@@ -63,6 +62,6 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
         val compositorShader: CompositorShader.Buffer
     )
 
-    val SheepModel.Panel.number : Int
+    val SheepModel.Panel.number: Int
         get() = Regex("\\d+").find(name)?.value?.toInt() ?: -1
 }

--- a/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
@@ -15,29 +15,26 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
         )
 
         return object : Show {
-            val shaders =
-                sheepModel.allPanels.associateWith { panel ->
-                    showRunner.getShaderBuffer(panel, PixelShader())
-                }
+            val shaderBuffers = showRunner.allSurfaces.map { surface ->
+                showRunner.getShaderBuffer(surface, PixelShader())
+            }
             val fadeTimeMs = 1000
 
             override fun nextFrame() {
-                sheepModel.allPanels.forEach { panel ->
-                    if (panel.number > -1) {
-                        val now = getTimeMillis().and(0xfffffff).toInt()
-                        val colorIndex = (now / fadeTimeMs + panel.number) % colorArray.size
-                        val startColor = colorArray[colorIndex]
-                        val endColor = colorArray[(colorIndex + 1) % colorArray.size]
+                shaderBuffers.forEachIndexed { i, buffer ->
+                    val now = getTimeMillis().and(0xfffffff).toInt()
+                    val colorIndex = (now / fadeTimeMs + i) % colorArray.size
+                    val startColor = colorArray[colorIndex]
+                    val endColor = colorArray[(colorIndex + 1) % colorArray.size]
 
-                        val colors = shaders[panel]!!.colors
-                        colors.forEachIndexed { index, color ->
-                            if (Random.nextFloat() < .1) {
-                                colors[index] = Color.WHITE
-                            } else {
-                                val tweenedColor =
-                                    startColor.fade(endColor, ((now + index) % fadeTimeMs) / fadeTimeMs.toFloat())
-                                colors[index] = tweenedColor
-                            }
+                    val colors = buffer.colors
+                    colors.forEachIndexed { index, color ->
+                        if (Random.nextFloat() < .1) {
+                            colors[index] = Color.WHITE
+                        } else {
+                            val tweenedColor =
+                                startColor.fade(endColor, ((now + index) % fadeTimeMs) / fadeTimeMs.toFloat())
+                            colors[index] = tweenedColor
                         }
                     }
                 }

--- a/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
@@ -4,10 +4,10 @@ import baaahs.*
 import baaahs.shaders.PixelShader
 import kotlin.random.Random
 
-val RandomShow = object : Show.MetaData("Random") {
+object RandomShow : Show.MetaData("Random") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
-        val pixelShaderBuffers = sheepModel.allPanels.map { panel ->
-            showRunner.getShaderBuffer(panel, PixelShader())
+        val pixelShaderBuffers = showRunner.allSurfaces.map { surface ->
+            showRunner.getShaderBuffer(surface, PixelShader())
         }
         val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 

--- a/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
@@ -1,6 +1,9 @@
 package baaahs.shows
 
-import baaahs.*
+import baaahs.Color
+import baaahs.SheepModel
+import baaahs.Show
+import baaahs.ShowRunner
 import baaahs.gadgets.ColorPicker
 import baaahs.shaders.SolidShader
 
@@ -9,11 +12,11 @@ object SolidColorShow : Show.MetaData("Solid Color") {
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
 
         val shader = SolidShader()
-        val shaderBuffers = sheepModel.allPanels.map {
+        val shaderBuffers = showRunner.allSurfaces.map {
             showRunner.getShaderBuffer(it, shader).apply { color = Color.WHITE }
         }
 
-        return object: Show {
+        return object : Show {
             var priorColor = colorPicker.color
 
             override fun nextFrame() {

--- a/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
@@ -7,48 +7,40 @@ import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.random.Random
 
-val SomeDumbShow = object : Show.MetaData("SomeDumbShow") {
+object SomeDumbShow : Show.MetaData("SomeDumbShow") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
         val pixelShader = PixelShader()
-        val pixelShaderBuffers = sheepModel.allPanels.map { panel -> showRunner.getShaderBuffer(panel, pixelShader) }
+
+        val pixelShaderBuffers =
+            showRunner.allSurfaces.map { surface -> showRunner.getShaderBuffer(surface, pixelShader) }
         val movingHeads = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 
-        init {
-//        println("Creating new SomeDumbShow, we have ${pixelShaderBuffers.size} buffers")
-        }
-
         override fun nextFrame() {
-//        panelShaderBuffers.forEach { shader -> shader.color = Color.random() }
             val seed = Random(0)
+            val now = getTimeMillis()
+
+            fun Random.nextTimeShiftedFloat(): Float =
+                sin(nextFloat() + now / 1000.0).toFloat()
+
+            fun Color.desaturateRandomishly(baseSaturation: Float, seed: Random): Color {
+                return withSaturation(baseSaturation * abs(seed.nextFloat()))
+            }
 
             pixelShaderBuffers.forEach { shaderBuffer ->
                 val baseSaturation = seed.nextFloat()
-                val panelColor = if (seed.nextFloat() < 0.1) Color.random() else colorPicker.color
+                val panelColor = if (seed.nextTimeShiftedFloat() < 0.1) Color.random() else colorPicker.color
 
                 shaderBuffer.colors.forEachIndexed { i, pixel ->
-                    shaderBuffer.colors[i] = desaturateRandomishly(baseSaturation, seed, panelColor)
+                    shaderBuffer.colors[i] = panelColor.desaturateRandomishly(baseSaturation, seed)
                 }
             }
 
             movingHeads.forEach { buf ->
                 buf.colorWheel = buf.closestColorFor(colorPicker.color)
-                buf.pan += (nextRandomFloat(seed) - .5f) / 5
-                buf.tilt += (nextRandomFloat(seed) - .5f) / 5
+                buf.pan += (seed.nextTimeShiftedFloat() - .5f) / 5
+                buf.tilt += (seed.nextTimeShiftedFloat() - .5f) / 5
             }
         }
-
-        private fun desaturateRandomishly(
-            baseSaturation: Float,
-            seed: Random,
-            panelColor: Color
-        ): Color {
-            val saturation = baseSaturation * abs(nextRandomFloat(seed))
-            val desaturatedColor = panelColor.withSaturation(saturation)
-            return desaturatedColor
-        }
-
-        private fun nextRandomFloat(seed: Random): Float =
-            sin(seed.nextFloat() + getTimeMillis() / 1000.0).toFloat()
     }
 }

--- a/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
@@ -9,7 +9,7 @@ import baaahs.shaders.SolidShader
 import kotlin.math.PI
 import kotlin.random.Random
 
-val ThumpShow = object : Show.MetaData("Thump") {
+object ThumpShow : Show.MetaData("Thump") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         private val beatProvider = showRunner.getBeatProvider()
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
@@ -18,15 +18,15 @@ val ThumpShow = object : Show.MetaData("Thump") {
         val sineWaveShader = SineWaveShader()
         val compositorShader = CompositorShader(solidShader, sineWaveShader)
 
-        private val shaderBufs = sheepModel.allPanels.map { panel ->
-            val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
+        private val shaderBufs = showRunner.allSurfaces.map { surface ->
+            val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
 
-            val sineWaveShaderBuffer = showRunner.getShaderBuffer(panel, sineWaveShader).apply {
+            val sineWaveShaderBuffer = showRunner.getShaderBuffer(surface, sineWaveShader).apply {
                 density = Random.nextFloat() * 20
             }
 
             val compositorShaderBuffer =
-                showRunner.getCompositorBuffer(panel, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD, 1f)
+                showRunner.getCompositorBuffer(surface, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD, 1f)
 
             ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }
@@ -58,7 +58,7 @@ val ThumpShow = object : Show.MetaData("Thump") {
         }
     }
 
-    inner class ShaderBufs(
+    class ShaderBufs(
         val solidShaderBuffer: SolidShader.Buffer,
         val sineWaveShaderBuffer: SineWaveShader.Buffer,
         val compositorShaderBuffer: CompositorShader.Buffer


### PR DESCRIPTION
Many shows don't care which panel is which, they just wanna render to surfaces, you dig? But then… some do, shazam!

- Change most shows to get shaders for (potentially unmapped) surfaces, not panels.
- Change all shows (actually Show.MetaDatas) to be object declarations.
- Add docs for existing Shaders.
- Brains may represent anonymous surfaces.
- Fix ByteArrayReader.readBoolean() bug.
- Optimize SomeDumbShow.
- Add support for finding panels' neighbors.
- Add dumb [Life](https://bitstorm.org/gameoflife/)-like show which demonstrates panel neighbor awareness.