### PR TITLE
Rewrote ShowRunner, this time with tests

### DIFF
--- a/src/commonMain/kotlin/baaahs/Brain.kt
+++ b/src/commonMain/kotlin/baaahs/Brain.kt
@@ -30,7 +30,7 @@ class Brain(
     private suspend fun sendHello() {
         while (true) {
             if (lastInstructionsReceivedAtMs < getTimeMillis() - 10000) {
-                link.broadcastUdp(Ports.PINKY, BrainHelloMessage(id, surfaceName ?: ""))
+                link.broadcastUdp(Ports.PINKY, BrainHelloMessage(id, surfaceName))
             }
 
             delay(5000)
@@ -83,7 +83,7 @@ class Brain(
                 currentShaderDesc = null
                 currentShaderBits = null
 
-                link.broadcastUdp(Ports.PINKY, BrainHelloMessage(id, surfaceName ?: ""))
+                link.broadcastUdp(Ports.PINKY, BrainHelloMessage(id, surfaceName))
             }
 
             // Other message types are ignored by Brains.

--- a/src/commonMain/kotlin/baaahs/Display.kt
+++ b/src/commonMain/kotlin/baaahs/Display.kt
@@ -22,7 +22,7 @@ interface PinkyDisplay {
     var onShowChange: (() -> Unit)
     var selectedShow: Show.MetaData?
     var nextFrameMs: Int
-    var stats: ShowRunner.Stats?
+    var stats: Pinky.NetworkStats?
 }
 
 open class StubPinkyDisplay : PinkyDisplay {
@@ -34,9 +34,12 @@ open class StubPinkyDisplay : PinkyDisplay {
     override var onShowChange: () -> Unit = { }
     override var selectedShow: Show.MetaData? = null
     override var nextFrameMs: Int = 0
-    override var stats: ShowRunner.Stats? = null
+    override var stats: Pinky.NetworkStats? = null
 }
 
 interface BrainDisplay {
+    var id: String?
+    var surface: Surface?
+    var onReset: suspend () -> Unit
     fun haveLink(link: Network.Link)
 }

--- a/src/commonMain/kotlin/baaahs/Gadget.kt
+++ b/src/commonMain/kotlin/baaahs/Gadget.kt
@@ -69,7 +69,7 @@ class GadgetValueObserver<T>(initialValue: T, val onChange: () -> Unit) : Observ
 }
 
 @Serializable()
-class GadgetData(@Polymorphic val gadget: Gadget, val topicName: String)
+class GadgetData(val name: String, @Polymorphic val gadget: Gadget, val topicName: String)
 
 class GadgetDisplay(pubSub: PubSub.Client, onUpdatedGadgets: (Array<GadgetData>) -> Unit) {
     val activeGadgets = mutableListOf<GadgetData>()

--- a/src/commonMain/kotlin/baaahs/Mapper.kt
+++ b/src/commonMain/kotlin/baaahs/Mapper.kt
@@ -161,6 +161,8 @@ class Mapper(
             val pixelShader = PixelShader()
             val buffer = pixelShader.createBuffer(object : Surface {
                 override val pixelCount = SparkleMotion.MAX_PIXEL_COUNT
+
+                override fun describe(): String = "Mapper surface"
             })
             buffer.setAll(Color.BLACK)
             for (i in 0 until maxPixelsPerBrain) {
@@ -205,6 +207,8 @@ class Mapper(
         val solidShader = SolidShader()
         val buffer = solidShader.createBuffer(object : Surface {
             override val pixelCount = SparkleMotion.MAX_PIXEL_COUNT
+
+            override fun describe(): String = "Mapper surface"
         }).apply { this.color = color }
         return BrainShaderMessage(solidShader, buffer)
     }

--- a/src/commonMain/kotlin/baaahs/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/Shaders.kt
@@ -25,6 +25,8 @@ enum class ShaderId(val reader: ShaderReader<*>) {
 
 interface Surface {
     val pixelCount: Int
+
+    fun describe(): String
 }
 
 interface ShaderReader<T : Shader<*>> {

--- a/src/commonMain/kotlin/baaahs/SheepModel.kt
+++ b/src/commonMain/kotlin/baaahs/SheepModel.kt
@@ -36,7 +36,7 @@ class SheepModel {
                     }
                     "g" -> {
                         var name = args.joinToString(" ")
-                        val match = Regex("^G_([^_]+).*?\$").matchEntire(name)
+                        val match = Regex("^G_0?([^_]+).*?\$").matchEntire(name)
                         if (match != null) {
                             name = match.groups[1]!!.value
                         }
@@ -100,6 +100,10 @@ class SheepModel {
 
         val faces = Faces()
         val lines = mutableListOf<Line>()
+
+        override fun describe(): String = "Panel $name"
+        override fun equals(other: Any?): Boolean = other is Panel && name == other.name
+        override fun hashCode(): Int = name.hashCode()
     }
 
     class MovingHead(val name: String, val origin: Point/*, val heading: Point*/) {

--- a/src/commonMain/kotlin/baaahs/Show.kt
+++ b/src/commonMain/kotlin/baaahs/Show.kt
@@ -9,7 +9,19 @@ interface Show {
      */
     fun nextFrame()
 
+    /**
+     * Called when surfaces are newly or no longer available to the show.
+     *
+     * If the show is able to reconfigure itself for the new set of shaders, it should do so and return `true`.
+     *
+     * @return true if the show should be reinitialized.
+     */
+    fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>): Unit =
+        throw RestartShowException()
+
     abstract class MetaData(val name: String) {
         abstract fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show
     }
+
+    class RestartShowException : Exception()
 }

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -12,6 +12,9 @@ class ShowRunner(
     private val beatProvider: Pinky.BeatProvider,
     private val dmxUniverse: Dmx.Universe
 ) {
+    val allSurfaces: List<Surface> get() = brainsBySurface.keys.toList()
+    val allUnusedSurfaces: List<Surface> get() = brainsBySurface.keys.toList().minus(shaderBuffers.keys)
+
     private val brainsBySurface = brains.groupBy { it.surface }
     private val shaderBuffers: MutableMap<Surface, MutableList<Shader.Buffer>> = hashMapOf()
 

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -1,18 +1,23 @@
 package baaahs
 
-import baaahs.net.Network
-import baaahs.proto.BrainShaderMessage
-import baaahs.proto.Ports
 import baaahs.shaders.CompositingMode
 import baaahs.shaders.CompositorShader
 
 class ShowRunner(
+    private val model: SheepModel,
+    initialShow: Show.MetaData,
     private val gadgetProvider: GadgetProvider,
     brains: List<RemoteBrain>,
     private val beatProvider: Pinky.BeatProvider,
     private val dmxUniverse: Dmx.Universe
 ) {
-    val allSurfaces: List<Surface> get() = brainsBySurface.keys.toList()
+    var nextShow: Show.MetaData? = initialShow
+    var currentShow: Show.MetaData? = null
+    var currentShowRenderer: Show? = null
+    private val changedSurfaces = mutableListOf<SurfacesChanges>()
+    private var totalSurfaceReceivers = 0
+
+    val allSurfaces: List<Surface> get() = surfaceReceivers.keys.toList()
     val allUnusedSurfaces: List<Surface> get() = brainsBySurface.keys.toList().minus(shaderBuffers.keys)
 
     private val brainsBySurface = brains.groupBy { it.surface }
@@ -76,38 +81,99 @@ class ShowRunner(
         return Shenzarpy(getDmxBuffer(baseChannel, 16))
     }
 
-    fun send(link: Network.Link, stats: Stats? = null) {
+    /**
+     * Obtain a gadget that can be used to receive input from a user. The gadget will be displayed in the show's UI.
+     *
+     * @param name Symbolic name for this gadget; must be unique within the show.
+     * @param gadget The gadget to display.
+     */
+    fun <T : Gadget> getGadget(name: String, gadget: T) = gadgetProvider.getGadget(name, gadget)
+
+    fun surfacesChanged(addedSurfaces: Collection<SurfaceReceiver>, removedSurfaces: Collection<SurfaceReceiver>) {
+        changedSurfaces.add(SurfacesChanges(ArrayList(addedSurfaces), ArrayList(removedSurfaces)))
+    }
+
+    fun nextFrame() {
+        // Always generate and send the next frame right away, then perform any housekeeping tasks immediately
+        // afterward, to avoid frame lag.
+        currentShowRenderer?.let {
+            it.nextFrame()
+            send()
+        }
+
+        housekeeping()
+    }
+
+    private val surfaceReceivers = mutableMapOf<Surface, MutableList<SurfaceReceiver>>()
+
+    private fun housekeeping() {
+        for ((added, removed) in changedSurfaces) {
+            println("ShowRunner surfaces changed! ${added.size} added, ${removed.size} removed")
+            for (receiver in removed) removeReceiver(receiver)
+            for (receiver in added) addReceiver(receiver)
+
+            if (nextShow == null) {
+                try {
+                    currentShowRenderer?.surfacesChanged(added.map { it.surface }, removed.map { it.surface })
+                } catch (e: Show.RestartShowException) {
+                    // Show doesn't support changing surfaces, just restart it cold.
+                    nextShow = currentShow ?: nextShow
+                }
+            }
+        }
+        changedSurfaces.clear()
+
+        if (totalSurfaceReceivers > 0) {
+            nextShow?.let {
+                shaderBuffers.clear()
+
+                val gadgetsState = gadgetProvider.getGadgetsState()
+                gadgetProvider.clear()
+                currentShowRenderer = it.createShow(model, this)
+                currentShow = nextShow
+                gadgetProvider.setGadgetsState(gadgetsState)
+                gadgetProvider.sync()
+
+                nextShow = null
+            }
+        }
+    }
+
+    private fun addReceiver(receiver: SurfaceReceiver) {
+        receiversFor(receiver.surface).add(receiver)
+        totalSurfaceReceivers++
+    }
+
+    private fun removeReceiver(receiver: SurfaceReceiver) {
+        receiversFor(receiver.surface).remove(receiver)
+        shaderBuffers.remove(receiver.surface)
+        totalSurfaceReceivers--
+    }
+
+    private fun receiversFor(surface: Surface): MutableList<SurfaceReceiver> {
+        return surfaceReceivers.getOrPut(surface) { mutableListOf() }
+    }
+
+    fun send() {
         shaderBuffers.forEach { (surface, shaderBuffers) ->
             if (shaderBuffers.size != 1) {
-                throw IllegalStateException("Too many shader buffers for $surface: $shaderBuffers")
+                throw IllegalStateException("Too many shader buffers for ${surface.describe()}: $shaderBuffers")
             }
-
             val shaderBuffer = shaderBuffers.first()
-            val remoteBrains = brainsBySurface[surface]
-            if (remoteBrains != null && remoteBrains.isNotEmpty()) {
-                val messageBytes = BrainShaderMessage(shaderBuffer.shader, shaderBuffer).toBytes()
-                remoteBrains.forEach { remoteBrain ->
-                    link.sendUdp(
-                        remoteBrain.address,
-                        Ports.BRAIN,
-                        messageBytes
-                    )
-                }
-                stats?.apply {
-                    bytesSent += messageBytes.size
-                    packetsSent += 1
-                }
+
+            receiversFor(surface).forEach { receiver ->
+                receiver.sendFn(shaderBuffer)
             }
         }
 
         dmxUniverse.sendFrame()
     }
 
-    fun <T : Gadget> getGadget(gadget: T) = gadgetProvider.getGadget(gadget)
-
     fun shutDown() {
         gadgetProvider.clear()
     }
 
-    class Stats(var bytesSent: Int = 0, var packetsSent: Int = 0)
+    data class SurfacesChanges(val added: Collection<SurfaceReceiver>, val removed: Collection<SurfaceReceiver>)
+    data class SurfaceReceiver(val surface: Surface, val sendFn: (Shader.Buffer) -> Unit)
+
 }

--- a/src/commonMain/kotlin/baaahs/net/FragmentingUdpLink.kt
+++ b/src/commonMain/kotlin/baaahs/net/FragmentingUdpLink.kt
@@ -16,9 +16,11 @@ class FragmentingUdpLink(private val link: Network.Link) : Network.Link {
      * * total payload size (long)
      * * this frame offset (long)
      */
+    companion object {
+        const val headerSize = 12
+    }
 
     private val mtu = link.udpMtu
-    private val headerSize = 12
     private var nextMessageId: Short = 0
 
     private var fragments = arrayListOf<Fragment>()

--- a/src/commonMain/kotlin/baaahs/proto/Protocol.kt
+++ b/src/commonMain/kotlin/baaahs/proto/Protocol.kt
@@ -41,19 +41,19 @@ fun parse(bytes: ByteArray): Message {
     }
 }
 
-class BrainHelloMessage(val brainId: String, val panelName: String) : Message(Type.BRAIN_HELLO) {
+class BrainHelloMessage(val brainId: String, val surfaceName: String?) : Message(Type.BRAIN_HELLO) {
     companion object {
         fun parse(reader: ByteArrayReader): BrainHelloMessage {
             return BrainHelloMessage(
                 reader.readString(),
-                reader.readString()
+                reader.readNullableString()
             )
         }
     }
 
     override fun serialize(writer: ByteArrayWriter) {
         writer.writeString(brainId)
-        writer.writeString(panelName)
+        writer.writeNullableString(surfaceName)
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
@@ -16,14 +16,14 @@ object CompositeShow : Show.MetaData("Composite") {
         val solidShader = SolidShader()
         val sineWaveShader = SineWaveShader()
 
-        private val shaderBufs = sheepModel.allPanels.map { panel ->
-            val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
-            val sineWaveShaderBuffer = showRunner.getShaderBuffer(panel, sineWaveShader).apply {
+        private val shaderBufs = showRunner.allSurfaces.map { surface ->
+            val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
+            val sineWaveShaderBuffer = showRunner.getShaderBuffer(surface, sineWaveShader).apply {
                 density = Random.nextFloat() * 20
             }
 
             val compositorShaderBuffer =
-                showRunner.getCompositorBuffer(panel, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD)
+                showRunner.getCompositorBuffer(surface, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD)
 
             ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }

--- a/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
@@ -11,12 +11,15 @@ import kotlin.random.Random
 
 object CompositeShow : Show.MetaData("Composite") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
-        val colorPicker = showRunner.getGadget(ColorPicker("Color"))
+        val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 
         val solidShader = SolidShader()
         val sineWaveShader = SineWaveShader()
 
-        private val shaderBufs = showRunner.allSurfaces.map { surface ->
+        private val shaderBufs = showRunner.allSurfaces.associateWith { surface -> shaderBufsFor(surface) }
+            .toMutableMap()
+
+        private fun shaderBufsFor(surface: Surface): ShaderBufs {
             val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
             val sineWaveShaderBuffer = showRunner.getShaderBuffer(surface, sineWaveShader).apply {
                 density = Random.nextFloat() * 20
@@ -25,7 +28,7 @@ object CompositeShow : Show.MetaData("Composite") {
             val compositorShaderBuffer =
                 showRunner.getCompositorBuffer(surface, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD)
 
-            ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
+            return ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }
 
         private val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
@@ -34,7 +37,7 @@ object CompositeShow : Show.MetaData("Composite") {
             val theta = ((getTimeMillis() % 10000 / 1000f) % (2 * PI)).toFloat()
 
             var i = 0
-            shaderBufs.forEach { shaderBuffer ->
+            shaderBufs.values.forEach { shaderBuffer ->
                 shaderBuffer.solidShaderBuffer.color = colorPicker.color
                 shaderBuffer.sineWaveShaderBuffer.color = Color.WHITE
                 shaderBuffer.sineWaveShaderBuffer.theta = theta + i++
@@ -47,6 +50,11 @@ object CompositeShow : Show.MetaData("Composite") {
                 buf.pan = PI.toFloat() / 2
                 buf.tilt = theta / 2
             }
+        }
+
+        override fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>) {
+            removedSurfaces.forEach { shaderBufs.remove(it) }
+            newSurfaces.forEach { shaderBufs[it] = shaderBufsFor(it) }
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
@@ -7,7 +7,7 @@ import kotlin.random.Random
 
 object LifeyShow : Show.MetaData("Lifey") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
-        val speedSlider = showRunner.getGadget(Slider("Speed", .25f))
+        val speedSlider = showRunner.getGadget("speed", Slider("Speed", .25f))
 
         val shader = SolidShader()
         val shaderBuffers = sheepModel.allPanels.associateWith {

--- a/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
@@ -22,11 +22,12 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
 
             val solidShader = SolidShader()
             val sparkleShader = SparkleShader()
-            val shaderBuffers = sheepModel.allPanels.map { panel ->
-                val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
-                val sparkleShaderBuffer = showRunner.getShaderBuffer(panel, sparkleShader)
+
+            val shaderBuffers = showRunner.allSurfaces.map { surface ->
+                val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
+                val sparkleShaderBuffer = showRunner.getShaderBuffer(surface, sparkleShader)
                 val compositorShaderBuffer = showRunner.getCompositorBuffer(
-                    panel, solidShaderBuffer, sparkleShaderBuffer, CompositingMode.ADD, 1f
+                    surface, solidShaderBuffer, sparkleShaderBuffer, CompositingMode.ADD, 1f
                 )
 
                 Shaders(solidShaderBuffer, sparkleShaderBuffer, compositorShaderBuffer)

--- a/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
@@ -18,7 +18,7 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
         )
 
         return object : Show {
-            val slider = showRunner.getGadget(Slider("Sparkliness", 0f))
+            val slider = showRunner.getGadget("sparkliness", Slider("Sparkliness", 0f))
 
             val solidShader = SolidShader()
             val sparkleShader = SparkleShader()

--- a/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
@@ -15,7 +15,7 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
         )
 
         return object : Show {
-            val shaderBuffers = sheepModel.allPanels.map { surface ->
+            val shaderBuffers = showRunner.allSurfaces.map { surface ->
                 showRunner.getShaderBuffer(surface, PixelShader())
             }
             val fadeTimeMs = 1000

--- a/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
@@ -6,8 +6,8 @@ import kotlin.random.Random
 
 object RandomShow : Show.MetaData("Random") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
-        val pixelShaderBuffers = sheepModel.allPanels.map { panel ->
-            showRunner.getShaderBuffer(panel, PixelShader())
+        val pixelShaderBuffers = showRunner.allSurfaces.map { surface ->
+            showRunner.getShaderBuffer(surface, PixelShader())
         }
         val movingHeadBuffers = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 

--- a/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
@@ -9,10 +9,10 @@ import baaahs.shaders.SimpleSpatialShader
 
 object SimpleSpatialShow : Show.MetaData("Spatial") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
-        val colorPicker = showRunner.getGadget(ColorPicker("Color"))
-        val centerXSlider = showRunner.getGadget(Slider("center X", 0.5f))
-        val centerYSlider = showRunner.getGadget(Slider("center Y", 0.5f))
-        val radiusSlider = showRunner.getGadget(Slider("radius", 0.25f))
+        val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
+        val centerXSlider = showRunner.getGadget("centerX", Slider("center X", 0.5f))
+        val centerYSlider = showRunner.getGadget("centerY", Slider("center Y", 0.5f))
+        val radiusSlider = showRunner.getGadget("radius", Slider("radius", 0.25f))
 
         val shader = SimpleSpatialShader()
         val shaderBuffers = showRunner.allSurfaces.map {

--- a/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
@@ -15,7 +15,7 @@ object SimpleSpatialShow : Show.MetaData("Spatial") {
         val radiusSlider = showRunner.getGadget(Slider("radius", 0.25f))
 
         val shader = SimpleSpatialShader()
-        val shaderBuffers = sheepModel.allPanels.map {
+        val shaderBuffers = showRunner.allSurfaces.map {
             showRunner.getShaderBuffer(it, shader)
         }
 

--- a/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
@@ -12,7 +12,7 @@ object SolidColorShow : Show.MetaData("Solid Color") {
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
 
         val shader = SolidShader()
-        val shaderBuffers = sheepModel.allPanels.map {
+        val shaderBuffers = showRunner.allSurfaces.map {
             showRunner.getShaderBuffer(it, shader).apply { color = Color.WHITE }
         }
 

--- a/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
@@ -9,7 +9,7 @@ import baaahs.shaders.SolidShader
 
 object SolidColorShow : Show.MetaData("Solid Color") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
-        val colorPicker = showRunner.getGadget(ColorPicker("Color"))
+        val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 
         val shader = SolidShader()
         val shaderBuffers = showRunner.allSurfaces.map {

--- a/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
@@ -11,7 +11,9 @@ object SomeDumbShow : Show.MetaData("SomeDumbShow") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         val colorPicker = showRunner.getGadget(ColorPicker("Color"))
         val pixelShader = PixelShader()
-        val pixelShaderBuffers = sheepModel.allPanels.map { panel -> showRunner.getShaderBuffer(panel, pixelShader) }
+
+        val pixelShaderBuffers =
+            showRunner.allSurfaces.map { surface -> showRunner.getShaderBuffer(surface, pixelShader) }
         val movingHeads = sheepModel.eyes.map { showRunner.getMovingHead(it) }
 
         override fun nextFrame() {

--- a/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
@@ -9,12 +9,16 @@ import kotlin.random.Random
 
 object SomeDumbShow : Show.MetaData("SomeDumbShow") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
-        val colorPicker = showRunner.getGadget(ColorPicker("Color"))
+        val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
         val pixelShader = PixelShader()
 
         val pixelShaderBuffers =
             showRunner.allSurfaces.map { surface -> showRunner.getShaderBuffer(surface, pixelShader) }
         val movingHeads = sheepModel.eyes.map { showRunner.getMovingHead(it) }
+
+        init {
+            println("SomeDumbShow: pixelShaderBuffers = ${pixelShaderBuffers.size}")
+        }
 
         override fun nextFrame() {
             val seed = Random(0)

--- a/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
@@ -12,7 +12,7 @@ import kotlin.random.Random
 object ThumpShow : Show.MetaData("Thump") {
     override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
         private val beatProvider = showRunner.getBeatProvider()
-        val colorPicker = showRunner.getGadget(ColorPicker("Color"))
+        val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 
         val solidShader = SolidShader()
         val sineWaveShader = SineWaveShader()

--- a/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
@@ -16,16 +16,17 @@ object ThumpShow : Show.MetaData("Thump") {
 
         val solidShader = SolidShader()
         val sineWaveShader = SineWaveShader()
+        val compositorShader = CompositorShader(solidShader, sineWaveShader)
 
-        private val shaderBufs = sheepModel.allPanels.map { panel ->
-            val solidShaderBuffer = showRunner.getShaderBuffer(panel, solidShader)
+        private val shaderBufs = showRunner.allSurfaces.map { surface ->
+            val solidShaderBuffer = showRunner.getShaderBuffer(surface, solidShader)
 
-            val sineWaveShaderBuffer = showRunner.getShaderBuffer(panel, sineWaveShader).apply {
+            val sineWaveShaderBuffer = showRunner.getShaderBuffer(surface, sineWaveShader).apply {
                 density = Random.nextFloat() * 20
             }
 
             val compositorShaderBuffer =
-                showRunner.getCompositorBuffer(panel, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD, 1f)
+                showRunner.getCompositorBuffer(surface, solidShaderBuffer, sineWaveShaderBuffer, CompositingMode.ADD, 1f)
 
             ShaderBufs(solidShaderBuffer, sineWaveShaderBuffer, compositorShaderBuffer)
         }

--- a/src/commonMain/kotlin/baaahs/util.kt
+++ b/src/commonMain/kotlin/baaahs/util.kt
@@ -8,6 +8,11 @@ fun <E> List<E>.random(): E? = if (size > 0) get(Random.nextInt(size)) else null
 
 fun <E> List<E>.random(random: Random): E? = if (size > 0) get(random.nextInt(size)) else null
 
+fun <E> Collection<E>.only(description: String = "item"): E {
+    if (size != 1) throw IllegalArgumentException("Expected one $description, found $size: $this")
+    else return iterator().next()
+}
+
 fun toRadians(degrees: Float) = (degrees * PI / 180).toFloat()
 
 suspend fun randomDelay(timeMs: Int) {
@@ -22,6 +27,10 @@ class logger {
 
         fun warn(message: String) {
             println("WARN: $message")
+        }
+
+        fun error(message: String) {
+            println("ERROR: $message")
         }
     }
 }

--- a/src/commonTest/kotlin/baaahs/GadgetProviderTest.kt
+++ b/src/commonTest/kotlin/baaahs/GadgetProviderTest.kt
@@ -1,0 +1,38 @@
+package baaahs
+
+import baaahs.gadgets.Slider
+import baaahs.sim.FakeNetwork
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.expect
+
+class GadgetProviderTest {
+    @Test
+    fun whenOneGadgetStateUpdateFails_setGadgetsState_shouldStillUpdateTheRest() {
+        val gadgetProvider = GadgetProvider(PubSub.Server(FakeNetwork().link(), 1234))
+
+        val first = gadgetProvider.getGadget("first", Slider("first"))
+            .apply { value = .123f }
+        val second = gadgetProvider.getGadget("second", Slider("second"))
+            .apply { value = .234f }
+        val third = gadgetProvider.getGadget("third", Slider("third"))
+            .apply { value = .345f }
+
+        expect(gadgetProvider.getGadgetsState().toString()) {
+            "{first={\"value\":0.123}, second={\"value\":0.234}, third={\"value\":0.345}}"
+        }
+
+        gadgetProvider.setGadgetsState(
+            mapOf(
+                "first" to JsonObject(mapOf("value" to JsonPrimitive(0.321))),
+                "second" to JsonObject(mapOf("valueXXX" to JsonPrimitive(0.432))),
+                "third" to JsonObject(mapOf("value" to JsonPrimitive(0.543)))
+            )
+        )
+
+        expect(first.value) { 0.321f }
+        expect(second.value) { 0.234f }
+        expect(third.value) { 0.543f }
+    }
+}

--- a/src/commonTest/kotlin/baaahs/GadgetTest.kt
+++ b/src/commonTest/kotlin/baaahs/GadgetTest.kt
@@ -1,6 +1,7 @@
 package baaahs
 
 import baaahs.gadgets.Slider
+import baaahs.shows.SimpleSpatialShow
 import baaahs.sim.FakeDmxUniverse
 import baaahs.sim.FakeNetwork
 import ext.TestCoroutineContext
@@ -42,12 +43,12 @@ class GadgetTest {
         pubSubServer.install(gadgetModule)
 
         val gadgetProvider = GadgetProvider(pubSubServer)
-        val showRunner = ShowRunner(gadgetProvider, listOf(), object : Pinky.BeatProvider {
+        val showRunner = ShowRunner(SheepModel(), SimpleSpatialShow, gadgetProvider, listOf(), object : Pinky.BeatProvider {
             override val beat: Float = 1.0f
             override var bpm: Float = 1.0f
         }, FakeDmxUniverse())
 
-        val serverSlider = showRunner.getGadget(Slider("fader", .1234f))
+        val serverSlider = showRunner.getGadget("fader", Slider("fader", .1234f))
 
         val pubSubClient = PubSub.connect(serverLink, serverLink.myAddress, 1234)
         pubSubClient.install(gadgetModule)

--- a/src/commonTest/kotlin/baaahs/GadgetTest.kt
+++ b/src/commonTest/kotlin/baaahs/GadgetTest.kt
@@ -1,8 +1,6 @@
 package baaahs
 
 import baaahs.gadgets.Slider
-import baaahs.shows.SimpleSpatialShow
-import baaahs.sim.FakeDmxUniverse
 import baaahs.sim.FakeNetwork
 import ext.TestCoroutineContext
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -21,11 +19,19 @@ class GadgetTest {
         val someGadget = SomeGadget(123)
 
         val log1 = mutableListOf<String>()
-        val listener1 = object: GadgetListener { override fun onChanged(gadget: Gadget) { log1.add("changed") } }
+        val listener1 = object : GadgetListener {
+            override fun onChanged(gadget: Gadget) {
+                log1.add("changed")
+            }
+        }
         someGadget.listen(listener1)
 
         val log2 = mutableListOf<String>()
-        val listener2 = object: GadgetListener { override fun onChanged(gadget: Gadget) { log2.add("changed") } }
+        val listener2 = object : GadgetListener {
+            override fun onChanged(gadget: Gadget) {
+                log2.add("changed")
+            }
+        }
         someGadget.listen(listener2)
 
         someGadget.value = 321
@@ -43,12 +49,7 @@ class GadgetTest {
         pubSubServer.install(gadgetModule)
 
         val gadgetProvider = GadgetProvider(pubSubServer)
-        val showRunner = ShowRunner(SheepModel(), SimpleSpatialShow, gadgetProvider, listOf(), object : Pinky.BeatProvider {
-            override val beat: Float = 1.0f
-            override var bpm: Float = 1.0f
-        }, FakeDmxUniverse())
-
-        val serverSlider = showRunner.getGadget("fader", Slider("fader", .1234f))
+        val serverSlider = gadgetProvider.getGadget("fader", Slider("fader", .1234f))
 
         val pubSubClient = PubSub.connect(serverLink, serverLink.myAddress, 1234)
         pubSubClient.install(gadgetModule)

--- a/src/commonTest/kotlin/baaahs/PinkyTest.kt
+++ b/src/commonTest/kotlin/baaahs/PinkyTest.kt
@@ -1,0 +1,71 @@
+package baaahs
+
+import baaahs.net.FragmentingUdpLink
+import baaahs.net.TestNetwork
+import baaahs.proto.BrainHelloMessage
+import baaahs.shaders.SolidShader
+import baaahs.sim.FakeDmxUniverse
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlin.test.Test
+import kotlin.test.expect
+
+@InternalCoroutinesApi
+class PinkyTest {
+    val network = TestNetwork(1_000_000)
+    private val clientAddress = network.link()
+
+    val sheepModel = SheepModel().apply { load() }
+    val testShow1 = TestShow1()
+    val pinky = Pinky(sheepModel, listOf(testShow1), network, FakeDmxUniverse(), StubPinkyDisplay())
+
+    @Test
+    fun asBrainsComeOnline_showShouldBeNotified() {
+        pinky.receive(clientAddress.myAddress, BrainHelloMessage("brain1", null).toBytes())
+        pinky.updateSurfaces()
+        pinky.drawNextFrame()
+        pinky.drawNextFrame()
+
+        val show = testShow1.createdShows.only()
+        expect(show.shaderBuffers.size) { 1 }
+        expect(show.shaderBuffers.keys.only() is Pinky.UnknownSurface) { true }
+
+        pinky.receive(clientAddress.myAddress, BrainHelloMessage("brain1", "17L").toBytes())
+        pinky.updateSurfaces()
+        pinky.drawNextFrame()
+        pinky.drawNextFrame()
+        expect(show.shaderBuffers.size) { 1 }
+        val surface = show.shaderBuffers.keys.only()
+        expect(surface is SheepModel.Panel) { true }
+        expect((surface as SheepModel.Panel).name) { "17L" }
+    }
+
+    fun defrag(bytes: ByteArray) = bytes.slice(FragmentingUdpLink.headerSize until bytes.size).toByteArray()
+
+    class TestShow1(var supportsSurfaceChange: Boolean = true) : Show.MetaData("TestShow1") {
+        val createdShows = mutableListOf<ShowRenderer>()
+        val solidShader = SolidShader()
+
+        override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+            return ShowRenderer(showRunner).also { createdShows.add(it) }
+        }
+
+        inner class ShowRenderer(private val showRunner: ShowRunner) : Show {
+            val shaderBuffers =
+                showRunner.allSurfaces.associateWith { showRunner.getShaderBuffer(it, solidShader) }.toMutableMap()
+
+            override fun nextFrame() {
+                shaderBuffers.values.forEach { it.color = Color.WHITE }
+            }
+
+            override fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>) {
+                if (!supportsSurfaceChange) {
+                    super.surfacesChanged(newSurfaces, removedSurfaces)
+                } else {
+                    removedSurfaces.forEach { shaderBuffers.remove(it) }
+                    newSurfaces.forEach { shaderBuffers[it] = showRunner.getShaderBuffer(it, solidShader) }
+                }
+            }
+        }
+    }
+
+}

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -1,0 +1,252 @@
+package baaahs
+
+import baaahs.SheepModel.Panel
+import baaahs.ShowRunner.SurfaceReceiver
+import baaahs.gadgets.Slider
+import baaahs.shaders.SolidShader
+import baaahs.sim.FakeDmxUniverse
+import baaahs.sim.FakeNetwork
+import ext.TestCoroutineContext
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlin.test.*
+
+@InternalCoroutinesApi
+class ShowRunnerTest {
+    val testCoroutineContext = TestCoroutineContext("network")
+    val network = FakeNetwork(0, coroutineContext = testCoroutineContext)
+
+    val serverNetwork = network.link()
+    val server = PubSub.listen(serverNetwork, 1234).apply { install(gadgetModule) }
+
+    val gadgetProvider = GadgetProvider(server)
+    lateinit var showRunner: ShowRunner
+
+    val testShow1 = TestShow1()
+    val surface1Messages = mutableListOf<Shader.Buffer>()
+    val surface1Receiver = SurfaceReceiver(Panel("surface 1")) { buffer -> surface1Messages.add(buffer) }
+    val surface2Messages = mutableListOf<Shader.Buffer>()
+    val surface2Receiver = SurfaceReceiver(Panel("surface 2")) { buffer -> surface2Messages.add(buffer) }
+    lateinit var dmxUniverse: FakeDmxUniverse
+    val dmxEvents = mutableListOf<String>()
+
+    @BeforeTest
+    fun setUp() {
+        dmxUniverse = FakeDmxUniverse()
+        dmxUniverse.reader(1, 1) { dmxEvents.add("dmx frame sent") }
+        showRunner = ShowRunner(SheepModel(), testShow1, gadgetProvider, listOf(), FakeBeatProvider, dmxUniverse)
+        surface1Messages.clear()
+        surface2Messages.clear()
+        dmxEvents.clear()
+    }
+
+    @Test
+    fun whenNoKnownSurfaces_shouldNotCreateShow() {
+        showRunner.nextFrame()
+        expect(0) { testShow1.createdShows.size }
+        expect(0) { surface1Messages.size }
+    }
+
+    @Test
+    fun shouldRenderShow() {
+        showRunner.surfacesChanged(listOf(surface1Receiver, surface2Receiver), emptyList())
+        showRunner.nextFrame() // First time through nothing is rendered but a show is created.
+        expect(1) { testShow1.createdShows.size }
+        expect(0) { surface1Messages.size }
+
+        showRunner.nextFrame() // Render to our surface.
+        expect(1) { testShow1.createdShows.size }
+        expect(1) { surface1Messages.size }
+
+        val buffer1 = surface1Messages[0]
+        expect(buffer1.shader) { testShow1.solidShader }
+        expect((buffer1 as SolidShader.Buffer).color) { Color.WHITE }
+
+        val buffer2 = surface1Messages[0]
+        expect(buffer2.shader) { testShow1.solidShader }
+        expect((buffer2 as SolidShader.Buffer).color) { Color.WHITE }
+    }
+
+    @Test
+    fun forShowsThatSupportSurfaceChanges_whenSurfacesAreAddedOrRemoved_shouldUpdateShow() {
+        showRunner.nextFrame() // No surfaces so no show created, nothing rendered.
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // Create a new show with one surface, but we don't render anything the first time.
+        expect(1) { testShow1.createdShows.size }
+        expect(0) { surface1Messages.size }
+
+        showRunner.nextFrame() // Render to our surface.
+        expect(1) { testShow1.createdShows.size }
+        expect(1) { surface1Messages.size }
+
+        showRunner.surfacesChanged(listOf(surface2Receiver), emptyList())
+        showRunner.nextFrame() // Render a frame, then inform show of the new surface.
+        expect(1) { testShow1.createdShows.size }
+        expect(2) { surface1Messages.size }
+        expect(0) { surface2Messages.size }
+
+        showRunner.nextFrame() // Render a frame on both surfaces.
+        expect(1) { testShow1.createdShows.size }
+        expect(3) { surface1Messages.size }
+        expect(1) { surface2Messages.size }
+
+        showRunner.surfacesChanged(emptyList(), listOf(surface1Receiver))
+        showRunner.nextFrame() // Render another frame on both surfaces, then update the show's surfaces.
+        expect(1) { testShow1.createdShows.size }
+        expect(4) { surface1Messages.size }
+        expect(2) { surface2Messages.size }
+
+        showRunner.nextFrame() // Render another frame on the remaining surface.
+        expect(1) { testShow1.createdShows.size }
+        expect(4) { surface1Messages.size }
+        expect(3) { surface2Messages.size }
+    }
+
+    @Test
+    fun forShowsThatDontSupportSurfaceChanges_whenSurfacesAreAddedOrRemoved_shouldRecreateShowAfterNextFrame() {
+        testShow1.supportsSurfaceChange = false
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // First time through we don't actually render anything.
+        expect(1) { testShow1.createdShows.size }
+        expect(0) { surface1Messages.size }
+
+        showRunner.nextFrame() // Render a frame.
+        expect(1) { testShow1.createdShows.size }
+        expect(1) { surface1Messages.size }
+
+        showRunner.surfacesChanged(listOf(surface2Receiver), emptyList())
+        showRunner.nextFrame() // Prior show renders a frame, new show is created with two surfaces.
+        expect(2) { testShow1.createdShows.size }
+        expect(2) { surface1Messages.size }
+        expect(0) { surface2Messages.size }
+
+        showRunner.nextFrame() // Render a frame with the new show.
+        expect(2) { testShow1.createdShows.size }
+        expect(3) { surface1Messages.size }
+        expect(1) { surface2Messages.size }
+
+        showRunner.surfacesChanged(emptyList(), listOf(surface1Receiver))
+        showRunner.nextFrame() // Render another frame on both surfaces, then recreate the show with new surfaces.
+        expect(3) { testShow1.createdShows.size }
+        expect(4) { surface1Messages.size }
+        expect(2) { surface2Messages.size }
+
+        showRunner.nextFrame() // Render another frame on the remaining surface.
+        expect(3) { testShow1.createdShows.size }
+        expect(4) { surface1Messages.size }
+        expect(3) { surface2Messages.size }
+    }
+
+    @Test
+    fun forShowsThatDontSupportSurfaceChanges_whenShowIsRecreated_gadgetSettingsAreRestored() {
+        testShow1.supportsSurfaceChange = false
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // Create show and request gadgets.
+        expect(testShow1.createdShows.size) { 1 }
+
+        val originalSlider = gadgetProvider.findGadget("slider")!! as Slider
+        expect(originalSlider.value) { 1.0f }
+        originalSlider.value = 0.5f
+
+        showRunner.surfacesChanged(listOf(surface2Receiver), emptyList())
+        showRunner.nextFrame() // Recreate show and restore gadget data.
+        expect(testShow1.createdShows.size) { 2 }
+
+        val recreatedSlider = gadgetProvider.findGadget("slider")!! as Slider
+        expect(recreatedSlider.value) { 0.5f }
+    }
+
+    @Test
+    fun shouldUpdateDmxAfterEveryFrame() {
+        expect(dmxEvents) { emptyList<String>() }
+
+        showRunner.nextFrame()
+        showRunner.send()
+        expect(dmxEvents) { listOf("dmx frame sent") }
+    }
+
+    @Ignore
+    @Test
+    fun shouldSyncGadgetsProperly() {
+        TODO("write me")
+    }
+
+    @Test
+    fun whenShowLeavesHangingBuffersForASurface_shouldReportError() {
+        testShow1.onShowCreate = {
+            showRunner.allSurfaces.forEach { surface ->
+                showRunner.getShaderBuffer(surface, SolidShader())
+            }
+        }
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // Creates show but doesn't render a frame yet.
+        val e = assertFailsWith(IllegalStateException::class) {
+            showRunner.nextFrame()
+        }
+        assertTrue { e.message!!.startsWith("Too many shader buffers for Panel surface 1") }
+    }
+
+    @Test
+    fun whenSurfaceIsReAddedAndNewBufferIsRegistered_shouldHaveForgottenAboutOldOne() {
+        testShow1.supportsSurfaceChange = true
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // Creates show and registers a buffer for surface1.
+
+        showRunner.surfacesChanged(listOf(), listOf(surface1Receiver))
+        showRunner.nextFrame() // Removes old buffer for surface1.
+
+        showRunner.surfacesChanged(listOf(surface1Receiver), emptyList())
+        showRunner.nextFrame() // Creates new buffer for surface1.
+
+        showRunner.nextFrame() // Renders frame, expect no exceptions due to too many buffers.
+    }
+
+    class TestShow1(
+        var supportsSurfaceChange: Boolean = true,
+        var onShowCreate: () -> Unit = {},
+        var onNextFrame: () -> Unit = {},
+        var onSurfacesChanged: (List<Surface>, List<Surface>) -> Unit = { _, _ -> }
+    ) : Show.MetaData("TestShow1") {
+        val createdShows = mutableListOf<Show>()
+        val solidShader = SolidShader()
+
+        override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+            return ShowRenderer(showRunner).also { createdShows.add(it) }
+        }
+
+        inner class ShowRenderer(private val showRunner: ShowRunner) : Show {
+            val slider = showRunner.getGadget("slider", Slider("slider"))
+            val shaderBuffers =
+                showRunner.allSurfaces.associateWith { showRunner.getShaderBuffer(it, solidShader) }.toMutableMap()
+
+            init {
+                onShowCreate()
+            }
+
+            override fun nextFrame() {
+                shaderBuffers.values.forEach { it.color = Color.WHITE }
+                onNextFrame()
+            }
+
+            override fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>) {
+                if (!supportsSurfaceChange) {
+                    super.surfacesChanged(newSurfaces, removedSurfaces)
+                } else {
+                    removedSurfaces.forEach { shaderBuffers.remove(it) }
+                    newSurfaces.forEach { shaderBuffers[it] = showRunner.getShaderBuffer(it, solidShader) }
+                }
+
+                onSurfacesChanged(newSurfaces, removedSurfaces)
+            }
+        }
+    }
+
+    object FakeBeatProvider : Pinky.BeatProvider {
+        override var bpm = 120f
+        override val beat = 0f
+    }
+}

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -177,7 +177,7 @@ class ShowRunnerTest {
 
     @Test
     fun whenShowLeavesHangingBuffersForASurface_shouldReportError() {
-        testShow1.onShowCreate = {
+        testShow1.onCreateShow = {
             showRunner.allSurfaces.forEach { surface ->
                 showRunner.getShaderBuffer(surface, SolidShader())
             }
@@ -250,7 +250,7 @@ class ShowRunnerTest {
 
     class TestShow1(
         var supportsSurfaceChange: Boolean = true,
-        var onShowCreate: () -> Unit = {},
+        var onCreateShow: () -> Unit = {},
         var onNextFrame: () -> Unit = {},
         var onSurfacesChanged: (List<Surface>, List<Surface>) -> Unit = { _, _ -> }
     ) : Show.MetaData("TestShow1") {
@@ -267,7 +267,7 @@ class ShowRunnerTest {
                 showRunner.allSurfaces.associateWith { showRunner.getShaderBuffer(it, solidShader) }.toMutableMap()
 
             init {
-                onShowCreate()
+                onCreateShow()
             }
 
             override fun nextFrame() {

--- a/src/commonTest/kotlin/baaahs/net/FragmentingUdpLinkTest.kt
+++ b/src/commonTest/kotlin/baaahs/net/FragmentingUdpLinkTest.kt
@@ -10,9 +10,9 @@ class FragmentingUdpLinkTest {
     private val mtu = 1400
 
     private val receivedPayloads = mutableListOf<ByteArray>()
-    private val sendTestLink = TestNetworkLink(mtu)
+    private val sendTestLink = TestNetwork.TestNetworkLink(mtu)
     private val sendLink = FragmentingUdpLink(sendTestLink)
-    private val recvTestLink = TestNetworkLink(mtu)
+    private val recvTestLink = TestNetwork.TestNetworkLink(mtu)
     private val recvLink = FragmentingUdpLink(recvTestLink)
 
     @BeforeTest
@@ -60,52 +60,6 @@ class FragmentingUdpLinkTest {
     private fun send(smallPayload: ByteArray) {
         sendLink.sendUdp(recvLink.myAddress, port, smallPayload)
         sendTestLink.sendTo(recvTestLink)
-    }
-
-    class TestNetworkLink(mtu: Int) : Network.Link {
-        override val myAddress = someAddress()
-        val packetsToSend = mutableListOf<ByteArray>()
-        val receviedPackets = mutableListOf<ByteArray>()
-
-        private var udpListener: Network.UdpListener? = null
-
-        fun sendTo(link: TestNetworkLink) {
-            packetsToSend.forEach { bytes ->
-                link.receiveUdp(bytes)
-            }
-            packetsToSend.clear()
-        }
-
-        private fun receiveUdp(bytes: ByteArray) {
-            receviedPackets += bytes
-            udpListener?.receive(myAddress, bytes)
-        }
-
-        override val udpMtu = mtu
-
-        override fun listenUdp(port: Int, udpListener: Network.UdpListener) {
-            this.udpListener = udpListener
-        }
-
-        override fun sendUdp(toAddress: Network.Address, port: Int, bytes: ByteArray) {
-            packetsToSend += bytes
-        }
-
-        override fun broadcastUdp(port: Int, bytes: ByteArray) {
-            packetsToSend += bytes
-        }
-
-        override fun listenTcp(port: Int, tcpServerSocketListener: Network.TcpServerSocketListener) {
-            TODO("TestNetworkLink.listenTcp not implemented")
-        }
-
-        override fun connectTcp(
-            toAddress: Network.Address,
-            port: Int,
-            tcpListener: Network.TcpListener
-        ): Network.TcpConnection {
-            TODO("TestNetworkLink.connectTcp not implemented")
-        }
     }
 
     companion object {

--- a/src/commonTest/kotlin/baaahs/net/TestNetwork.kt
+++ b/src/commonTest/kotlin/baaahs/net/TestNetwork.kt
@@ -1,0 +1,56 @@
+package baaahs.net
+
+class TestNetwork(var defaultMtu: Int = 1400) : Network {
+    val links = mutableListOf<TestNetworkLink>()
+
+    override fun link(): Network.Link {
+        return TestNetworkLink(defaultMtu).also { links.add(it) }
+    }
+
+    class TestNetworkLink(mtu: Int) : Network.Link {
+        override val myAddress = FragmentingUdpLinkTest.someAddress()
+        val packetsToSend = mutableListOf<ByteArray>()
+        val receviedPackets = mutableListOf<ByteArray>()
+
+        private var udpListener: Network.UdpListener? = null
+
+        fun sendTo(link: TestNetworkLink) {
+            packetsToSend.forEach { bytes ->
+                link.receiveUdp(bytes)
+            }
+            packetsToSend.clear()
+        }
+
+        private fun receiveUdp(bytes: ByteArray) {
+            receviedPackets += bytes
+            udpListener?.receive(myAddress, bytes)
+        }
+
+        override val udpMtu = mtu
+
+        override fun listenUdp(port: Int, udpListener: Network.UdpListener) {
+            this.udpListener = udpListener
+        }
+
+        override fun sendUdp(toAddress: Network.Address, port: Int, bytes: ByteArray) {
+            packetsToSend += bytes
+        }
+
+        override fun broadcastUdp(port: Int, bytes: ByteArray) {
+            packetsToSend += bytes
+        }
+
+        override fun listenTcp(port: Int, tcpServerSocketListener: Network.TcpServerSocketListener) {
+//            TODO("TestNetworkLink.listenTcp not implemented")
+        }
+
+        override fun connectTcp(
+            toAddress: Network.Address,
+            port: Int,
+            tcpListener: Network.TcpListener
+        ): Network.TcpConnection {
+            TODO("TestNetworkLink.connectTcp not implemented")
+        }
+    }
+
+}

--- a/src/commonTest/kotlin/baaahs/shaders/PixelShaderTest.kt
+++ b/src/commonTest/kotlin/baaahs/shaders/PixelShaderTest.kt
@@ -36,5 +36,7 @@ class PixelShaderTest {
         return dstBuf
     }
 
-    class FakeSurface(override val pixelCount: Int) : Surface
+    class FakeSurface(override val pixelCount: Int) : Surface {
+        override fun describe(): String = "fake"
+    }
 }

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -32,6 +32,7 @@
   <div class="simulatorSection">
     <b>Brains:</b>
     <div id="brainsView"></div>
+    <div id="brainDetails"></div>
   </div>
 
   <div class="visualizerSection">

--- a/src/jsMain/resources/styles.css
+++ b/src/jsMain/resources/styles.css
@@ -96,6 +96,13 @@ body {
     padding: 2px;
 }
 
+.brain-box {
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    border: 2px solid white;
+}
+
 .brain-offline {
     background-color: darkgrey;
 }

--- a/src/jvmMain/kotlin/baaahs/BrainMain.kt
+++ b/src/jvmMain/kotlin/baaahs/BrainMain.kt
@@ -20,6 +20,10 @@ import kotlin.math.sqrt
 fun main(args: Array<String>) {
     val network = JvmNetwork(notReallyAnHttpServer())
     val brain = Brain(JvmNetwork.myAddress.toString(), network, object: BrainDisplay {
+        override var id: String? = null
+        override var surface: Surface? = null
+        override var onReset: suspend () -> Unit = {}
+
         override fun haveLink(link: Network.Link) {
             println("Brain has a link!")
         }


### PR DESCRIPTION
- Unmapped surfaces (brains that don't know to which panel they're attached) can be selected for rendering.
- When shows are recreated due to new or removed surface, gadget values are restored.
- Gadgets now require a symbolic name.
- Brains show up as little boxes in simulator panel again. Mouse over to see info, click to reset.
- Shows can react to changed surfaces without restarting by implementing `#surfacesChanged`, which will be called when new surfaces are discovered (so there's no jaggies when new brains come online).
- Added tests for a bunch of stuff.