### PR TITLE
Enable hot module replacement for the react UI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "@babel/preset-react"
   ],
   "plugins": [
+    "react-hot-loader/babel",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties"
   ]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run this in one shell window:
 Run this in a second shell window and go to http://localhost:8001/index.html :
 
 ```sh
-./gradlew serve
+npm run start:dev
 ```
 
 ## CI & Deployment

--- a/build.gradle
+++ b/build.gradle
@@ -128,25 +128,10 @@ compileTestKotlinJvm {
 }
 
 jsProcessResources { t ->
-    t.dependsOn(":buildReactUI")
-
-    t.from('build/webpack')
     t.from('build/classes/kotlin/js/main')
-
     t.from('node_modules/kotlin') { include 'kotlin.*' }
     t.from('node_modules/kotlinx-coroutines-core') { include 'kotlinx-coroutines-core.*' }
     t.from('node_modules/three/build') { include 'three.js' }
-}
-
-task serve {
-    dependsOn(":jsJar")
-
-    doLast {
-        SimpleHttpFileServerFactory factory = new SimpleHttpFileServerFactory()
-        HttpFileServer server = factory.start(new File("build/processedResources/js/main"), 8001)
-        println("Server Started on http://localhost:${server.port}/index.html ctrc+c to kill it")
-        java.lang.Thread.sleep(Long.MAX_VALUE);
-    }
 }
 
 task installReactUImodules(type: Exec) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -745,6 +745,30 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-+JHIYh33FVglJYZAUtRjfT5qZoT2mueJGNzU5weS2CVw26BgbxGKSujlJhO85BaRbg8sqNWyW1hYBILgK3ZCgA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.6",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+          "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -1960,7 +1984,8 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -2345,7 +2370,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -2549,8 +2575,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2568,13 +2593,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2587,18 +2610,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2701,8 +2721,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2712,7 +2731,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2725,20 +2743,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2755,7 +2770,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2828,8 +2842,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2839,7 +2852,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2915,8 +2927,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2946,7 +2957,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2964,7 +2974,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3003,13 +3012,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3072,6 +3079,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "~0.5.1"
@@ -3080,7 +3088,8 @@
         "process": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+          "dev": true
         }
       }
     },
@@ -3219,6 +3228,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -3880,6 +3890,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -4696,9 +4707,10 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.8.0.tgz",
-      "integrity": "sha512-HY9F0vITYSVmXhAR6tPkMk240nxmoH8+0rca9iO2B82KVguiCiBJkieS0Wb4CeSIzLWecYx3iOcq8dcbnp0bxA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.9.0.tgz",
+      "integrity": "sha512-1N6MWV9++qYWrrs41MRhxATwyx743tr8RpeyL1VOZ54zsU8fOx4slYreHZ8v2BDGVfy+dJ0myJZrJA9/26RlCA==",
+      "dev": true,
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -4714,7 +4726,8 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
         }
       }
     },
@@ -4726,7 +4739,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "reactcss": {
       "version": "1.2.3",
@@ -5143,7 +5157,8 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm test",
     "start": "webpack-cli --config ./webpack.config.js --mode development --watch",
-    "start:dev": "webpack-dev-server --config ./webpack.config.js --mode development --color",
+    "start:dev": "webpack-dev-server --config ./webpack.config.js --hot --inline --mode development --color",
     "build": "webpack-cli --config ./webpack.config.js --mode production"
   },
   "repository": {
@@ -42,7 +42,6 @@
     "react-color": "^2.17.0",
     "react-dom": "^16.8.4",
     "react-draggable": "^3.2.1",
-    "react-hot-loader": "^4.8.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "three": "^0.102.1",
@@ -50,5 +49,9 @@
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.2.1"
   },
-  "browserslist": "> 0.25%, not dead"
+  "browserslist": "> 0.25%, not dead",
+  "devDependencies": {
+    "@hot-loader/react-dom": "^16.8.6",
+    "react-hot-loader": "^4.9.0"
+  }
 }

--- a/src/jsMain/js/app/index.jsx
+++ b/src/jsMain/js/app/index.jsx
@@ -1,3 +1,4 @@
+import { hot } from 'react-hot-loader';
 import React, {Component, Fragment} from 'react';
 import ColorPicker from './Menu/components/ColorPicker';
 import ShowList from './ShowList';
@@ -12,7 +13,7 @@ import styles from './app.scss';
 
 const baaahs = sparklemotion.baaahs;
 
-export default class App extends Component {
+class App extends Component {
   constructor(props) {
     super(props);
 
@@ -80,3 +81,5 @@ export default class App extends Component {
 App.propTypes = {
   pubSub: PropTypes.object.isRequired,
 };
+
+export default hot(module)(App);

--- a/src/jsMain/js/index.jsx
+++ b/src/jsMain/js/index.jsx
@@ -45,5 +45,3 @@ CameraControls.install( { THREE: THREE } );
 document.createCameraControls = (camera, element) => {
   return new CameraControls(camera, element);
 };
-
-module.hot.accept();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  entry: ['react-hot-loader/patch', './src/jsMain/js/index.jsx'],
+  entry: ['./src/jsMain/js/index.jsx'],
   module: {
     rules: [
       {
@@ -30,23 +30,21 @@ module.exports = {
   resolve: {
     extensions: ['*', '.js', '.jsx'],
   },
-  output: {
-    path: __dirname + '/build/webpack/',
-    publicPath: '/js/',
-    filename: 'react_app.js',
-  },
-  devtool: false,
+  devtool: 'eval',
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.SourceMapDevToolPlugin({
       test: /\.(js|jsx|css|sass|scss)$/,
       exclude: /node_modules/,
     }),
   ],
   devServer: {
-    contentBase: './',
     hot: true,
     port: 8000,
     open: true, // Opens page in browser
+    contentBase: __dirname + '/build/processedResources/js/main/',
+  },
+  output: {
+    path: __dirname + '/build/processedResources/js/main/',
+    filename: 'react_app.js',
   },
 };


### PR DESCRIPTION
By serving the dev site using `webpack-dev-server` and tweaking the webpack config a bit, we can get instantaneous UI updates anytime we update the react components. This should allow front-end development to go much faster by avoiding full page reloads.

* The <App> module is now `hot` exported
* The local build of the site is now served using the `npm run start:dev` command (or `npm run start` if you don’t want hot-reloading amazingness)
* Remove the `buildReactUI` task from the `jsProcessResources` step since the dev-server now builds the `ReactUI` bundle. I didn’t delete the `buildReactUI` even though it isn’t called directly because we might still want something similar for production builds in the future