### PR TITLE
Fix the github page circleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,11 @@ jobs:
 
       - run:
           name: Build
+          # Make sure the webpack build runs after the gradle build
+          # because it outputs directly into the gradle build directory
           command: |
-            npm run build
             ./gradlew build dokka
+            npm run build
 
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
By running the webpack build after the kotlin build.
The webpack build outputs directly into the kotlin `procossedResources` build directory, which was getting recreated when running `gradlew build`