### PR TITLE
Rename show API components.

### DIFF
--- a/src/commonMain/kotlin/baaahs/Display.kt
+++ b/src/commonMain/kotlin/baaahs/Display.kt
@@ -15,24 +15,24 @@ interface NetworkDisplay {
 }
 
 interface PinkyDisplay {
-    fun listShows(showMetas: List<Show.MetaData>)
+    fun listShows(showMetas: List<Show>)
 
     var brainCount: Int
     var beat: Int
     var onShowChange: (() -> Unit)
-    var selectedShow: Show.MetaData?
+    var selectedShow: Show?
     var nextFrameMs: Int
     var stats: Pinky.NetworkStats?
 }
 
 open class StubPinkyDisplay : PinkyDisplay {
-    override fun listShows(showMetas: List<Show.MetaData>) {
+    override fun listShows(showMetas: List<Show>) {
     }
 
     override var brainCount = 0
     override var beat = 0
     override var onShowChange: () -> Unit = { }
-    override var selectedShow: Show.MetaData? = null
+    override var selectedShow: Show? = null
     override var nextFrameMs: Int = 0
     override var stats: Pinky.NetworkStats? = null
 }

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 
 class Pinky(
     val sheepModel: SheepModel,
-    val showMetas: List<Show.MetaData>,
+    val showMetas: List<Show>,
     val network: Network,
     val dmxUniverse: Dmx.Universe,
     val display: PinkyDisplay
@@ -40,7 +40,7 @@ class Pinky(
     val address: Network.Address get() = link.myAddress
     private val networkStats = NetworkStats()
 
-    suspend fun run(): Show {
+    suspend fun run(): Show.Renderer {
         GlobalScope.launch { beatProvider.run() }
 
         link.listenUdp(Ports.PINKY, this)

--- a/src/commonMain/kotlin/baaahs/Show.kt
+++ b/src/commonMain/kotlin/baaahs/Show.kt
@@ -1,26 +1,27 @@
 package baaahs
 
 /** A show takes input from gadgets and uses it to configure shaders, creating pretty stuff on surfaces. */
-interface Show {
-    /**
-     * Renders the next frame of the show.
-     *
-     * Try to keep this under 30ms or so.
-     */
-    fun nextFrame()
+abstract class Show(val name: String) {
 
-    /**
-     * Called when surfaces are newly or no longer available to the show.
-     *
-     * If the show is able to reconfigure itself for the new set of shaders, it should do so and return `true`.
-     *
-     * @return true if the show should be reinitialized.
-     */
-    fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>): Unit =
-        throw RestartShowException()
+    abstract fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer
 
-    abstract class MetaData(val name: String) {
-        abstract fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show
+    interface Renderer {
+        /**
+         * Renders the next frame of the show.
+         *
+         * Try to keep this under 30ms or so.
+         */
+        fun nextFrame()
+
+        /**
+         * Called when surfaces are newly or no longer available to the show.
+         *
+         * If the show is able to reconfigure itself for the new set of shaders, it should do so and return `true`.
+         *
+         * @return true if the show should be reinitialized.
+         */
+        fun surfacesChanged(newSurfaces: List<Surface>, removedSurfaces: List<Surface>): Unit =
+            throw RestartShowException()
     }
 
     class RestartShowException : Exception()

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -5,15 +5,15 @@ import baaahs.shaders.CompositorShader
 
 class ShowRunner(
     private val model: SheepModel,
-    initialShow: Show.MetaData,
+    initialShow: Show,
     private val gadgetProvider: GadgetProvider,
     brains: List<RemoteBrain>,
     private val beatProvider: Pinky.BeatProvider,
     private val dmxUniverse: Dmx.Universe
 ) {
-    var nextShow: Show.MetaData? = initialShow
-    var currentShow: Show.MetaData? = null
-    var currentShowRenderer: Show? = null
+    var nextShow: Show? = initialShow
+    private var currentShow: Show? = null
+    private var currentShowRenderer: Show.Renderer? = null
     private val changedSurfaces = mutableListOf<SurfacesChanges>()
     private var totalSurfaceReceivers = 0
 
@@ -144,7 +144,7 @@ class ShowRunner(
                 shadersLocked = false
                 gadgetsLocked = false
 
-                currentShowRenderer = it.createShow(model, this)
+                currentShowRenderer = it.createRenderer(model, this)
 
                 shadersLocked = true
                 gadgetsLocked = true

--- a/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/CompositeShow.kt
@@ -9,8 +9,8 @@ import baaahs.shaders.SolidShader
 import kotlin.math.PI
 import kotlin.random.Random
 
-object CompositeShow : Show.MetaData("Composite") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
+object CompositeShow : Show("Composite") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner) = object : Renderer {
         val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 
         val solidShader = SolidShader()

--- a/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/LifeyShow.kt
@@ -5,8 +5,8 @@ import baaahs.gadgets.Slider
 import baaahs.shaders.SolidShader
 import kotlin.random.Random
 
-object LifeyShow : Show.MetaData("Lifey") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+object LifeyShow : Show("Lifey") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
         val speedSlider = showRunner.getGadget("speed", Slider("Speed", .25f))
 
         val shader = SolidShader()
@@ -21,7 +21,7 @@ object LifeyShow : Show.MetaData("Lifey") {
         fun SheepModel.Panel.isSelected() = selectedPanels.contains(this)
         fun SheepModel.Panel.neighborsSelected() = neighbors().filter { selectedPanels.contains(it) }.count()
 
-        return object : Show {
+        return object : Renderer {
             override fun nextFrame() {
                 val nowMs = getTimeMillis()
                 val intervalMs = (speedSlider.value * 1000).toLong()

--- a/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PanelTweenShow.kt
@@ -7,8 +7,8 @@ import baaahs.shaders.CompositorShader
 import baaahs.shaders.SolidShader
 import baaahs.shaders.SparkleShader
 
-object PanelTweenShow : Show.MetaData("PanelTweenShow") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+object PanelTweenShow : Show("PanelTweenShow") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
         val colorArray = arrayOf(
             Color.from("#FF8A47"),
             Color.from("#FC6170"),
@@ -17,7 +17,7 @@ object PanelTweenShow : Show.MetaData("PanelTweenShow") {
             Color.from("#FFD747")
         )
 
-        return object : Show {
+        return object : Renderer {
             val slider = showRunner.getGadget("sparkliness", Slider("Sparkliness", 0f))
 
             val solidShader = SolidShader()

--- a/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/PixelTweenShow.kt
@@ -4,8 +4,8 @@ import baaahs.*
 import baaahs.shaders.PixelShader
 import kotlin.random.Random
 
-object PixelTweenShow : Show.MetaData("PixelTweenShow") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+object PixelTweenShow : Show("PixelTweenShow") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
         val colorArray = arrayOf(
             Color.from("#FF8A47"),
             Color.from("#FC6170"),
@@ -14,7 +14,7 @@ object PixelTweenShow : Show.MetaData("PixelTweenShow") {
             Color.from("#FFD747")
         )
 
-        return object : Show {
+        return object : Renderer {
             val shaderBuffers = showRunner.allSurfaces.map { surface ->
                 showRunner.getShaderBuffer(surface, PixelShader())
             }

--- a/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/RandomShow.kt
@@ -4,8 +4,8 @@ import baaahs.*
 import baaahs.shaders.PixelShader
 import kotlin.random.Random
 
-object RandomShow : Show.MetaData("Random") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
+object RandomShow : Show("Random") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner) = object : Renderer {
         val pixelShaderBuffers = showRunner.allSurfaces.map { surface ->
             showRunner.getShaderBuffer(surface, PixelShader())
         }

--- a/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SimpleSpatialShow.kt
@@ -7,8 +7,8 @@ import baaahs.gadgets.ColorPicker
 import baaahs.gadgets.Slider
 import baaahs.shaders.SimpleSpatialShader
 
-object SimpleSpatialShow : Show.MetaData("Spatial") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+object SimpleSpatialShow : Show("Spatial") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
         val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
         val centerXSlider = showRunner.getGadget("centerX", Slider("center X", 0.5f))
         val centerYSlider = showRunner.getGadget("centerY", Slider("center Y", 0.5f))
@@ -19,7 +19,7 @@ object SimpleSpatialShow : Show.MetaData("Spatial") {
             showRunner.getShaderBuffer(it, shader)
         }
 
-        return object : Show {
+        return object : Renderer {
             override fun nextFrame() {
                 shaderBuffers.forEach {
                     it.color = colorPicker.color

--- a/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SolidColorShow.kt
@@ -7,8 +7,8 @@ import baaahs.ShowRunner
 import baaahs.gadgets.ColorPicker
 import baaahs.shaders.SolidShader
 
-object SolidColorShow : Show.MetaData("Solid Color") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+object SolidColorShow : Show("Solid Color") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
         val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 
         val shader = SolidShader()
@@ -16,7 +16,7 @@ object SolidColorShow : Show.MetaData("Solid Color") {
             showRunner.getShaderBuffer(it, shader).apply { color = Color.WHITE }
         }
 
-        return object : Show {
+        return object : Renderer {
             var priorColor = colorPicker.color
 
             override fun nextFrame() {

--- a/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/SomeDumbShow.kt
@@ -7,8 +7,8 @@ import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.random.Random
 
-object SomeDumbShow : Show.MetaData("SomeDumbShow") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
+object SomeDumbShow : Show("SomeDumbShow") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner) = object : Renderer {
         val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
         val pixelShader = PixelShader()
 

--- a/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/ThumpShow.kt
@@ -9,8 +9,8 @@ import baaahs.shaders.SolidShader
 import kotlin.math.PI
 import kotlin.random.Random
 
-object ThumpShow : Show.MetaData("Thump") {
-    override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner) = object : Show {
+object ThumpShow : Show("Thump") {
+    override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner) = object : Renderer {
         private val beatProvider = showRunner.getBeatProvider()
         val colorPicker = showRunner.getGadget("color", ColorPicker("Color"))
 

--- a/src/commonTest/kotlin/baaahs/PinkyTest.kt
+++ b/src/commonTest/kotlin/baaahs/PinkyTest.kt
@@ -41,15 +41,15 @@ class PinkyTest {
 
     fun defrag(bytes: ByteArray) = bytes.slice(FragmentingUdpLink.headerSize until bytes.size).toByteArray()
 
-    class TestShow1(var supportsSurfaceChange: Boolean = true) : Show.MetaData("TestShow1") {
+    class TestShow1(var supportsSurfaceChange: Boolean = true) : Show("TestShow1") {
         val createdShows = mutableListOf<ShowRenderer>()
         val solidShader = SolidShader()
 
-        override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+        override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
             return ShowRenderer(showRunner).also { createdShows.add(it) }
         }
 
-        inner class ShowRenderer(private val showRunner: ShowRunner) : Show {
+        inner class ShowRenderer(private val showRunner: ShowRunner) : Renderer {
             val shaderBuffers =
                 showRunner.allSurfaces.associateWith { showRunner.getShaderBuffer(it, solidShader) }.toMutableMap()
 

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -253,15 +253,15 @@ class ShowRunnerTest {
         var onCreateShow: () -> Unit = {},
         var onNextFrame: () -> Unit = {},
         var onSurfacesChanged: (List<Surface>, List<Surface>) -> Unit = { _, _ -> }
-    ) : Show.MetaData("TestShow1") {
+    ) : Show("TestShow1") {
         val createdShows = mutableListOf<ShowRenderer>()
         val solidShader = SolidShader()
 
-        override fun createShow(sheepModel: SheepModel, showRunner: ShowRunner): Show {
+        override fun createRenderer(sheepModel: SheepModel, showRunner: ShowRunner): Renderer {
             return ShowRenderer(showRunner).also { createdShows.add(it) }
         }
 
-        inner class ShowRenderer(private val showRunner: ShowRunner) : Show {
+        inner class ShowRenderer(private val showRunner: ShowRunner) : Renderer {
             val slider = showRunner.getGadget("slider", Slider("slider"))
             val shaderBuffers =
                 showRunner.allSurfaces.associateWith { showRunner.getShaderBuffer(it, solidShader) }.toMutableMap()

--- a/src/jsMain/kotlin/baaahs/Displays.kt
+++ b/src/jsMain/kotlin/baaahs/Displays.kt
@@ -63,7 +63,7 @@ class JsNetworkDisplay(document: Document) : NetworkDisplay {
 
 class JsPinkyDisplay(element: Element) : PinkyDisplay {
     override var onShowChange: (() -> Unit) = {}
-    override var selectedShow: Show.MetaData? = null
+    override var selectedShow: Show? = null
         set(value) {
             field = value
             val options = showListInput.options
@@ -90,7 +90,7 @@ class JsPinkyDisplay(element: Element) : PinkyDisplay {
     private val beat3: Element
     private val beat4: Element
     private val beats: List<Element>
-    private var showList = emptyList<Show.MetaData>()
+    private var showList = emptyList<Show>()
     private val showListInput: HTMLSelectElement
     private var nextFrameElapsed: Element
     private var statsSpan: Element
@@ -110,7 +110,7 @@ class JsPinkyDisplay(element: Element) : PinkyDisplay {
         beat4 = beatsDiv.appendElement("span") { appendText("4") }
         beats = listOf(beat1, beat2, beat3, beat4)
 
-        element.appendElement("b") { appendText("Show: ") }
+        element.appendElement("b") { appendText("Renderer: ") }
         showListInput = element.appendElement("select") { className = "showsDiv" } as HTMLSelectElement
         showListInput.onchange = {
             selectedShow = showList.find { it.name == showListInput.selectedOptions[0]?.textContent }
@@ -124,7 +124,7 @@ class JsPinkyDisplay(element: Element) : PinkyDisplay {
         statsSpan = element.appendElement("span") {}
     }
 
-    override fun listShows(showMetas: List<Show.MetaData>) {
+    override fun listShows(showMetas: List<Show>) {
         showListInput.clear()
         showList = showMetas
         showMetas.forEach {

--- a/src/jvmMain/kotlin/baaahs/PinkyMain.kt
+++ b/src/jvmMain/kotlin/baaahs/PinkyMain.kt
@@ -43,10 +43,10 @@ fun main(args: Array<String>) {
 
     val pinky =
         Pinky(sheepModel, AllShows.allShows, JvmNetwork(httpServer), FakeDmxUniverse(), object : StubPinkyDisplay() {
-            override fun listShows(showMetas: List<Show.MetaData>) {
+            override fun listShows(showMetas: List<Show>) {
                 println("showMetas = ${showMetas}")
             }
-            override var selectedShow: Show.MetaData? = null
+            override var selectedShow: Show? = null
                 set(value) { field = value; println("selectedShow: ${value}") }
 
             override var nextFrameMs: Int = 0


### PR DESCRIPTION
`Show.MetaData` is now `Show`; `Show` is now `Show.Renderer`.