### PR TITLE
Shaders render one pixel at a time.

### DIFF
--- a/src/commonMain/kotlin/baaahs/Brain.kt
+++ b/src/commonMain/kotlin/baaahs/Brain.kt
@@ -128,7 +128,13 @@ class Brain(
 
     class ShaderBits<B : Shader.Buffer>(val shader: Shader<B>, val renderer: Shader.Renderer<B>, val buffer: B) {
         fun read(reader: ByteArrayReader) = buffer.read(reader)
-        fun draw(pixels: Pixels) = renderer.draw(buffer, pixels)
+        fun draw(pixels: Pixels) {
+            renderer.beginFrame(buffer, pixels.size)
+            for (i in pixels.indices) {
+                pixels[i] = renderer.draw(buffer, i)
+            }
+            renderer.endFrame()
+        }
     }
 
     inner class UnmappedSurface : Surface {

--- a/src/commonMain/kotlin/baaahs/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/Shaders.kt
@@ -77,7 +77,9 @@ abstract class Shader<B : Shader.Buffer>(val id: ShaderId) {
     }
 
     interface Renderer<B : Buffer> {
-        fun draw(buffer: B, pixels: Pixels)
+        fun beginFrame(buffer: B, pixelCount: Int) {}
+        fun draw(buffer: B, pixelIndex: Int): Color
+        fun endFrame() {}
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
@@ -70,9 +70,7 @@ class PixelShader() : Shader<PixelShader.Buffer>(ShaderId.PIXEL) {
     }
 
     class Renderer : Shader.Renderer<Buffer> {
-        override fun draw(buffer: Buffer, pixels: Pixels) {
-            pixels.set(buffer.colors)
-        }
+        override fun draw(buffer: Buffer, pixelIndex: Int): Color = buffer.colors[pixelIndex]
     }
 
 }

--- a/src/commonMain/kotlin/baaahs/shaders/SimpleSpatialShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SimpleSpatialShader.kt
@@ -47,22 +47,18 @@ class SimpleSpatialShader() : Shader<SimpleSpatialShader.Buffer>(ShaderId.SIMPLE
     class Renderer(surface: Surface) : Shader.Renderer<Buffer> {
         private val pixelVertices = (surface as? Brain.MappedSurface)?.pixelVertices
 
-        override fun draw(buffer: Buffer, pixels: Pixels) {
-            if (pixelVertices == null) return
+        override fun draw(buffer: Buffer, pixelIndex: Int): Color {
+            if (pixelVertices == null || pixelIndex >= pixelVertices.size) return Color.BLACK
 
-            for (i in 0 until min(pixels.size, pixelVertices.size)) {
-                val (pixX, pixY) = pixelVertices[i]
+            val (pixX, pixY) = pixelVertices[pixelIndex]
 
-                val distX = pixX - buffer.centerX
-                val distY = pixY - buffer.centerY
-                val dist = sqrt(distX * distX + distY * distY)
-                pixels[i] = if (dist < buffer.radius - 0.025f) {
-                    buffer.color
-                } else if (dist < buffer.radius + 0.025f) {
-                    Color.BLACK
-                } else {
-                    buffer.color.fade(Color.BLACK, dist * 2)
-                }
+            val distX = pixX - buffer.centerX
+            val distY = pixY - buffer.centerY
+            val dist = sqrt(distX * distX + distY * distY)
+            return when {
+                dist < buffer.radius - 0.025f -> buffer.color
+                dist < buffer.radius + 0.025f -> Color.BLACK
+                else -> buffer.color.fade(Color.BLACK, dist * 2)
             }
         }
     }

--- a/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SineWaveShader.kt
@@ -42,15 +42,18 @@ class SineWaveShader() : Shader<SineWaveShader.Buffer>(ShaderId.SINE_WAVE) {
     }
 
     class Renderer : Shader.Renderer<Buffer> {
-        override fun draw(buffer: Buffer, pixels: Pixels) {
+        private var pixelCount: Int = 1
+
+        override fun beginFrame(buffer: Buffer, pixelCount: Int) {
+            this.pixelCount = pixelCount
+        }
+
+        override fun draw(buffer: Buffer, pixelIndex: Int): Color {
             val theta = buffer.theta
-            val pixelCount = pixels.size
             val density = buffer.density
 
-            for (i in pixels.indices) {
-                val v = sin(theta + 2 * PI * (i.toFloat() / pixelCount * density)) / 2 + .5
-                pixels[i] = Color.BLACK.fade(buffer.color, v.toFloat())
-            }
+            val v = sin(theta + 2 * PI * (pixelIndex.toFloat() / pixelCount * density)) / 2 + .5
+            return Color.BLACK.fade(buffer.color, v.toFloat())
         }
     }
 }

--- a/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SolidShader.kt
@@ -34,11 +34,6 @@ class SolidShader : Shader<SolidShader.Buffer>(ShaderId.SOLID) {
     }
 
     class Renderer : Shader.Renderer<Buffer> {
-
-        override fun draw(buffer: Buffer, pixels: Pixels) {
-            for (i in pixels.indices) {
-                pixels[i] = buffer.color
-            }
-        }
+        override fun draw(buffer: Buffer, pixelIndex: Int): Color = buffer.color
     }
 }

--- a/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SparkleShader.kt
@@ -37,10 +37,8 @@ class SparkleShader : Shader<SparkleShader.Buffer>(ShaderId.SPARKLE) {
     }
 
     class Renderer : Shader.Renderer<Buffer> {
-        override fun draw(buffer: Buffer, pixels: Pixels) {
-            for (i in pixels.indices) {
-                pixels[i] = if (Random.nextFloat() < buffer.sparkliness ) { buffer.color } else { Color.BLACK }
-            }
+        override fun draw(buffer: Buffer, pixelIndex: Int): Color {
+            return if (Random.nextFloat() < buffer.sparkliness ) { buffer.color } else { Color.BLACK }
         }
     }
 }

--- a/src/commonTest/kotlin/baaahs/shaders/util.kt
+++ b/src/commonTest/kotlin/baaahs/shaders/util.kt
@@ -33,7 +33,11 @@ internal fun <T : Shader.Buffer> render(srcShader: Shader<T>, srcBuf: T, surface
     val (dstShader: Shader<T>, dstBuf) = send(srcShader, srcBuf, surface)
     val pixels = FakePixels(surface.pixelCount)
     val renderer = dstShader.createRenderer(surface)
-    renderer.draw(dstBuf, pixels)
+    renderer.beginFrame(dstBuf, pixels.size)
+    for (i in pixels.indices) {
+        pixels[i] = renderer.draw(dstBuf, i)
+    }
+    renderer.endFrame()
     return pixels
 }
 


### PR DESCRIPTION
No need for secondary pixel buffers when compositing.