### PR TITLE
Fix slider updating between multiple web UIs.

### DIFF
--- a/src/commonMain/kotlin/baaahs/PubSub.kt
+++ b/src/commonMain/kotlin/baaahs/PubSub.kt
@@ -66,7 +66,7 @@ abstract class PubSub {
         private val toSend: MutableList<ByteArray> = mutableListOf()
 
         override fun connected(tcpConnection: Network.TcpConnection) {
-            logger.debug("[${tcpConnection.fromAddress} -> $name] PubSub: new $this connection")
+            debug("connection $this established")
             connection = tcpConnection
             toSend.forEach { tcpConnection.send(it) }
             toSend.clear()
@@ -77,8 +77,6 @@ abstract class PubSub {
             when (val command = reader.readString()) {
                 "sub" -> {
                     val topicName = reader.readString()
-                    println("[${tcpConnection.fromAddress} -> $name] sub $topicName")
-
                     val topicInfo = topics.getOrPut(topicName) { TopicInfo(topicName) }
                     val listener = object : Listener(this) {
                         override fun onUpdate(data: String) = sendTopicUpdate(topicName, data)
@@ -94,8 +92,6 @@ abstract class PubSub {
                 "update" -> {
                     val topicName = reader.readString()
                     val data = reader.readString()
-                    println("[${tcpConnection.fromAddress} -> $name] update $topicName $data")
-
                     val topicInfo = topics[topicName]
                     topicInfo?.notify(data, this)
                 }
@@ -107,8 +103,9 @@ abstract class PubSub {
         }
 
         fun sendTopicUpdate(name: String, data: String) {
+            debug("update $name $data")
+
             val writer = ByteArrayWriter()
-            println("-> update $name $data to ${connection?.toAddress}")
             writer.writeString("update")
             writer.writeString(name)
             writer.writeString(data)
@@ -116,6 +113,8 @@ abstract class PubSub {
         }
 
         fun sendTopicSub(topicName: String) {
+            debug("sub $topicName")
+
             val writer = ByteArrayWriter()
             writer.writeString("sub")
             writer.writeString(topicName)
@@ -133,6 +132,10 @@ abstract class PubSub {
             } else {
                 tcpConnection.send(bytes)
             }
+        }
+
+        private fun debug(message: String) {
+            logger.debug("[PubSub $name -> ${connection?.toAddress ?: "(deferred)"}]: $message")
         }
     }
 
@@ -154,7 +157,7 @@ abstract class PubSub {
         }
 
         override fun incomingConnection(fromConnection: Network.TcpConnection): Network.TcpListener {
-            return Connection("server", topics)
+            return Connection("server at ${fromConnection.toAddress}", topics)
         }
 
         fun <T : Any> publish(topic: Topic<T>, data: T, onUpdate: (T) -> Unit): Channel<T> {

--- a/src/commonTest/kotlin/baaahs/GadgetTest.kt
+++ b/src/commonTest/kotlin/baaahs/GadgetTest.kt
@@ -13,25 +13,18 @@ class GadgetTest {
     private val testCoroutineContext = TestCoroutineContext("network")
     private val network = FakeNetwork(0, coroutineContext = testCoroutineContext)
     private val serverLink = network.link()
+    private val clientLink = network.link()
 
     @Test
     fun whenGadgetValuesChange_shouldNotifyListeners() {
         val someGadget = SomeGadget(123)
 
         val log1 = mutableListOf<String>()
-        val listener1 = object : GadgetListener {
-            override fun onChanged(gadget: Gadget) {
-                log1.add("changed")
-            }
-        }
+        val listener1: GadgetListener = { _ -> log1.add("changed") }
         someGadget.listen(listener1)
 
         val log2 = mutableListOf<String>()
-        val listener2 = object : GadgetListener {
-            override fun onChanged(gadget: Gadget) {
-                log2.add("changed")
-            }
-        }
+        val listener2: GadgetListener = { _ -> log2.add("changed") }
         someGadget.listen(listener2)
 
         someGadget.value = 321
@@ -52,22 +45,53 @@ class GadgetTest {
         val serverSlider = Slider("fader", .1234f)
         gadgetManager.sync(listOf("fader" to serverSlider))
 
-        val pubSubClient = PubSub.connect(serverLink, serverLink.myAddress, 1234)
+        val pubSubClient = PubSub.connect(clientLink, serverLink.myAddress, 1234)
         pubSubClient.install(gadgetModule)
 
-        var clientGadgets = listOf<Gadget>()
-        GadgetDisplay(pubSubClient) { gadgets -> clientGadgets = gadgets.map { it.gadget }.toMutableList() }
+        val gadgetEvents = mutableListOf<String>()
+
+        var clientAGadgets = listOf<Gadget>()
+        GadgetDisplay(pubSubClient) { gadgets -> clientAGadgets = gadgets.map { it.gadget }.toMutableList() }
         gadgetManager.sync(listOf("fader" to serverSlider))
         testCoroutineContext.runAll()
 
-        expect(1) { clientGadgets.size }
-        val clientSlider = clientGadgets[0] as Slider
-        expect(.1234f) { clientSlider.value }
+        expect(1) { clientAGadgets.size }
+        val clientASlider = clientAGadgets[0] as Slider
+        expect(.1234f) { clientASlider.value }
 
-        clientSlider.value = .4321f
+        clientASlider.value = .4321f
         testCoroutineContext.runAll()
 
         expect(.4321f) { serverSlider.value }
+
+        val client2Link = network.link()
+        val pubSubClient2 = PubSub.connect(client2Link, serverLink.myAddress, 1234)
+        pubSubClient2.install(gadgetModule)
+
+        var clientBGadgets = listOf<Gadget>()
+        GadgetDisplay(pubSubClient2) { gadgets -> clientBGadgets = gadgets.map { it.gadget }.toMutableList() }
+        testCoroutineContext.runAll()
+
+        expect(1) { clientBGadgets.size }
+        val clientBSlider = clientBGadgets[0] as Slider
+        expect(.4321f) { clientBSlider.value }
+
+        clientASlider.listen { gadget -> gadgetEvents.add("clientASlider updated to ${gadget.state}") }
+        clientBSlider.listen { gadget -> gadgetEvents.add("clientBSlider updated to ${gadget.state}") }
+
+        clientASlider.value = .8765f
+        testCoroutineContext.runAll()
+
+        expect(.8765f) { clientASlider.value }
+        expect(.8765f) { clientBSlider.value }
+
+        // UI must be notified of change.
+        expect(
+            listOf(
+                "clientASlider updated to {value=0.8765}",
+                "clientBSlider updated to {value=0.8765}"
+            )
+        ) { gadgetEvents.sorted() }
     }
 
     class SomeGadget(initialValue: Int) : Gadget() {

--- a/src/jsMain/js/app/components/gadgets/ColorPicker/index.jsx
+++ b/src/jsMain/js/app/components/gadgets/ColorPicker/index.jsx
@@ -37,8 +37,7 @@ class ColorPicker extends Component {
     // Send color updates once every 150ms while the picker is dragged
     this._throttledHandleColorChange = throttle(this._handleColorChange, 150);
 
-    this._changeListener = {
-      onChanged: (gadget) => {
+    this._changeListener = () => {
         const { colors } = this.state;
         const { redI, greenI, blueI } = gadget.color;
         const color = [redI, greenI, blueI];
@@ -47,7 +46,6 @@ class ColorPicker extends Component {
         updatedColors[0] = color;
 
         this.setState({ colors: updatedColors });
-      },
     };
     gadget.listen(this._changeListener);
   }

--- a/src/jsMain/js/app/components/gadgets/ColorPicker/index.jsx
+++ b/src/jsMain/js/app/components/gadgets/ColorPicker/index.jsx
@@ -20,12 +20,10 @@ class ColorPicker extends Component {
   constructor(props) {
     super(props);
 
-    const { gadget } = this.props;
-    const { redI, greenI, blueI } = gadget.color;
+    const { redI, greenI, blueI } = props.gadget.color;
     const color = [redI, greenI, blueI];
 
     this.state = {
-      gadget,
       colors: [color],
       radius: 10,
       selectedIndex: -1,
@@ -37,23 +35,12 @@ class ColorPicker extends Component {
     // Send color updates once every 150ms while the picker is dragged
     this._throttledHandleColorChange = throttle(this._handleColorChange, 150);
 
-    this._changeListener = () => {
-        const { colors } = this.state;
-        const { redI, greenI, blueI } = gadget.color;
-        const color = [redI, greenI, blueI];
-
-        const updatedColors = colors.slice();
-        updatedColors[0] = color;
-
-        this.setState({ colors: updatedColors });
-    };
-    gadget.listen(this._changeListener);
+    props.gadget.listen(this._changeListener);
   }
 
   componentWillUnmount() {
-    const { gadget } = this.state;
     if (this._changeListener) {
-      gadget.unlisten(this._changeListener);
+      this.props.gadget.unlisten(this._changeListener);
     }
   }
 
@@ -98,13 +85,24 @@ class ColorPicker extends Component {
     ctx.putImageData(image, 0, 0);
   }
 
+  _changeListener = () => {
+    const { colors } = this.state;
+    const { redI, greenI, blueI } = this.props.gadget.color;
+    const color = [redI, greenI, blueI];
+
+    const updatedColors = colors.slice();
+    updatedColors[0] = color;
+
+    this.setState({ colors: updatedColors });
+  };
+
+
   _handleColorChange = () => {
     const { colors } = this.state;
     const [red, green, blue] = colors[0];
     const hex = chroma.rgb(red, green, blue).hex();
 
-    const { gadget } = this.state;
-    gadget.color = baaahs.Color.Companion.fromString(hex);
+    this.props.gadget.color = baaahs.Color.Companion.fromString(hex);
   };
 
   _onPickerDragged(ev, data, index) {

--- a/src/jsMain/js/app/components/gadgets/Slider/index.jsx
+++ b/src/jsMain/js/app/components/gadgets/Slider/index.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import throttle from 'lodash/throttle';
 import sass from './Slider.scss';
-import { Handles, Rail, Slider, Ticks, Tracks } from 'react-compound-slider';
-import { Handle, SliderRail, Tick, Track } from './slider-parts';
+import {Handles, Rail, Slider, Ticks, Tracks} from 'react-compound-slider';
+import {Handle, SliderRail, Tick, Track} from './slider-parts';
 
 const sliderStyle = {
   position: 'relative',
@@ -18,38 +18,34 @@ class RangeSlider extends React.Component {
   constructor(props) {
     super(props);
 
-    let value = props.gadget.value;
     this.state = {
       gadget: props.gadget,
-      value: value,
-      update: value,
     };
 
-    props.gadget.listen({
-      onChanged: () => {
-        this.forceUpdate();
-      },
+    props.gadget.listen(() => {
+      this.forceUpdate();
     });
   }
 
-  onUpdate = (update) => {
-    this.setState({ update }, () => {
-      this.throttleUpdateGadgetValue(update);
-    });
-  };
+  componentWillUnmount() {
+    const { gadget } = this.state;
+    if (this._changeListener) {
+      gadget.unlisten(this._changeListener);
+    }
+  }
 
-  throttleUpdateGadgetValue = throttle((value) => {
-    this.props.gadget.value = value;
+  onUpdate = throttle((value) => {
+    this.onChange(value);
   }, 10);
 
   onChange = (value) => {
-    const { gadget } = this.props;
-    this.setState({ value });
+    const { gadget } = this.state;
     gadget.value = value;
+    this.setState({ gadget });
   };
 
   render() {
-    const { gadget, value, update } = this.state;
+    const { gadget } = this.state;
 
     return (
       <div className={sass['slider--wrapper']}>
@@ -63,11 +59,13 @@ class RangeSlider extends React.Component {
           step={0.01}
           domain={domain}
           rootStyle={sliderStyle}
-          onUpdate={this.onUpdate}
+          onUpdate={(values) => {
+            this.onUpdate(values[0]);
+          }}
           onChange={(values) => {
             this.onChange(values[0]);
           }}
-          values={[value]}
+          values={[gadget.value]}
         >
           <Rail>
             {({ getRailProps }) => <SliderRail getRailProps={getRailProps} />}

--- a/src/jsMain/js/app/components/gadgets/Slider/index.jsx
+++ b/src/jsMain/js/app/components/gadgets/Slider/index.jsx
@@ -19,18 +19,17 @@ class RangeSlider extends React.Component {
     super(props);
 
     this.state = {
-      gadget: props.gadget,
+      value: props.gadget.value,
     };
 
     props.gadget.listen(() => {
-      this.forceUpdate();
+      this.setState({ value: props.gadget.value });
     });
   }
 
   componentWillUnmount() {
-    const { gadget } = this.state;
     if (this._changeListener) {
-      gadget.unlisten(this._changeListener);
+      this.props.gadget.unlisten(this._changeListener);
     }
   }
 
@@ -39,18 +38,17 @@ class RangeSlider extends React.Component {
   }, 10);
 
   onChange = (value) => {
-    const { gadget } = this.state;
-    gadget.value = value;
-    this.setState({ gadget });
+    this.props.gadget.value = value;
+    this.setState({ value });
   };
 
   render() {
-    const { gadget } = this.state;
+    const { value } = this.state;
 
     return (
       <div className={sass['slider--wrapper']}>
         <label className={sass['slider--label']} htmlFor="range-slider">
-          {gadget.name}
+          {this.props.gadget.name}
         </label>
         <Slider
           vertical
@@ -65,7 +63,7 @@ class RangeSlider extends React.Component {
           onChange={(values) => {
             this.onChange(values[0]);
           }}
-          values={[gadget.value]}
+          values={[value]}
         >
           <Rail>
             {({ getRailProps }) => <SliderRail getRailProps={getRailProps} />}


### PR DESCRIPTION
Updates between web UI instances was broken (click "Web UI" and move sliders).

- Gadget state update notifications to the UI were lost in 105e1d3.
- Slider component wasn't redrawing when update notifications arrived.
- Moved slider value state back to gadget.
- ColorPicker doesn't update properly still.