### PR TITLE
Log elapsed time to render a frame of pixels

### DIFF
--- a/brain/sw/components/led-renderer/led-renderer.cpp
+++ b/brain/sw/components/led-renderer/led-renderer.cpp
@@ -122,6 +122,7 @@ LEDRenderer::_task() {
 
 void
 LEDRenderer::render() {
+    int64_t startTime = esp_timer_get_time();
 
     // Render into all the pixels
     if (m_shader) {
@@ -142,6 +143,9 @@ LEDRenderer::render() {
     } else {
         ESP_LOGE(TAG, "Nothing to render!!!!");
     }
+
+    int64_t endTime = esp_timer_get_time();
+    ESP_LOGI(TAG, "Rendering %d pixels took %lldms", m_buffer.PixelCount(), (endTime - startTime) / 1000);
 
 
     // Don't want to block a rendering task in case the blitter task has gone upside down

--- a/brain/sw/playa/main/main.cpp
+++ b/brain/sw/playa/main/main.cpp
@@ -31,7 +31,7 @@ extern "C" void app_main()
     // esp_log_level_set("#   net", ESP_LOG_DEBUG);
     // esp_log_level_set("#   msg", ESP_LOG_DEBUG);
     esp_log_level_set("# brain", ESP_LOG_INFO);
-    esp_log_level_set("#ledren", ESP_LOG_DEBUG);
+    esp_log_level_set("#ledren", ESP_LOG_WARN);
 
     esp_log_level_set("httpd", ESP_LOG_NONE);
     esp_log_level_set("#   net", ESP_LOG_NONE);


### PR DESCRIPTION
This is super noisy, maybe there's a better way? I think the info is pretty useful though.