### PR TITLE
Prerender shows on Pinky

### DIFF
--- a/brain/sw/components/shaders/pixel-shader.h
+++ b/brain/sw/components/shaders/pixel-shader.h
@@ -17,6 +17,7 @@ private:
     Color *m_palette;
     size_t m_dataBufSize;
     uint8_t *m_dataBuf;
+    size_t m_dataBufRead;
 
     /** Shader construction failed, we'll render nothing. */
     bool m_disabled = false;

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -20,7 +20,8 @@ class Pinky(
     val network: Network,
     val dmxUniverse: Dmx.Universe,
     val fs: Fs,
-    val display: PinkyDisplay
+    val display: PinkyDisplay,
+    private val prerenderPixels: Boolean = false
 ) : Network.UdpListener {
     private val link = FragmentingUdpLink(network.link())
     private val udpSocket = link.listenUdp(Ports.PINKY, this)
@@ -49,8 +50,6 @@ class Pinky(
     private val networkStats = NetworkStats()
 
     private val storage = Storage(fs)
-
-    private val prerenderPixels = true
 
     init {
         httpServer.listenWebSocket("/ws/mapper") { MapperEndpoint(storage) }

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -205,7 +205,7 @@ class ShowRunner(
             val shaderBuffer = shaderBuffers.first()
 
             receiversFor(surface).forEach { receiver ->
-                receiver.sendFn(shaderBuffer)
+                receiver.send(shaderBuffer)
             }
         }
 
@@ -217,6 +217,9 @@ class ShowRunner(
     }
 
     data class SurfacesChanges(val added: Collection<SurfaceReceiver>, val removed: Collection<SurfaceReceiver>)
-    class SurfaceReceiver(val surface: Surface, val sendFn: (Shader.Buffer) -> Unit)
+
+    open class SurfaceReceiver(val surface: Surface, private val sendFn: (Shader.Buffer) -> Unit) {
+        open fun send(shaderBuffer: Shader.Buffer) = sendFn(shaderBuffer)
+    }
 
 }

--- a/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/PixelShader.kt
@@ -116,7 +116,7 @@ class PixelShader(private val encoding: Encoding = Encoding.DIRECT_ARGB) : Shade
 
         /** [serialize] and [read] are asymmetrical because pixel count is read in [Buffer.read]. */
         override fun serialize(writer: ByteArrayWriter) {
-            writer.writeShort(colorsBuf.size)
+            writer.writeShort(pixelCount)
             colorsBuf.forEach { color -> writeColor(color, writer) }
         }
 

--- a/src/jvmMain/kotlin/baaahs/PinkyMain.kt
+++ b/src/jvmMain/kotlin/baaahs/PinkyMain.kt
@@ -42,7 +42,7 @@ fun main(args: Array<String>) {
 
             override var showFrameMs: Int = 0
                 set(value) { field = value; /* println("showFrameMs: ${value}") */ }
-        })
+        }, prerenderPixels = true)
 
     (pinky.httpServer as JvmNetwork.RealLink.KtorHttpServer).application.routing {
         static {


### PR DESCRIPTION
Shows are now prerendered on Pinky by default, and sent to Brains using `PixelShader`.

Switch back using `Pinky.prerenderPixels = false`.