### PR TITLE
Fix NaN error when there's no beat data

### DIFF
--- a/src/commonMain/kotlin/baaahs/BeatData.kt
+++ b/src/commonMain/kotlin/baaahs/BeatData.kt
@@ -21,24 +21,26 @@ data class BeatData(
         }
 
     fun beatWithinMeasure(clock: Clock): Float {
+        if (beatIntervalMs == 0) return -1f
         val elapsedSinceStartOfMeasure = clock.now() - measureStartTimeMs
         return ((elapsedSinceStartOfMeasure / beatIntervalMs).toFloat()) % beatsPerMeasure
     }
 
     fun timeSinceMeasure(clock: Clock): Float {
+        if (beatIntervalMs == 0) return -1f
         val elapsedSinceStartOfMeasure = clock.now() - measureStartTimeMs
         return (elapsedSinceStartOfMeasure / beatIntervalMs).toFloat()
     }
 
     /** Returns 1.0 if we're on a beat, 0.0 when we're furthest from the last beat,
      * and anywhere in between otherwise. */
-    fun fractionTilNextBeat(clock: Clock): Float =
-        1 - beatWithinMeasure(clock) % 1.0f
+    fun fractionTillNextBeat(clock: Clock): Float =
+        if (beatIntervalMs == 0) -1f else 1 - beatWithinMeasure(clock) % 1.0f
 
     /** Returns 1.0 if we're on the start of the measure, 0.0 when we're furthest from the start of the measure,
      * and anywhere in between otherwise. */
-    fun fractionTilNextMeasure(clock: Clock): Float =
-        1 - timeSinceMeasure(clock)
+    fun fractionTillNextMeasure(clock: Clock): Float =
+        if (beatIntervalMs == 0) -1f else 1 - timeSinceMeasure(clock)
 }
 
 

--- a/src/commonMain/kotlin/baaahs/shows/GlslShow.kt
+++ b/src/commonMain/kotlin/baaahs/shows/GlslShow.kt
@@ -71,13 +71,13 @@ abstract class GlslShow(name: String) : Show(name) {
 
     class BeatDataSource(val beatData: BeatData, val clock: Clock) : DataSource {
         override fun getValue(): Any {
-            return beatData.fractionTilNextBeat(clock)
+            return beatData.fractionTillNextBeat(clock)
         }
     }
 
     class StartOfMeasureDataSource(val beatData: BeatData, val clock: Clock) : DataSource {
         override fun getValue(): Any {
-            return beatData.fractionTilNextMeasure(clock)
+            return beatData.fractionTillNextMeasure(clock)
         }
     }
 }

--- a/src/commonTest/kotlin/baaahs/BeatDataTest.kt
+++ b/src/commonTest/kotlin/baaahs/BeatDataTest.kt
@@ -23,4 +23,12 @@ class BeatDataTest {
         expect(3f) { BeatData(0.0, 500).beatWithinMeasure(FakeClock(1500.0)) }
         expect(3f) { BeatData(0.0, 500).beatWithinMeasure(FakeClock(3500.0)) }
     }
+
+    @Test
+    fun whenNoBeatDataPresent_beatAndTimeAreNegativeOne() {
+        expect(-1f) { BeatData(0.0, 0).beatWithinMeasure(FakeClock(0.0)) }
+        expect(-1f) { BeatData(0.0, 0).timeSinceMeasure(FakeClock(0.0)) }
+        expect(-1f) { BeatData(0.0, 0).fractionTillNextBeat(FakeClock(0.0)) }
+        expect(-1f) { BeatData(0.0, 0).fractionTillNextBeat(FakeClock(0.0)) }
+    }
 }


### PR DESCRIPTION
I'm not sure `-1` is the right thing to return there semantically, but it's better than `NaN`.