### PR TITLE
Add Renderer.release()

### DIFF
--- a/src/commonMain/kotlin/baaahs/Brain.kt
+++ b/src/commonMain/kotlin/baaahs/Brain.kt
@@ -90,11 +90,13 @@ class Brain(
 
                     @Suppress("UNCHECKED_CAST")
                     val shader = Shader.parse(ByteArrayReader(shaderDesc)) as Shader<Shader.Buffer>
-                    currentRenderTree = RenderTree(
+                    val newRenderTree = RenderTree(
                         shader,
                         shader.createRenderer(surface),
                         shader.createBuffer(surface)
                     )
+                    currentRenderTree?.release()
+                    currentRenderTree = newRenderTree
                 }
 
                 with(currentRenderTree!!) {
@@ -153,6 +155,10 @@ class Brain(
             }
             renderer.endFrame()
             pixels.finishedFrame()
+        }
+
+        fun release() {
+            renderer.release()
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -364,6 +364,7 @@ class Pinky(
                 }
 
                 renderTree = Brain.RenderTree(shader, renderer, shaderBuffer)
+                currentRenderTree?.release()
                 currentRenderTree = renderTree
 
                 if (pixels == null) {

--- a/src/commonMain/kotlin/baaahs/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/Shaders.kt
@@ -85,6 +85,7 @@ abstract class Shader<B : Shader.Buffer>(val id: ShaderId) {
         fun beginFrame(buffer: B, pixelCount: Int) {}
         fun draw(buffer: B, pixelIndex: Int): Color
         fun endFrame() {}
+        fun release() {}
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/glsl/GlslPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GlslPlugin.kt
@@ -9,5 +9,7 @@ interface GlslPlugin {
         fun afterCompile(program: Program)
 
         fun beforeRender()
+
+        fun release()
     }
 }

--- a/src/commonMain/kotlin/baaahs/glsl/GlslRenderer.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GlslRenderer.kt
@@ -212,6 +212,11 @@ void main(void) {
         }
     }
 
+    fun release() {
+        rendererPlugins.forEach { it.release() }
+        arrangement.release()
+    }
+
     inner class Arrangement(val pixelCount: Int, val uvCoords: FloatArray, val surfaces: List<GlslSurface>) {
         val adjustableUniforms: List<AdjustableUniform> =
             adjustableValues.map { adjustableValue ->

--- a/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/CompositorShader.kt
@@ -93,6 +93,11 @@ class CompositorShader(val aShader: Shader<*>, val bShader: Shader<*>) :
             rendererA.endFrame()
             rendererB.endFrame()
         }
+
+        override fun release() {
+            rendererA.release()
+            rendererB.release()
+        }
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/shaders/SoundAnalysisPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/shaders/SoundAnalysisPlugin.kt
@@ -70,10 +70,8 @@ class SoundAnalysisPlugin(val soundAnalyzer: SoundAnalyzer, val historySize: Int
             uniform.set(textureId)
         }
 
-        fun finalize() {
-            gl.check {
-                gl.deleteTexture(texture)
-            }
+        override fun release() {
+            gl.check { gl.deleteTexture(texture) }
         }
     }
 }


### PR DESCRIPTION
`GlslRenderer` needs a chance to free resources on the main thread.

Fixes segfault:
```
---------------  T H R E A D  ---------------

Current thread (0x00007fad4f123800):  JavaThread "Finalizer" daemon [_thread_in_native, id=19203, stack(0x0000700001763000,0x0000700001863000)]

Stack: [0x0000700001763000,0x0000700001863000],  sp=0x0000700001862750,  free space=1021k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libGL.dylib+0x1519]  glDeleteTextures+0x12
C  [liblwjgl.dylib+0x17b1c]
[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/scratch/mesos/slaves/62fa45a9-5cd4-454d-8a8a-6602ff6286e3-S178/frameworks/1735e8a2-a1db-478c-8104-60c8b0af87dd-0196/executors/d499fc30-2fcc-4cd1-a8a8-89674f0e8997/runs/f9fd96e9-c683-4085-b9dc-d0187a22e147/workspace/open/src/hotspot/os/bsd/decoder_machO.hpp:43)]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  org.lwjgl.system.JNI.callPV(I[IJ)V+0
j  org.lwjgl.opengl.GL11C.glDeleteTextures([I)V+22
j  org.lwjgl.opengl.GL11.glDeleteTextures([I)V+1
j  com.danielgergely.kgl.KglLwjgl.deleteTexture(I)V+7
j  baaahs.shaders.SoundAnalysisPlugin$RendererPlugin.finalize()V+17
j  java.lang.System$2.invokeFinalize(Ljava/lang/Object;)V+1 java.base@11.0.5
j  java.lang.ref.Finalizer.runFinalizer(Ljdk/internal/misc/JavaLangAccess;)V+101 java.base@11.0.5
j  java.lang.ref.Finalizer$FinalizerThread.run()V+46 java.base@11.0.5
v  ~StubRoutines::call_stub

siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000000
```