### PR TITLE
Optimize dev browser reload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,6 +211,7 @@ kotlin {
                 implementation(npm("resize-observer-polyfill", "^1.5.1"))
                 implementation(npm("react-ace", "^9.0.0"))
                 implementation(npm("ace-builds", "^1.4.11"))
+                implementation(npm("normalize.css", "^7.0.0"))
                 implementation(npm("@blueprintjs/core", "^3.24.0"))
                 implementation(npm("@blueprintjs/icons", "^3.14.0"))
             }
@@ -264,6 +265,14 @@ tasks.named<ProcessResources>("jsProcessResources") {
     from("build/js/node_modules/@fortawesome") {
         include("fontawesome-free/css/all.min.css")
         include("fontawesome-free/webfonts/*")
+    }
+    from("build/js/node_modules/normalize.css") {
+        include("normalize.css")
+    }
+    from("build/js/node_modules/@blueprintjs") {
+        into("blueprintjs")
+        include("core/lib/css/blueprint.css")
+        include("icons/lib/css/blueprint-icons.css")
     }
 
     doLast {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,6 +248,19 @@ tasks.withType(Kotlin2JsCompile::class) {
     kotlinOptions.sourceMapEmbedSources = "always"
 }
 
+// see https://discuss.kotlinlang.org/t/kotlin-js-react-unstable-building/15582/6
+tasks.named<Kotlin2JsCompile>("compileKotlinJs") {
+    val outDir = outputFile.parent
+    val tempOutDir = "$outDir/kotlin-out"
+    kotlinOptions.outputFile = "$tempOutDir/${outputFile.name}"
+    doLast {
+        copy {
+            from(tempOutDir)
+            into(outDir)
+        }
+    }
+}
+
 tasks.withType(KotlinWebpack::class) {
     sourceMaps = true
     inputs.dir("src/jsMain/js")

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -20,6 +20,7 @@
   document.resourcesBase = ".";
   document.sparklemotionMode = "Simulator";
 </script>
+<script type="application/javascript" src="vendors.js"></script>
 <script type="application/javascript" src="sparklemotion.js"></script>
 
 </body>

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -5,10 +5,10 @@
   <title>Simulator | sparklemotion</title>
   <link rel="stylesheet" href="styles.css"/>
   <link rel="stylesheet" href="react-mosaic-component.css"/>
-  <link href="https://unpkg.com/normalize.css@^7.0.0" rel="stylesheet" />
-  <link href="https://unpkg.com/@blueprintjs/icons@^3.4.0/lib/css/blueprint-icons.css" rel="stylesheet" />
-  <link href="https://unpkg.com/@blueprintjs/core@^3.10.0/lib/css/blueprint.css" rel="stylesheet" />
-  <link rel="stylesheet" href="./fontawesome-free/css/all.min.css">
+  <link rel="stylesheet" href="normalize.css"/>
+  <link rel="stylesheet" href="blueprintjs/icons/lib/css/blueprint-icons.css"/>
+  <link rel="stylesheet" href="blueprintjs/core/lib/css/blueprint.css"/>
+  <link rel="stylesheet" href="fontawesome-free/css/all.min.css">
 </head>
 <body>
 <div id="app"></div>

--- a/webpack.config.d/output.js
+++ b/webpack.config.d/output.js
@@ -54,6 +54,26 @@ if (config.devServer) {
       aggregateTimeout: 2000,
       poll: 1000
     };
+
+    config.optimization = {
+        splitChunks: {
+            chunks: 'all',
+            name: true,
+
+            cacheGroups: {
+                commons: {
+                    test: /[\\/]node_modules[\\/]|[\\/]packages_imported[\\/]/,
+                    name: 'vendors',
+                    chunks: 'all'
+                },
+                default: {
+                    minChunks: 2,
+                    priority: -20,
+                    reuseExistingChunk: true
+                }
+            }
+        }
+    };
 } else {
     // Otherwise we get "unknown module and require" from production build.
     config.optimization = {

--- a/webpack.config.d/output.js
+++ b/webpack.config.d/output.js
@@ -1,4 +1,6 @@
-var path = require('path');
+const path = require('path');
+
+config = config || {};
 
 // cwd is build/js/packages/sparklemotion
 config.resolve.modules.push(path.resolve(__dirname, "../../node_modules"));
@@ -6,7 +8,7 @@ config.resolve.modules.push(path.resolve(__dirname, "../../node_modules"));
 config.module.rules.push(
     {
         test: /\.(js|jsx)$/,
-        include: /src\/jsMain/,
+        include: /src\/jsMain\/js/,
         use: {
             loader: 'babel-loader',
             options: {
@@ -25,7 +27,7 @@ config.module.rules.push(
     },
     {
         test: /\.(css|sass|scss)$/,
-        include: /src\/jsMain/,
+        include: /src\/jsMain\/js/,
         use: [
             'style-loader',
             {

--- a/webpack.config.d/output.js
+++ b/webpack.config.d/output.js
@@ -55,6 +55,11 @@ if (config.devServer) {
       poll: 1000
     };
 
+    // see https://discuss.kotlinlang.org/t/kotlin-js-react-unstable-building/15582/6
+    config.entry.main = config.entry.main.map(
+      s => s.replace(`/kotlin-out/`, "/"),
+    );
+
     config.optimization = {
         splitChunks: {
             chunks: 'all',


### PR DESCRIPTION
* Reduces `sparklemotion.js` from ~70mb to 6.5mb.
* Prevent some premature/failing hot reloads.
* Fetch all CSS from npm deps.