### PR TITLE
Rework how patches are represented

### DIFF
--- a/src/commonMain/kotlin/baaahs/ShowResources.kt
+++ b/src/commonMain/kotlin/baaahs/ShowResources.kt
@@ -19,7 +19,7 @@ interface ShowResources {
     fun <T : Gadget> createdGadget(id: String, gadget: T)
     fun <T : Gadget> useGadget(id: String): T
 
-    fun openShader(shader: Shader): OpenShader
+    fun openShader(shader: Shader, addToCache: Boolean = false): OpenShader
     fun openDataFeed(id: String, dataSource: DataSource): GlslProgram.DataFeed
     fun useDataFeed(dataSource: DataSource): GlslProgram.DataFeed
     fun openShow(show: Show): OpenShow = OpenShow(show, this)
@@ -46,8 +46,12 @@ abstract class BaseShowResources(
         return dataFeeds[dataSource]!!
     }
 
-    override fun openShader(shader: Shader): OpenShader {
-        return shaders.getOrPut(shader) { glslAnalyzer.asShader(shader) }
+    override fun openShader(shader: Shader, addToCache: Boolean): OpenShader {
+        return if (addToCache) {
+            shaders.getOrPut(shader) { glslAnalyzer.asShader(shader) }
+        } else {
+            shaders[shader] ?: glslAnalyzer.asShader(shader)
+        }
     }
 
     override fun releaseUnused() {

--- a/src/commonMain/kotlin/baaahs/glshaders/ColorShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/ColorShader.kt
@@ -1,16 +1,9 @@
 package baaahs.glshaders
 
+import baaahs.show.ShaderOutPortRef
+
 abstract class ColorShader(glslCode: GlslCode) : OpenShader.Base(glslCode) {
     override val shaderType: OpenShader.Type = OpenShader.Type.Color
-
-    protected fun toInputPort(it: GlslCode.GlslVar): InputPort {
-        return InputPort(
-            it.name, it.dataType, it.name.capitalize(),
-            pluginRef = it.hint?.pluginRef,
-            pluginConfig = it.hint?.config,
-            glslVar = it
-        )
-    }
 }
 
 class ShaderToyColorShader(glslCode: GlslCode) : ColorShader(glslCode) {
@@ -81,8 +74,8 @@ class ShaderToyColorShader(glslCode: GlslCode) : ColorShader(glslCode) {
         explicitUniforms + implicitUniforms + uvCoordPort
     }
 
-    override val outputPorts: List<OutputPort> =
-        listOf(OutputPort("vec4", "<arg0>", "Output Color", ContentType.Color))
+    override val outputPort: OutputPort =
+        OutputPort("vec4", ShaderOutPortRef.ReturnValue, "Output Color", ContentType.Color)
 
     override fun invocationGlsl(namespace: GlslCode.Namespace, portMap: Map<String, String>): String {
         return namespace.qualify(entryPoint.name) +
@@ -118,8 +111,8 @@ class GenericColorShader(glslCode: GlslCode) : ColorShader(glslCode) {
 //    it.type, it.name, title, contentType,
 //    it.hint?.plugin ?: contentType.pluginId, it.hint?.map ?: emptyMap()
 
-    override val outputPorts: List<OutputPort> =
-        listOf(OutputPort("vec4", "gl_FragColor", "Output Color", ContentType.Color))
+    override val outputPort: OutputPort =
+        OutputPort("vec4", "gl_FragColor", "Output Color", ContentType.Color)
 
     override fun invocationGlsl(namespace: GlslCode.Namespace, portMap: Map<String, String>): String {
         return StringBuilder().apply {

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslAnalyzer.kt
@@ -22,7 +22,7 @@ class GlslAnalyzer {
 
         return OpenShader.tryColorShader(glslObj)
             ?: OpenShader.tryUvTranslatorShader(glslObj)
-            ?: throw IllegalArgumentException("huh? unknown sort of shader")
+            ?: throw AnalysisException("Can't determine shader type")
     }
 
     internal fun findStatements(shaderText: String): List<GlslStatement> {

--- a/src/commonMain/kotlin/baaahs/glshaders/OutputPort.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/OutputPort.kt
@@ -1,8 +1,12 @@
 package baaahs.glshaders
 
+import baaahs.show.ShaderOutPortRef
+
 data class OutputPort(
     val dataType: String,
-    val name: String,
+    val id: String,
     val description: String?,
     val contentType: ContentType
-)
+) {
+    fun isReturnValue() = id == ShaderOutPortRef.ReturnValue
+}

--- a/src/commonMain/kotlin/baaahs/glshaders/UvShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/UvShader.kt
@@ -29,8 +29,7 @@ class UvShader(glslCode: GlslCode) : OpenShader.Base(glslCode) {
         }
     }
 
-    override val outputPorts: List<OutputPort>
-            = listOf(OutputPort("vec2", ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinate))
+    override val outputPort: OutputPort = OutputPort("vec2", ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinate)
 
     override fun invocationGlsl(namespace: GlslCode.Namespace, portMap: Map<String, String>): String {
         val buf = StringBuilder()

--- a/src/commonMain/kotlin/baaahs/glsl/errors.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/errors.kt
@@ -5,8 +5,8 @@ abstract class GlslException(message: String) : Exception(message) {
 }
 
 class AnalysisException(
-    message: String, row: Int
-) : GlslException("GLSL analysis error: $message") {
+    message: String, row: Int = -1
+) : GlslException("Shader analysis error: $message") {
     override val errors = listOf(GlslError(message, row))
 }
 

--- a/src/commonMain/kotlin/baaahs/show/PortRef.kt
+++ b/src/commonMain/kotlin/baaahs/show/PortRef.kt
@@ -6,9 +6,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed class PortRef {
-    infix fun linkTo(other: PortRef): Link =
-        Link(this, other)
-
     abstract fun dereference(showEditor: ShowEditor): LinkEditor.Port
 }
 
@@ -19,21 +16,21 @@ data class DataSourceRef(val dataSourceId: String) : PortRef() {
 }
 
 interface ShaderPortRef {
-    val shaderId: String
+    val shaderInstanceId: String
 }
 
 @Serializable @SerialName("shader-in")
-data class ShaderInPortRef(override val shaderId: String, val portId: String) : PortRef(), ShaderPortRef {
+data class ShaderInPortRef(override val shaderInstanceId: String, val portId: String) : PortRef(), ShaderPortRef {
     override fun dereference(showEditor: ShowEditor): LinkEditor.Port =
-        showEditor.shaders.getBang(shaderId, "shader").inputPort(portId)
+        ShaderInPortEditor(showEditor.shaderInstances.getBang(shaderInstanceId, "shader instance"), portId)
 }
 
 @Serializable @SerialName("shader-out")
-data class ShaderOutPortRef(override val shaderId: String, val portId: String) : PortRef(), ShaderPortRef {
+data class ShaderOutPortRef(override val shaderInstanceId: String, val portId: String = ReturnValue) : PortRef(), ShaderPortRef {
     fun isReturnValue() = portId == ReturnValue
 
     override fun dereference(showEditor: ShowEditor): LinkEditor.Port =
-        showEditor.shaders.getBang(shaderId, "shader").outputPort(portId)
+        ShaderOutPortEditor(showEditor.shaderInstances.getBang(shaderInstanceId, "shader instance"), portId)
 
     companion object {
         const val ReturnValue = "_"

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -90,12 +90,13 @@ object SampleData {
             addPatchSet("Blue Aqua Green") {
                 addPatch(blueAquaGreenPatch)
 
-                blueAquaGreenPatch.links.forEach { link ->
-                    val from = link.from
-                    if (from is DataSourceEditor && from.dataSource is CorePlugin.GadgetDataSource<*>) {
-                        addControl("Patches", from.dataSource)
-                    }
-                }
+                // TODO
+//                blueAquaGreenPatch.links.forEach { link ->
+//                    val from = link.from
+//                    if (from is DataSourceEditor && from.dataSource is CorePlugin.GadgetDataSource<*>) {
+//                        addControl("Patches", from.dataSource)
+//                    }
+//                }
             }
         }
 

--- a/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
@@ -1,0 +1,31 @@
+package baaahs.show.live
+
+import baaahs.getBang
+import baaahs.glshaders.OpenShader
+import baaahs.show.DataSourceRef
+import baaahs.show.PortRef
+import baaahs.show.ShaderInstance
+import baaahs.show.ShaderRole
+
+class LiveShaderInstance(
+    val shader: OpenShader,
+    val incomingLinks: Map<String, PortRef>,
+    val role: ShaderRole?
+) {
+    fun findDataSourceRefs(): List<DataSourceRef> {
+        return incomingLinks.values.filterIsInstance<DataSourceRef>()
+    }
+
+    companion object {
+        fun from(
+            shaderInstance: ShaderInstance,
+            openShaders: Map<String, OpenShader>
+        ): LiveShaderInstance {
+            return LiveShaderInstance(
+                openShaders.getBang(shaderInstance.shaderId, "shader"),
+                shaderInstance.incomingLinks,
+                shaderInstance.role
+            )
+        }
+    }
+}

--- a/src/commonMain/kotlin/baaahs/util.kt
+++ b/src/commonMain/kotlin/baaahs/util.kt
@@ -123,3 +123,12 @@ fun String.camelize(): String =
         .map { it.toLowerCase().capitalize() }
         .joinToString("")
         .decapitalize()
+
+
+fun randomId(prefix: String): String {
+    return prefix +
+            "-" +
+            Random.nextInt(0, Int.MAX_VALUE).toString(16) +
+            "-" +
+            Random.nextInt(0, Int.MAX_VALUE).toString(16)
+}

--- a/src/commonMain/kotlin/baaahs/util/UniqueIds.kt
+++ b/src/commonMain/kotlin/baaahs/util/UniqueIds.kt
@@ -1,5 +1,7 @@
 package baaahs.util
 
+import baaahs.unknown
+
 class UniqueIds<T> {
     private val toId = mutableMapOf<T, String>()
     private val byId = mutableMapOf<String, T>()
@@ -7,6 +9,10 @@ class UniqueIds<T> {
     fun all() = byId.toMap()
 
     operator fun get(id: String): T? = byId[id]
+
+    fun getBang(id: String, type: String): T {
+        return byId.get(id) ?: error(unknown(type, id, byId.keys))
+    }
 
     fun idFor(value: T, suggest: () -> String): String {
         return toId.getOrPut(value) {

--- a/src/commonTest/kotlin/baaahs/shows/FakeShowResources.kt
+++ b/src/commonTest/kotlin/baaahs/shows/FakeShowResources.kt
@@ -26,7 +26,7 @@ class FakeShowResources(
 
     override val dataSources: List<DataSource> get() = dataFeeds.keys.toList()
 
-    override fun openShader(shader: Shader): OpenShader =
+    override fun openShader(shader: Shader, addToCache: Boolean): OpenShader =
         shaders.getBang(shader, "shader")
 
     override fun openDataFeed(id: String, dataSource: DataSource): GlslProgram.DataFeed =

--- a/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
@@ -1,7 +1,6 @@
 package baaahs.shows
 
 import baaahs.glshaders.CorePlugin
-import baaahs.glshaders.InputPort
 import baaahs.glshaders.Plugins
 import baaahs.show.*
 import kotlinx.serialization.json.*
@@ -67,6 +66,7 @@ private fun forJson(show: Show): JsonObject {
             }
         }
         "shaders" to show.shaders.jsonMap { jsonFor(it) }
+        "shaderInstances" to show.shaderInstances.jsonMap { jsonFor(it) }
         "dataSources" to show.dataSources.jsonMap { jsonFor(it) }
     }
 }
@@ -144,29 +144,10 @@ fun jsonFor(dataSource: DataSource): JsonElement {
 
 private fun jsonFor(patch: Patch): JsonObject {
     return json {
-        "links" to patch.links.jsonMap { jsonFor(it) }
+        "shaderInstanceIds" to patch.shaderInstanceIds.jsonMap { JsonPrimitive(it) }
         "surfaces" to json {
             "name" to "All Surfaces"
         }
-    }
-}
-
-private fun jsonFor(it: Link): JsonObject {
-    return json {
-        "from" to jsonFor(it.from)
-        "to" to jsonFor(it.to)
-    }
-}
-
-private fun jsonFor(inputPort: InputPort): JsonObject {
-    return json {
-        "id" to inputPort.id
-        "type" to inputPort.dataType
-        "title" to inputPort.title
-        "pluginRef" to inputPort.pluginRef
-        "pluginConfig" to inputPort.pluginConfig?.jsonMap { it }
-        "varName" to inputPort.varName
-        "isImplicit" to inputPort.isImplicit
     }
 }
 
@@ -178,12 +159,12 @@ private fun jsonFor(portRef: PortRef): JsonObject {
         }
         is ShaderInPortRef -> json {
             "type" to "shader-in"
-            "shaderId" to portRef.shaderId
+            "shaderInstanceId" to portRef.shaderInstanceId
             "portId" to portRef.portId
         }
         is ShaderOutPortRef -> json {
             "type" to "shader-out"
-            "shaderId" to portRef.shaderId
+            "shaderInstanceId" to portRef.shaderInstanceId
             "portId" to portRef.portId
         }
         is OutputPortRef -> json {
@@ -195,6 +176,12 @@ private fun jsonFor(portRef: PortRef): JsonObject {
 }
 
 private fun jsonFor(shader: Shader) = json { "src" to shader.src }
+
+private fun jsonFor(shaderInstance: ShaderInstance) = json {
+    "shaderId" to shaderInstance.shaderId
+    "incomingLinks" to shaderInstance.incomingLinks.jsonMap { jsonFor(it) }
+    "role" to shaderInstance.role?.id
+}
 
 fun expectJson(expected: JsonElement, block: () -> JsonElement) {
     val json = Json(JsonConfiguration.Stable.copy(prettyPrint = true))

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -315,20 +315,10 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
                                 shaderEditorWindow {
                                     attrs.onAddToPatch = { shader ->
                                         val newPatch = AutoWirer(props.showResources.plugins).autoWire(shader.src)
-                                        val editor = ShowEditor(show, showState).editScene(showState.selectedScene) {
-                                            editPatchSet(showState.selectedPatchSet) {
-                                                if (this.patchMappings.isEmpty()) {
-                                                    addPatch {
-                                                        links = newPatch.links.toMutableList()
-                                                        surfaces = newPatch.surfaces
-                                                    }
-                                                } else {
-                                                    editPatch(0) {
-                                                        links = newPatch.links.toMutableList()
-                                                        surfaces = newPatch.surfaces
-                                                    }
-                                                }
-                                            }
+                                        val editor = ShowEditor(show, showState)
+                                        showState.findPatchSetEditor(editor)?.apply {
+                                            patchMappings.clear() // TODO not this.
+                                            addPatch(newPatch)
                                         }
                                         handleShowEdit(editor.getShow(), editor.getShowState())
                                     }

--- a/src/jsMain/kotlin/baaahs/app/ui/ControlsPalette.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/ControlsPalette.kt
@@ -22,7 +22,7 @@ import react.dom.div
 import kotlin.random.Random
 
 val ControlsPalette = xComponent<ControlsPaletteProps>("ControlsPalette") { props ->
-    val unplacedControlPaletteDiv = ref<HTMLElement>()
+    val unplacedControlPaletteDiv = ref<HTMLElement?>()
 
     val editModeStyle =
         if (props.editMode) Styles.editModeOn else Styles.editModeOff
@@ -64,6 +64,15 @@ val ControlsPalette = xComponent<ControlsPaletteProps>("ControlsPalette") { prop
                                     this.isDragDisabled = !props.editMode
                                     this.index = index
                                 }) { draggableProvided, snapshot ->
+                                    if (snapshot.isDragging) {
+                                        // Correct for translated parent.
+                                        unplacedControlPaletteDiv.current?.let {
+                                            val draggableStyle = draggableProvided.draggableProps.asDynamic().style
+                                            draggableStyle.left -= it.offsetLeft
+                                            draggableStyle.top -= it.offsetTop
+                                        }
+                                    }
+
                                     control {
                                         attrs.control = unplacedControl
                                         attrs.specialControlProps = props.specialControlProps

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/PatchList.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/PatchList.kt
@@ -69,15 +69,12 @@ val PatchSetList = xComponent<SpecialControlProps>("PatchSetList") { props ->
         }
     }
 
-    val selectedScene = props.showState.selectedScene
-    val patchSets = props.show.scenes[selectedScene].patchSets
+    val currentScene = props.showState.findScene(props.show)
 
     val handleEditButtonClick = useCallback(props.show, props.showState) { event: Event, index: Int ->
         props.show.edit(props.showState) {
-            editScene(selectedScene) {
-                editPatchSet(index) {
-                    patchyEditor = this
-                }
+            props.showState.findSceneEditor(this)?.editPatchSet(index) {
+                patchyEditor = this
             }
             event.preventDefault()
         }
@@ -102,7 +99,7 @@ val PatchSetList = xComponent<SpecialControlProps>("PatchSetList") { props ->
                 attrs["exclusive"] = true
 //            attrs["value"] = props.selected // ... but this is busted.
 //            attrs.onChangeFunction = eventHandler { value: Int -> props.onSelect(value) }
-                patchSets.forEachIndexed { index, patchSet ->
+                currentScene?.patchSets?.forEachIndexed { index, patchSet ->
                     draggable({
                         key = patchSet.id
                         draggableId = patchSet.id
@@ -145,7 +142,7 @@ val PatchSetList = xComponent<SpecialControlProps>("PatchSetList") { props ->
                         +"+"
                         attrs.onClickFunction = { _: Event ->
                             props.show.edit(props.showState) {
-                                editScene(selectedScene) {
+                                props.showState.findSceneEditor(this)?.apply {
                                     addPatchSet("Untitled Patch") {
                                         patchyEditor = this
                                     }

--- a/src/jsMain/kotlin/baaahs/ui/OldPatchEditor.kt
+++ b/src/jsMain/kotlin/baaahs/ui/OldPatchEditor.kt
@@ -33,7 +33,7 @@ import react.dom.b
 import react.dom.code
 import react.dom.h3
 
-val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
+val OldPatchEditor = xComponent<OldPatchEditorProps>("OldPatchEditor") { props ->
     val appContext = useContext(appContext)
     val shader = props.shader
     val openShader = appContext.showResources.openShader(shader)
@@ -60,7 +60,7 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
         if (id.contains(':')) {
             val (shaderId, portId) = id.split(':')
             val otherShader = props.showBuilder.getShaders().getBang(shaderId, "shader")
-            return baaahs.show.ShaderEditor.ShaderOutPortEditor(otherShader, portId)
+            return ShaderEditor.ShaderOutPortEditor(otherShader, portId)
         }
 
         return DataSourceEditor(props.showBuilder.getDataSources().getBang(id, "data source"))
@@ -186,12 +186,12 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
 
 }
 
-external interface ShaderEditorProps : RProps {
+external interface OldPatchEditorProps : RProps {
     var allShaders: Set<Shader>
     var patchEditor: PatchEditor
     var showBuilder: ShowBuilder
     var shader: Shader
 }
 
-fun RBuilder.shaderEditor(handler: RHandler<ShaderEditorProps>): ReactElement =
-    child(ShaderEditor, handler = handler)
+fun RBuilder.oldPatchEditor(handler: RHandler<OldPatchEditorProps>): ReactElement =
+    child(OldPatchEditor, handler = handler)

--- a/src/jsMain/kotlin/baaahs/ui/PatchyEditor.kt
+++ b/src/jsMain/kotlin/baaahs/ui/PatchyEditor.kt
@@ -2,6 +2,7 @@ package baaahs.ui
 
 import baaahs.show.PatchEditor
 import baaahs.show.PatchyEditor
+import baaahs.show.Shader
 import baaahs.show.ShowBuilder
 import kotlinx.css.em
 import kotlinx.css.margin
@@ -9,8 +10,10 @@ import kotlinx.css.padding
 import kotlinx.html.js.onChangeFunction
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.js.onSubmitFunction
+import materialui.AddCircleOutline
 import materialui.components.button.button
 import materialui.components.button.enums.ButtonColor
+import materialui.components.container.container
 import materialui.components.dialogactions.dialogActions
 import materialui.components.dialogcontent.dialogContent
 import materialui.components.dialogtitle.dialogTitle
@@ -19,6 +22,7 @@ import materialui.components.drawer.enums.DrawerAnchor
 import materialui.components.drawer.enums.DrawerStyle
 import materialui.components.drawer.enums.DrawerVariant
 import materialui.components.formcontrol.enums.FormControlVariant
+import materialui.components.iconbutton.iconButton
 import materialui.components.portal.portal
 import materialui.components.table.table
 import materialui.components.tablebody.tableBody
@@ -27,6 +31,7 @@ import materialui.components.tablecell.thCell
 import materialui.components.tablehead.tableHead
 import materialui.components.tablerow.tableRow
 import materialui.components.textfield.textField
+import materialui.icon
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
 import react.*
@@ -99,7 +104,7 @@ val PatchyEditor = xComponent<PatchyEditorProps>("PatchSetEditor") { props ->
                         }
                         tableBody {
                             props.editor.patchMappings.forEachIndexed { index: Int, patchEditor: PatchEditor ->
-                                val allShaders = patchEditor.findShaders()
+                                val allShaderInstances = patchEditor.findShaderInstances()
                                 tableRow {
                                     attrs.key = "$index"
 
@@ -112,13 +117,41 @@ val PatchyEditor = xComponent<PatchyEditorProps>("PatchSetEditor") { props ->
                                         attrs.key = "Patches"
 
                                         +"Shaders:"
-                                        allShaders.forEach { shader ->
+                                        allShaderInstances.forEach { shaderInstance ->
                                             oldPatchEditor {
-                                                attrs.allShaders = allShaders
+                                                attrs.allShaderInstances = allShaderInstances
                                                 attrs.patchEditor = patchEditor
                                                 attrs.showBuilder = showBuilder
-                                                attrs.shader = shader
+                                                attrs.shaderInstance = shaderInstance
                                             }
+                                        }
+
+                                        container {
+                                            iconButton {
+                                                icon(AddCircleOutline)
+
+                                                attrs.onClickFunction = {
+                                                    patchEditor.addShaderInstance(Shader("")) {}
+                                                    this@xComponent.forceRender()
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            tableRow {
+                                attrs.key = "__new__"
+
+                                tdCell {
+                                    attrs.colSpan = "2"
+
+                                    iconButton {
+                                        icon(AddCircleOutline)
+
+                                        attrs.onClickFunction = {
+                                            props.editor.patchMappings.add(PatchEditor())
+                                            this@xComponent.forceRender()
                                         }
                                     }
                                 }

--- a/src/jsMain/kotlin/baaahs/ui/PatchyEditor.kt
+++ b/src/jsMain/kotlin/baaahs/ui/PatchyEditor.kt
@@ -113,7 +113,7 @@ val PatchyEditor = xComponent<PatchyEditorProps>("PatchSetEditor") { props ->
 
                                         +"Shaders:"
                                         allShaders.forEach { shader ->
-                                            shaderEditor {
+                                            oldPatchEditor {
                                                 attrs.allShaders = allShaders
                                                 attrs.patchEditor = patchEditor
                                                 attrs.showBuilder = showBuilder

--- a/src/jsMain/kotlin/external/ReactBeautifulDnd.kt
+++ b/src/jsMain/kotlin/external/ReactBeautifulDnd.kt
@@ -46,7 +46,7 @@ private val Draggable: FunctionalComponent<DraggableProps> = reactBeautifulDndMo
 
 fun RBuilder.draggable(
     attrs: DraggableProps.() -> Unit,
-    children: (provided: DraggableProvided, snapshot: Any) -> ReactElement
+    children: (provided: DraggableProvided, snapshot: DraggableStateSnapshot) -> ReactElement
 ): ReactElement =
     child(
         Draggable,
@@ -54,6 +54,9 @@ fun RBuilder.draggable(
         RBuilder().childList.apply { add(children) }
     )
 
+external interface DraggableStateSnapshot {
+    var isDragging: Boolean
+}
 
 private val jsObj = js("Object")
 fun RDOMBuilder<*>.copyFrom(fromProps: CopyableProps?) {

--- a/src/jsMain/kotlin/materialui/Icons.kt
+++ b/src/jsMain/kotlin/materialui/Icons.kt
@@ -3,6 +3,7 @@
 package materialui
 
 external val Add: Icon
+external val AddCircleOutline: Icon
 external val ChevronLeft: Icon
 external val ChevronRight: Icon
 external val Close: Icon


### PR DESCRIPTION
A patch is composed of _n_ shader instances, which each hold their incoming links.
Shader instances may be assigned to roles. High-level patch wiring will be determined by well-known roles.
Shaders have one and only one output port (which could be a struct).