### PR TITLE
Distortion shaders

### DIFF
--- a/src/commonMain/kotlin/baaahs/Gadget.kt
+++ b/src/commonMain/kotlin/baaahs/Gadget.kt
@@ -59,16 +59,20 @@ open class Gadget {
     }
 
     @JsName("withoutTriggering")
-    fun withoutTriggering(gadgetListener: GadgetListener, fn: () -> Unit) {
-        val listener = listeners.find { it.callback == gadgetListener }
-            ?: throw IllegalStateException("$gadgetListener isn't listening to $this")
-
-        val priorEnabled = listener.enabled
-        listener.enabled = false
-        try {
+    fun withoutTriggering(gadgetListener: GadgetListener?, fn: () -> Unit) {
+        if (gadgetListener == null) {
             fn()
-        } finally {
-            listener.enabled = priorEnabled
+        } else {
+            val listener = listeners.find { it.callback == gadgetListener }
+                ?: throw IllegalStateException("$gadgetListener isn't listening to $this")
+
+            val priorEnabled = listener.enabled
+            listener.enabled = false
+            try {
+                fn()
+            } finally {
+                listener.enabled = priorEnabled
+            }
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/glshaders/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/ContentType.kt
@@ -3,7 +3,13 @@ package baaahs.glshaders
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ContentType(val description: String) {
+data class ContentType(
+    val description: String,
+    private val defaultInitializer: ((GlslType) -> String)? = null
+) {
+    fun initializer(dataType: GlslType): String =
+        defaultInitializer?.invoke(dataType) ?: dataType.defaultInitializer()
+
     companion object {
         val PixelCoordinatesTexture = ContentType("Pixel Coordinates Texture")
         val RasterCoordinate = ContentType("Raster Coordinate")
@@ -14,10 +20,13 @@ data class ContentType(val description: String) {
         val Mouse = ContentType("Mouse")
         val XyzCoordinate = ContentType("X/Y/Z Coordinate")
 
-        val Color = ContentType("Color")
+        val Color = ContentType("Color") { type ->
+            if (type == GlslType.Vec4) "vec4(0., 0., 0., 1.)" else type.defaultInitializer()
+        }
 
         val Time = ContentType("Time")
         val Resolution = ContentType("Resolution")
+        val PreviewResolution = ContentType("Preview Resolution")
         val Float = ContentType("Float")
         val Int = ContentType("Integer")
         val Media = ContentType("Media")

--- a/src/commonMain/kotlin/baaahs/glshaders/DistortionShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/DistortionShader.kt
@@ -5,7 +5,7 @@ import baaahs.show.Shader
 import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
-class FilterShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, glslCode) {
+class DistortionShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, glslCode) {
     companion object {
         val wellKnownInputPorts = listOf(
             InputPort("gl_FragCoord", "vec4", "Coordinates", ContentType.UvCoordinate),
@@ -18,27 +18,27 @@ class FilterShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader,
     }
 
     override val shaderType: ShaderType
-        get() = ShaderType.Filter
+        get() = ShaderType.Distortion
 
-    override val entryPointName: String get() = "mainFilter"
+    override val entryPointName: String get() = "mainDistortion"
 
     override val inputPorts: List<InputPort> by lazy {
-        listOf(InputPort("gl_FragColor", "vec4", "Input Color", ContentType.Color, varName = "<arg0>")) +
+        listOf(InputPort("gl_FragCoord", "vec2", "U/V Coordinatess", ContentType.UvCoordinate)) +
                 glslCode.uniforms.map {
                     wellKnownInputPorts[it.name]?.copy(dataType = it.dataType, glslVar = it)
                         ?: toInputPort(it)
                 }
     }
 
-    override val outputPort: OutputPort
-        get() = OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Output Color", ContentType.Color)
+    override val outputPort: OutputPort =
+        OutputPort(GlslType.Vec2, ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinate)
 
     override fun invocationGlsl(
         namespace: GlslCode.Namespace,
         resultVar: String,
         portMap: Map<String, String>
     ): String {
-        val inVar = portMap["gl_FragColor"] ?: throw LinkException("No input for shader \"$title\"")
-        return resultVar + " = " + namespace.qualify(entryPoint.name) + "($inVar)"
+        val inVar = portMap["gl_FragCoord"] ?: throw LinkException("No input for shader \"$title\"")
+        return resultVar + " = " + namespace.qualify(entryPoint.name) + "($inVar.xy)"
     }
 }

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslAnalyzer.kt
@@ -37,13 +37,7 @@ class GlslAnalyzer {
 
     fun openShader(shader: Shader): OpenShader {
         val glslObj = analyze(shader.src)
-
-        return when (shader.type) {
-            ShaderType.Projection -> OpenShader.tryUvTranslatorShader(shader, glslObj)
-            ShaderType.Distortion -> TODO()
-            ShaderType.Paint -> OpenShader.tryPaintShader(shader, glslObj)
-            ShaderType.Filter -> OpenShader.tryFilterShader(shader, glslObj)
-        } ?: throw AnalysisException("Can't open purported ${shader.type} shader \"${shader.title}\"")
+        return shader.type.open(shader, glslObj)
     }
 
     private class Context {

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslCode.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslCode.kt
@@ -125,6 +125,12 @@ class GlslCode(
 //            if (parts.isNotEmpty() && parts.first().startsWith("@@")) {
 //            } else null
         }
+
+        fun displayName(): String {
+            return Regex("([A-Z](?=[a-z]+)|[A-Z]+(?![a-z]))").replace(name) {
+                " " + it.value
+            }.capitalize()
+        }
     }
 
     class Hint(string: String, lineNumber: Int?) {

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslCode.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslCode.kt
@@ -1,6 +1,8 @@
 package baaahs.glshaders
 
 import baaahs.Logger
+import baaahs.glsl.AnalysisException
+import baaahs.unknown
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.json
 
@@ -26,6 +28,11 @@ class GlslCode(
     val uniforms: Collection<GlslVar> get() = globalVars.filter { it.isUniform }
     val functions: Collection<GlslFunction> get() = statements.filterIsInstance<GlslFunction>()
     val structs: Collection<GlslStruct> get() = statements.filterIsInstance<GlslStruct>()
+
+    fun findFunctionOrNull(name: String) =
+        functions.find { it.name == name}
+    fun findFunction(name: String) =
+        findFunctionOrNull(name) ?: error(unknown("function", name, functions.map { it.name }))
 
     companion object {
         private val logger = Logger("GlslCode")
@@ -110,7 +117,7 @@ class GlslCode(
         val hint: Hint? by lazy {
             val commentString = comments.joinToString(" ") { it.trim() }
             if (commentString.startsWith("@@")) {
-                Hint(commentString.trimStart('@').trim())
+                Hint(commentString.trimStart('@').trim(), lineNumber)
             } else {
                 null
             }
@@ -120,7 +127,7 @@ class GlslCode(
         }
     }
 
-    class Hint(string: String) {
+    class Hint(string: String, lineNumber: Int?) {
         val pluginRef: PluginRef
         val config: JsonObject
 
@@ -132,7 +139,7 @@ class GlslCode(
                 PluginRef(
                     "${pluginPackage.ifEmpty { "baaahs." }}${pluginClass.ifEmpty { "Core" }}",
                     resourceName)
-            } ?: error("don't understand hint: $string")
+            } ?: throw AnalysisException("don't understand hint: $string", lineNumber ?: -1)
 
             config = json {
                 parts.subList(1, parts.size).forEach { s ->

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslProgram.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslProgram.kt
@@ -163,6 +163,7 @@ val dataSourceProviderModule = SerializersModule {
     polymorphic(DataSource::class) {
 //        CorePlugin.NoOp::class with CorePlugin.NoOp.serializer()
         CorePlugin.Resolution::class with CorePlugin.Resolution.serializer()
+        CorePlugin.PreviewResolution::class with CorePlugin.PreviewResolution.serializer()
         CorePlugin.Time::class with CorePlugin.Time.serializer()
         CorePlugin.PixelCoordsTexture::class with CorePlugin.PixelCoordsTexture.serializer()
         CorePlugin.ModelInfoDataSource::class with CorePlugin.ModelInfoDataSource.serializer()

--- a/src/commonMain/kotlin/baaahs/glshaders/GlslType.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/GlslType.kt
@@ -1,0 +1,10 @@
+package baaahs.glshaders
+
+enum class GlslType(val glslLiteral: String) {
+    Float("float"),
+    Vec2("vec2"),
+    Vec3("vec3"),
+    Vec4("vec4");
+
+    open fun defaultInitializer(): String = "$glslLiteral(0.)"
+}

--- a/src/commonMain/kotlin/baaahs/glshaders/LinkedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/LinkedPatch.kt
@@ -156,7 +156,9 @@ class LinkedPatch(
 
             if (!resultRedirected) {
                 buf.append("\n")
-                buf.append("${openShader.outputPort.dataType} $resultVar;\n")
+                with (openShader.outputPort) {
+                    buf.append("${dataType.glslLiteral} $resultVar = ${contentType.initializer(dataType)};\n")
+                }
             }
 
             buf.append(openShader.toGlsl(namespace, resolvedPortMap), "\n")
@@ -175,7 +177,9 @@ class LinkedPatch(
         buf.append("\n")
         buf.append("// SparkleMotion-generated GLSL\n")
         buf.append("\n")
-        buf.append("layout(location = 0) out ${shaderInstance.shader.outputPort.dataType} sm_result;\n")
+        with (shaderInstance.shader.outputPort) {
+            buf.append("layout(location = 0) out ${dataType.glslLiteral} sm_result;\n")
+        }
         buf.append("\n")
 
         components.forEach { component ->

--- a/src/commonMain/kotlin/baaahs/glshaders/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/OpenShader.kt
@@ -39,7 +39,7 @@ interface OpenShader : RefCounted {
 
         protected fun toInputPort(it: GlslCode.GlslVar): InputPort {
             return InputPort(
-                it.name, it.dataType, it.name.capitalize(),
+                it.name, it.dataType, it.displayName(),
                 pluginRef = it.hint?.pluginRef,
                 pluginConfig = it.hint?.config,
                 glslVar = it

--- a/src/commonMain/kotlin/baaahs/glshaders/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/OpenShader.kt
@@ -15,7 +15,10 @@ interface OpenShader : RefCounted {
     val glslCode: GlslCode
     val title: String
     val shaderType: ShaderType
+    val entryPointName: String
     val entryPoint: GlslFunction
+        get() = glslCode.findFunction(entryPointName)
+
     val inputPorts: List<InputPort>
     val outputPort: OutputPort
 //    TODO val inputDefaults: Map<String, InputDefault>
@@ -78,37 +81,5 @@ interface OpenShader : RefCounted {
 
         override fun hashCode(): Int =
             src.hashCode()
-    }
-
-    companion object {
-        fun tryPaintShader(shader: Shader, glslCode: GlslCode): PaintShader? {
-            return when {
-                glslCode.functionNames.contains("main") ->
-                    GenericPaintShader(shader, glslCode)
-
-                glslCode.functionNames.contains("mainImage") ->
-                    ShaderToyPaintShader(shader, glslCode)
-
-                else -> null
-            }
-        }
-
-        fun tryFilterShader(shader: Shader, glslCode: GlslCode): FilterShader? {
-            return when {
-                glslCode.functionNames.contains("filterImage") ->
-                    FilterShader(shader, glslCode)
-
-                else -> null
-            }
-        }
-
-        fun tryUvTranslatorShader(shader: Shader, glslCode: GlslCode): UvShader? {
-            return when {
-                glslCode.functionNames.contains("mainUvFromRaster") ->
-                    UvShader(shader, glslCode)
-
-                else -> null
-            }
-        }
     }
 }

--- a/src/commonMain/kotlin/baaahs/glshaders/OutputPort.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/OutputPort.kt
@@ -3,7 +3,7 @@ package baaahs.glshaders
 import baaahs.show.ShaderOutPortRef
 
 data class OutputPort(
-    val dataType: String,
+    val dataType: GlslType,
     val id: String,
     val description: String?,
     val contentType: ContentType

--- a/src/commonMain/kotlin/baaahs/glshaders/PaintShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/PaintShader.kt
@@ -55,8 +55,7 @@ class ShaderToyPaintShader(shader: Shader, glslCode: GlslCode) : PaintShader(sha
         val uvCoordPort = InputPort("sm_FragCoord", "vec2", "Coordinates", ContentType.UvCoordinate)
     }
 
-    override val entryPoint: GlslCode.GlslFunction =
-        glslCode.functions.find { it.name == "mainImage" }!!
+    override val entryPointName: String get() = "mainImage"
 
     override val inputPorts: List<InputPort> by lazy {
         // ShaderToy shaders have a set of uniforms that are automatically declared;
@@ -77,7 +76,7 @@ class ShaderToyPaintShader(shader: Shader, glslCode: GlslCode) : PaintShader(sha
     }
 
     override val outputPort: OutputPort =
-        OutputPort("vec4", ShaderOutPortRef.ReturnValue, "Output Color", ContentType.Color)
+        OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Output Color", ContentType.Color)
 
     override fun invocationGlsl(
         namespace: GlslCode.Namespace,
@@ -102,8 +101,7 @@ class GenericPaintShader(shader: Shader, glslCode: GlslCode) : PaintShader(shade
         val uvCoordPort = InputPort("gl_FragCoord", "vec4", "Coordinates", ContentType.UvCoordinate)
     }
 
-    override val entryPoint: GlslCode.GlslFunction =
-        glslCode.functions.find { it.name == "main" }!!
+    override val entryPointName: String get() = "main"
 
     override val inputPorts: List<InputPort> by lazy {
         glslCode.uniforms.map {
@@ -115,7 +113,7 @@ class GenericPaintShader(shader: Shader, glslCode: GlslCode) : PaintShader(shade
 //    it.hint?.plugin ?: contentType.pluginId, it.hint?.map ?: emptyMap()
 
     override val outputPort: OutputPort =
-        OutputPort("vec4", "gl_FragColor", "Output Color", ContentType.Color)
+        OutputPort(GlslType.Vec4, "gl_FragColor", "Output Color", ContentType.Color)
 
     override fun invocationGlsl(
         namespace: GlslCode.Namespace,

--- a/src/commonMain/kotlin/baaahs/glshaders/ProjectionShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/ProjectionShader.kt
@@ -4,7 +4,7 @@ import baaahs.show.Shader
 import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
-class UvShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, glslCode) {
+class ProjectionShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, glslCode) {
     companion object {
         val pixelCoordsTextureInputPort = InputPort(
             "pixelCoordsTexture",
@@ -12,13 +12,16 @@ class UvShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, gls
             "U/V Coordinates Texture",
             ContentType.PixelCoordinatesTexture
         )
-        val magicUniforms = listOf(pixelCoordsTextureInputPort).associateBy { it.id }
+        val magicUniforms = listOf(
+            pixelCoordsTextureInputPort,
+            InputPort("resolution", "vec2", "Resolution", ContentType.Resolution),
+            InputPort("previewResolution", "vec2", "Preview Resolution", ContentType.PreviewResolution)
+        ).associateBy { it.id }
     }
 
     override val shaderType: ShaderType = ShaderType.Projection
 
-    override val entryPoint: GlslCode.GlslFunction
-            = glslCode.functions.find { it.name == "mainUvFromRaster" }!!
+    override val entryPointName: String get() = "mainProjection"
 
     override val inputPorts: List<InputPort> by lazy {
         glslCode.uniforms.map {
@@ -31,7 +34,8 @@ class UvShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(shader, gls
         }
     }
 
-    override val outputPort: OutputPort = OutputPort("vec2", ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinate)
+    override val outputPort: OutputPort =
+        OutputPort(GlslType.Vec2, ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinate)
 
     override fun invocationGlsl(
         namespace: GlslCode.Namespace,

--- a/src/commonMain/kotlin/baaahs/glshaders/ProjectionShader.kt
+++ b/src/commonMain/kotlin/baaahs/glshaders/ProjectionShader.kt
@@ -26,11 +26,7 @@ class ProjectionShader(shader: Shader, glslCode: GlslCode) : OpenShader.Base(sha
     override val inputPorts: List<InputPort> by lazy {
         glslCode.uniforms.map {
             magicUniforms[it.name]?.copy(dataType = it.dataType, glslVar = it)
-                ?: InputPort(
-                    it.name, it.dataType, it.name.capitalize(),
-                    pluginRef = it.hint?.pluginRef,
-                    pluginConfig = it.hint?.config
-                )
+                ?: toInputPort(it)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/glsl/Shaders.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/Shaders.kt
@@ -1,6 +1,5 @@
 package baaahs.glsl
 
-import baaahs.glshaders.GlslAnalyzer
 import baaahs.show.Shader
 import baaahs.show.ShaderType
 
@@ -67,7 +66,33 @@ object Shaders {
         }
     """.trimIndent())
 
-    val cylindricalUvMapper = GlslAnalyzer().openShader(
+    val checkerboard = Shader("Checkerboard", ShaderType.Paint, """
+        uniform float checkerboardSize = 10.0; // @@Slider min=.001 max=1 default=.1
+
+        void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+            vec2 pos = floor(fragCoord / checkerboardSize);
+            vec3 patternMask = vec3(mod(pos.x + mod(pos.y, 2.0), 2.0));
+            fragColor = vec4(patternMask.xyz, 1.);
+        }
+    """.trimIndent())
+
+    val ripple = Shader("Ripple", ShaderType.Distortion, """
+        uniform float time;
+
+        vec2 mainDistortion(vec2 uvIn) {
+          vec2 p = -1.0 + 2.0 * uvIn;
+          float len = length(p);
+          return uvIn + (p/len)*cos(len*12.0-time*4.0)*0.03;
+        }
+    """.trimIndent())
+
+    val flipY = Shader("Flip Y", ShaderType.Distortion, """
+        vec2 mainDistortion(vec2 uvIn) {
+          return vec2(uvIn.x, 1. - uvIn.y);
+        }
+    """.trimIndent())
+
+    val cylindricalProjection = Shader("Cylindrical Projection", ShaderType.Projection,
         /**language=glsl*/
         """
                 // Cylindrical Projection
@@ -93,7 +118,7 @@ object Shaders {
                     return vec2(u, v);
                 }
                 
-                vec2 mainUvFromRaster(vec2 rasterCoord) {
+                vec2 mainProjection(vec2 rasterCoord) {
                     int rasterX = int(rasterCoord.x);
                     int rasterY = int(rasterCoord.y);
                     

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -40,8 +40,7 @@ object SampleData {
     private val plugins = Plugins.findAll()
     private val autoWirer = AutoWirer(plugins)
 
-    private val uvShader = autoWirer.autoWire(Shaders.cylindricalUvMapper)
-        .acceptSymbolicChannelLinks().resolve()
+    private val uvShader = wireUp(Shaders.cylindricalProjection)
 
     private val showDefaultPaint = autoWirer.autoWire(Shader(
         "Darkness",
@@ -62,7 +61,7 @@ object SampleData {
         """
             uniform float brightness; // @@Slider min=0 max=1.25 default=1
 
-            vec4 filterImage(vec4 inColor) {
+            vec4 mainFilter(vec4 inColor) {
                 vec4 clampedColor = clamp(inColor, 0., 1.);
                 return vec4(clampedColor.rgb * brightness, clampedColor.a);
             }
@@ -98,7 +97,7 @@ object SampleData {
                 return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
             }
             
-            vec4 filterImage(vec4 inColor) {
+            vec4 mainFilter(vec4 inColor) {
                 if (saturation == 1.) return inColor;
 
                 vec4 clampedColor = clamp(inColor, 0., 1.);
@@ -191,4 +190,7 @@ object SampleData {
         addControl("More Controls", brightnessControl)
         addControl("More Controls", saturationControl)
     }.getShow()
+
+    private fun wireUp(shader: Shader) =
+        autoWirer.autoWire(shader).acceptSymbolicChannelLinks().resolve()
 }

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -1,10 +1,14 @@
 package baaahs.show
 
 import baaahs.Color
+import baaahs.getBang
 import baaahs.glshaders.AutoWirer
 import baaahs.glshaders.CorePlugin
 import baaahs.glshaders.Plugins
 import baaahs.glsl.Shaders
+import baaahs.show.mutable.MutableDataSource
+import baaahs.show.mutable.MutableLink
+import baaahs.show.mutable.MutablePatch
 import baaahs.show.mutable.MutableShow
 import kotlinx.serialization.json.json
 
@@ -42,97 +46,107 @@ object SampleData {
 
     private val uvShader = wireUp(Shaders.cylindricalProjection)
 
-    private val showDefaultPaint = autoWirer.autoWire(Shader(
-        "Darkness",
-        ShaderType.Paint,
-        /**language=glsl*/
-        """
-            void main(void) {
-                gl_FragColor = vec4(0., 0., 0., 1.);
-            }
-        """.trimIndent()
-    ))
+    private val showDefaultPaint = autoWirer.autoWire(
+        Shader(
+            "Darkness",
+            ShaderType.Paint,
+            /**language=glsl*/
+            """
+                void main(void) {
+                    gl_FragColor = vec4(0., 0., 0., 1.);
+                }
+            """.trimIndent()
+        )
+    )
         .acceptSymbolicChannelLinks().resolve()
 
-    private val brightnessFilter = autoWirer.autoWire(Shader(
-        "Brightness",
-        ShaderType.Filter,
-        /**language=glsl*/
-        """
-            uniform float brightness; // @@Slider min=0 max=1.25 default=1
-
-            vec4 mainFilter(vec4 inColor) {
-                vec4 clampedColor = clamp(inColor, 0., 1.);
-                return vec4(clampedColor.rgb * brightness, clampedColor.a);
-            }
-        """.trimIndent()
-    ))
+    private val brightnessFilter = autoWirer.autoWire(
+        Shader(
+            "Brightness",
+            ShaderType.Filter,
+            /**language=glsl*/
+            """
+                uniform float brightness; // @@Slider min=0 max=1.25 default=1
+    
+                vec4 mainFilter(vec4 inColor) {
+                    vec4 clampedColor = clamp(inColor, 0., 1.);
+                    return vec4(clampedColor.rgb * brightness, clampedColor.a);
+                }
+            """.trimIndent()
+        )
+    )
         .acceptSymbolicChannelLinks().resolve()
 
-    private val saturationFilter = autoWirer.autoWire(Shader(
-        "Saturation",
-        ShaderType.Filter,
-        /**language=glsl*/
-        """
-            uniform float saturation; // @@Slider min=0 max=1.25 default=1
-
-            // All components are in the range [0…1], including hue.
-            vec3 rgb2hsv(vec3 c)
-            {
-                vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-                vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
-                vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
-
-                float d = q.x - min(q.w, q.y);
-                float e = 1.0e-10;
-                return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-            }
-             
-
-            // All components are in the range [0…1], including hue.
-            vec3 hsv2rgb(vec3 c)
-            {
-                vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-                vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-                return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-            }
-            
-            vec4 mainFilter(vec4 inColor) {
-                if (saturation == 1.) return inColor;
-
-                vec4 clampedColor = clamp(inColor, 0., 1.);
-                vec3 hsv = rgb2hsv(clampedColor.rgb);
-                hsv.y *= saturation;
-                return vec4(hsv2rgb(hsv), clampedColor.a);
-            }
-        """.trimIndent()
-    ))
+    private val saturationFilter = autoWirer.autoWire(
+        Shader(
+            "Saturation",
+            ShaderType.Filter,
+            /**language=glsl*/
+            """
+                uniform float saturation; // @@Slider min=0 max=1.25 default=1
+    
+                // All components are in the range [0…1], including hue.
+                vec3 rgb2hsv(vec3 c)
+                {
+                    vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+                    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+    
+                    float d = q.x - min(q.w, q.y);
+                    float e = 1.0e-10;
+                    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+                }
+                 
+    
+                // All components are in the range [0…1], including hue.
+                vec3 hsv2rgb(vec3 c)
+                {
+                    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+                    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+                }
+                
+                vec4 mainFilter(vec4 inColor) {
+                    if (saturation == 1.) return inColor;
+    
+                    vec4 clampedColor = clamp(inColor, 0., 1.);
+                    vec3 hsv = rgb2hsv(clampedColor.rgb);
+                    hsv.y *= saturation;
+                    return vec4(hsv2rgb(hsv), clampedColor.a);
+                }
+            """.trimIndent()
+        )
+    )
         .acceptSymbolicChannelLinks().resolve()
 
-    private val redYellowGreenPatch = autoWirer.autoWire(Shader(
-        "GLSL Hue Test Pattern",
-        ShaderType.Paint,
-        /**language=glsl*/
-        """
-            uniform vec2 resolution;
-            void main(void) {
-                gl_FragColor = vec4(gl_FragCoord.xy / resolution, 0.0, 1.0);
-            }
-        """.trimIndent()
-    )).acceptSymbolicChannelLinks().resolve()
+    private val redYellowGreenPatch = autoWirer.autoWire(
+        Shader(
+            "GLSL Hue Test Pattern",
+            ShaderType.Paint,
+            /**language=glsl*/
+            """
+                uniform vec2 resolution;
+                void main(void) {
+                    gl_FragColor = vec4(gl_FragCoord.xy / resolution, 0.0, 1.0);
+                }
+            """.trimIndent()
+        )
+    ).acceptSymbolicChannelLinks().resolve()
 
-    private val blueAquaGreenPatch = autoWirer.autoWire(Shader(
-        "Another GLSL Hue Test Pattern",
-        ShaderType.Paint,
-        /**language=glsl*/
-        """
-            uniform vec2 resolution;
-            uniform float redness;
-            void main(void) {
-                gl_FragColor = vec4(redness, gl_FragCoord.xy / resolution, 1.0);
-            }
-        """.trimIndent()
-    )).acceptSymbolicChannelLinks().resolve()
+    private val blueAquaGreenPatch = autoWirer.autoWire(
+        Shader(
+            "Another GLSL Hue Test Pattern",
+            ShaderType.Paint,
+            /**language=glsl*/
+            """
+                uniform vec2 resolution;
+                uniform float redness;
+                void main(void) {
+                    gl_FragColor = vec4(redness, gl_FragCoord.xy / resolution, 1.0);
+                }
+            """.trimIndent()
+        )
+    ).acceptSymbolicChannelLinks().resolve()
 
     private val fireBallPatch = autoWirer.autoWire(FixtureShaders.fireBallGlsl)
         .acceptSymbolicChannelLinks().resolve()
@@ -150,6 +164,8 @@ object SampleData {
         "Saturation", 1f, 0f, 1.25f, null)
     val intensityControl = CorePlugin.SliderDataSource(
         "Intensity", 1f, 0f, 1f, null)
+    val checkerboardSizeControl = CorePlugin.SliderDataSource(
+        "Checkerboard Size", .1f, .001f, 1f, null)
 
     val sampleShow = MutableShow("Sample Show").apply {
         editLayouts {
@@ -160,6 +176,7 @@ object SampleData {
         addPatch(showDefaultPaint)
         addPatch(brightnessFilter)
         addPatch(saturationFilter)
+        addPatch(wireUp(Shaders.flipY))
 
         addScene("Pleistocene") {
             addPatchSet("Red Yellow Green") {
@@ -168,6 +185,19 @@ object SampleData {
             addPatchSet("Fire") {
                 addPatch(fireBallPatch)
                 addControl("Patches", intensityControl)
+            }
+            addPatchSet("Checkerboard") {
+                addPatch(wireUp(Shaders.checkerboard, mapOf(
+                    "checkerboardSize" to MutableDataSource(checkerboardSizeControl)
+                )))
+                addControl("Patches", checkerboardSizeControl)
+            }
+            addPatchSet("Wobbly Checkerboard") {
+                addPatch(wireUp(Shaders.checkerboard, mapOf(
+                    "checkerboardSize" to MutableDataSource(checkerboardSizeControl)
+                )))
+                addPatch(wireUp(Shaders.ripple))
+                addControl("Patches", checkerboardSizeControl)
             }
         }
         addScene("Holocene") {
@@ -191,6 +221,16 @@ object SampleData {
         addControl("More Controls", saturationControl)
     }.getShow()
 
-    private fun wireUp(shader: Shader) =
-        autoWirer.autoWire(shader).acceptSymbolicChannelLinks().resolve()
+    private fun wireUp(shader: Shader, ports: Map<String, MutableLink.Port> = emptyMap()): MutablePatch {
+        val unresolvedPatch = autoWirer.autoWire(shader)
+        unresolvedPatch.editShader(shader).apply {
+            ports.forEach { (portId, port) ->
+                incomingLinksOptions.getBang(portId, "port").apply {
+                    clear()
+                    add(port)
+                }
+            }
+        }
+        return unresolvedPatch.acceptSymbolicChannelLinks().resolve()
+    }
 }

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
@@ -3,6 +3,7 @@ package baaahs.show.mutable
 import baaahs.ShowState
 import baaahs.getBang
 import baaahs.glshaders.AutoWirer
+import baaahs.glshaders.ContentType
 import baaahs.glshaders.LinkedPatch
 import baaahs.randomId
 import baaahs.show.*
@@ -367,7 +368,7 @@ class MutablePatch {
         Patch.from(this, showBuilder)
 
     /** Build a [LinkedPatch] independent of an [baaahs.show.live.OpenShow]. */
-    fun openForPreview(autoWirer: AutoWirer, shaderType: ShaderType): LinkedPatch? {
+    fun openForPreview(autoWirer: AutoWirer): LinkedPatch? {
         val showBuilder = ShowBuilder()
         build(showBuilder)
 
@@ -380,7 +381,7 @@ class MutablePatch {
         val openPatch = OpenPatch(resolvedShaderInstances.values.toList(), surfaces)
 
         val portDiagram = autoWirer.buildPortDiagram(openPatch)
-        return portDiagram.resolvePatch(ShaderChannel.Main, shaderType.resultContentType)
+        return portDiagram.resolvePatch(ShaderChannel.Main, ContentType.Color)
     }
 
     fun addShaderInstance(mutableShaderInstance: MutableShaderInstance): MutablePatch {

--- a/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
@@ -314,7 +314,7 @@ object GlslAnalyzerSpec : Spek({
                         expect(
                             listOf(
                                 InputPort("pixelCoordsTexture", "sampler2D", "U/V Coordinates Texture", ContentType.PixelCoordinatesTexture),
-                                InputPort("modelInfo", "ModelInfo", "ModelInfo", null)
+                                InputPort("modelInfo", "ModelInfo", "Model Info", null)
                             )
                         ) { shader.inputPorts.map { it.copy(glslVar = null) } }
                     }

--- a/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
@@ -304,10 +304,10 @@ object GlslAnalyzerSpec : Spek({
                 }
 
                 context("with U/V translation shader") {
-                    override(shaderText) { Shaders.cylindricalUvMapper.src }
+                    override(shaderText) { Shaders.cylindricalProjection.src }
 
                     it("identifies mainImage() as the entry point") {
-                        expect("mainUvFromRaster") { shader.entryPoint.name }
+                        expect("mainProjection") { shader.entryPoint.name }
                     }
 
                     it("creates inputs for implicit uniforms") {

--- a/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/GlslAnalyzerSpec.kt
@@ -369,5 +369,11 @@ object GlslAnalyzerSpec : Spek({
                 }
             }
         }
+
+        it("englishizes camel case names") {
+            expect("A Man A Plan AAARGH Panama I Say") {
+                GlslStatement("vec3 aManAPlanAAARGHPanamaISay;\n").asVarOrNull()!!.displayName()
+            }
+        }
     }
 })

--- a/src/commonTest/kotlin/baaahs/glshaders/OpenPatchSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/OpenPatchSpec.kt
@@ -1,6 +1,6 @@
 package baaahs.glshaders
 
-import baaahs.glsl.Shaders.cylindricalUvMapper
+import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.show.ShaderChannel
 import baaahs.show.mutable.MutablePatch
 import baaahs.show.mutable.MutableShaderOutPort
@@ -50,7 +50,7 @@ object OpenPatchSpec : Spek({
                             link("blueness", CorePlugin.SliderDataSource("Blueness", 0f, 0f, 1f, null))
                             shaderChannel = ShaderChannel.Main
                         }
-                    }.openForPreview(autoWirer, shader.type)!!
+                    }.openForPreview(autoWirer)!!
                 }
                 val glsl by value {
                     linkedPatch.toGlsl().trim()
@@ -74,7 +74,7 @@ object OpenPatchSpec : Spek({
                         // Shader: This Shader's Name; namespace: p0
                         // This Shader's Name
 
-                        vec4 p0_gl_FragColor;
+                        vec4 p0_gl_FragColor = vec4(0., 0., 0., 1.);
 
                         #line 7
                         int p0_someGlobalVar;
@@ -105,7 +105,7 @@ object OpenPatchSpec : Spek({
                 context("with UV translation shader") {
                     override(linkedPatch) {
                         MutablePatch {
-                            addShaderInstance(cylindricalUvMapper.shader) {
+                            addShaderInstance(cylindricalProjection) {
                                 link("pixelCoordsTexture", CorePlugin.PixelCoordsTexture())
                                 link("modelInfo", CorePlugin.ModelInfoDataSource("ModelInfo"))
                                 shaderChannel = ShaderChannel.Main
@@ -115,7 +115,7 @@ object OpenPatchSpec : Spek({
                                 link(
                                     "gl_FragCoord",
                                     MutableShaderOutPort(
-                                        findShaderInstanceFor(cylindricalUvMapper.shader)
+                                        findShaderInstanceFor(cylindricalProjection)
                                     )
                                 )
                                 link("resolution", CorePlugin.Resolution())
@@ -123,7 +123,7 @@ object OpenPatchSpec : Spek({
                                 link("blueness", CorePlugin.SliderDataSource("Blueness", 0f, 0f, 1f, null))
                                 shaderChannel = ShaderChannel.Main
                             }
-                        }.openForPreview(autoWirer, shader.type)!!
+                        }.openForPreview(autoWirer)!!
                     }
 
                     it("generates GLSL") {
@@ -151,7 +151,7 @@ object OpenPatchSpec : Spek({
                                 // Shader: Cylindrical Projection; namespace: p0
                                 // Cylindrical Projection
 
-                                vec2 p0i_result;
+                                vec2 p0i_result = vec2(0.);
 
                                 #line 12
                                 const float p0_PI = 3.141592654;
@@ -168,7 +168,7 @@ object OpenPatchSpec : Spek({
                                 }
 
                                 #line 24
-                                vec2 p0_mainUvFromRaster(vec2 rasterCoord) {
+                                vec2 p0_mainProjection(vec2 rasterCoord) {
                                     int rasterX = int(rasterCoord.x);
                                     int rasterY = int(rasterCoord.y);
                                     
@@ -179,7 +179,7 @@ object OpenPatchSpec : Spek({
                                 // Shader: This Shader's Name; namespace: p1
                                 // This Shader's Name
                                 
-                                vec4 p1_gl_FragColor;
+                                vec4 p1_gl_FragColor = vec4(0., 0., 0., 1.);
 
                                 #line 7
                                 int p1_someGlobalVar;
@@ -200,7 +200,7 @@ object OpenPatchSpec : Spek({
 
                                 #line -1
                                 void main() {
-                                  p0i_result = p0_mainUvFromRaster(gl_FragCoord.xy); // Cylindrical Projection
+                                  p0i_result = p0_mainProjection(gl_FragCoord.xy); // Cylindrical Projection
                                   p1_main(); // This Shader's Name
                                   sm_result = p1_gl_FragColor;
                                 }

--- a/src/commonTest/kotlin/baaahs/glshaders/PatchLayeringSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/PatchLayeringSpec.kt
@@ -23,7 +23,7 @@ object PatchLayeringSpec : Spek({
             return autoWirer.autoWire(*shaders).acceptSymbolicChannelLinks().resolve()
         }
 
-        val uvShader = Shaders.cylindricalUvMapper.shader
+        val uvShader = Shaders.cylindricalProjection
         val blackShader by value {
             Shader("Black Shader", ShaderType.Paint,
                 "void main() {\n  gl_FragColor = vec4(0.);\n}")
@@ -34,11 +34,11 @@ object PatchLayeringSpec : Spek({
         }
         val brightnessFilter by value {
             Shader("Brightness Filter", ShaderType.Filter,
-                "uniform float brightness; // @@Slider min=0 max=1 default=1\nvec4 filterImage(vec4 colorIn) {\n  return colorIn * brightness;\n}")
+                "uniform float brightness; // @@Slider min=0 max=1 default=1\nvec4 mainFilter(vec4 colorIn) {\n  return colorIn * brightness;\n}")
         }
         val saturationFilter by value {
             Shader("Saturation Filter", ShaderType.Filter,
-                "vec4 filterImage(vec4 colorIn) { return colorIn; }")
+                "vec4 mainFilter(vec4 colorIn) { return colorIn; }")
         }
         val mutableShow by value { MutableShow("test show") }
         val show by value {
@@ -88,7 +88,7 @@ object PatchLayeringSpec : Spek({
                         // Shader: Cylindrical Projection; namespace: p0
                         // Cylindrical Projection
 
-                        vec2 p0i_result;
+                        vec2 p0i_result = vec2(0.);
 
                         #line 12
                         const float p0_PI = 3.141592654;
@@ -105,7 +105,7 @@ object PatchLayeringSpec : Spek({
                         }
 
                         #line 24
-                        vec2 p0_mainUvFromRaster(vec2 rasterCoord) {
+                        vec2 p0_mainProjection(vec2 rasterCoord) {
                             int rasterX = int(rasterCoord.x);
                             int rasterY = int(rasterCoord.y);
                             
@@ -116,7 +116,7 @@ object PatchLayeringSpec : Spek({
                         // Shader: Orange Shader; namespace: p1
                         // Orange Shader
 
-                        vec4 p1_gl_FragColor;
+                        vec4 p1_gl_FragColor = vec4(0., 0., 0., 1.);
 
                         #line 1
                         void p1_main() {
@@ -126,19 +126,19 @@ object PatchLayeringSpec : Spek({
                         // Shader: Brightness Filter; namespace: p2
                         // Brightness Filter
 
-                        vec4 p2i_result;
+                        vec4 p2i_result = vec4(0., 0., 0., 1.);
                         
                         #line 1
-                         vec4 p2_filterImage(vec4 colorIn) {
+                         vec4 p2_mainFilter(vec4 colorIn) {
                           return colorIn * in_brightnessSlider;
                         }
                         
                         
                         #line -1
                         void main() {
-                          p0i_result = p0_mainUvFromRaster(gl_FragCoord.xy); // Cylindrical Projection
+                          p0i_result = p0_mainProjection(gl_FragCoord.xy); // Cylindrical Projection
                           p1_main(); // Orange Shader
-                          p2i_result = p2_filterImage(p1_gl_FragColor); // Brightness Filter
+                          p2i_result = p2_mainFilter(p1_gl_FragColor); // Brightness Filter
                           sm_result = p2i_result;
                         }
                         

--- a/src/commonTest/kotlin/baaahs/glshaders/ShaderFactory.kt
+++ b/src/commonTest/kotlin/baaahs/glshaders/ShaderFactory.kt
@@ -1,8 +1,12 @@
 package baaahs.glshaders
 
+import baaahs.show.Shader
+import baaahs.show.ShaderType
+
 object ShaderFactory {
-    fun paintShader(title: String): PaintShader {
-        return GlslAnalyzer().openShader("""
+    fun paintShader(title: String): Shader {
+        return Shader(
+            title, ShaderType.Paint, """
             // $title
             uniform float time;
             uniform vec2  resolution;
@@ -17,6 +21,7 @@ object ShaderFactory {
                 someGlobalVar = anotherFunc(someConstVar);
                 gl_FragColor = vec4(uv.xy, blueness, 1.);
             }
-        """.trimIndent()) as PaintShader
+        """.trimIndent()
+        )
     }
 }

--- a/src/commonTest/kotlin/baaahs/glsl/GlslRendererTest.kt
+++ b/src/commonTest/kotlin/baaahs/glsl/GlslRendererTest.kt
@@ -7,7 +7,7 @@ import baaahs.glshaders.AutoWirer
 import baaahs.glshaders.GlslAnalyzer
 import baaahs.glshaders.GlslProgram
 import baaahs.glshaders.Plugins
-import baaahs.glsl.Shaders.cylindricalUvMapper
+import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.io.ByteArrayWriter
 import baaahs.model.ModelInfo
 import baaahs.shows.FakeShowPlayer
@@ -252,9 +252,9 @@ class GlslRendererTest {
         val autoWirer = AutoWirer(Plugins.safe())
         val shader = GlslAnalyzer().import(program)
         return autoWirer
-            .autoWire(cylindricalUvMapper.shader, shader)
+            .autoWire(cylindricalProjection, shader)
             .resolve()
-            .openForPreview(autoWirer, shader.type)!!
+            .openForPreview(autoWirer)!!
             .compile(glslContext) { id, dataSource ->
             dataSource.createFeed(fakeShowPlayer, id)
         }

--- a/src/commonTest/kotlin/baaahs/show/MutableShowSpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/MutableShowSpec.kt
@@ -5,7 +5,7 @@ import baaahs.glshaders.AutoWirer
 import baaahs.glshaders.Plugins
 import baaahs.glshaders.ShaderFactory
 import baaahs.glshaders.override
-import baaahs.glsl.Shaders.cylindricalUvMapper
+import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.show.mutable.MutableShow
 import baaahs.show.mutable.ShowBuilder
 import org.spekframework.spek2.Spek
@@ -215,7 +215,7 @@ object MutableShowSpec : Spek({
 })
 
 private fun AutoWirer.testPatch(title: String) =
-    autoWire(cylindricalUvMapper, ShaderFactory.paintShader(title))
+    autoWire(cylindricalProjection, ShaderFactory.paintShader(title))
         .acceptSymbolicChannelLinks()
         .resolve()
 

--- a/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
@@ -43,7 +43,7 @@ object ShowRunnerSpec : Spek({
         val model by value { TestModel() }
         val patch by value {
             AutoWirer(Plugins.safe()).autoWire(
-                Shaders.cylindricalUvMapper.shader, Shader("Untitled", ShaderType.Paint, shaderSrc)
+                Shaders.cylindricalProjection, Shader("Untitled", ShaderType.Paint, shaderSrc)
             ).acceptSymbolicChannelLinks().resolve()
         }
         val surfaces by value { listOf(FakeSurface(100)) }

--- a/src/jsMain/js/app/components/gadgets/Slider/index.jsx
+++ b/src/jsMain/js/app/components/gadgets/Slider/index.jsx
@@ -20,22 +20,23 @@ class RangeSlider extends React.Component {
     super(props);
 
     this.state = {
-      value: props.gadget.value,
-      listener: () => this._handleChangeFromServer()
+      value: props.gadget.value
     };
-    this.state.listener.gadgetName = props.gadget.title;
   }
 
   componentDidMount() {
-    this.props.gadget.listen(this.state.listener);
+    this.listener = () => this._handleChangeFromServer()
+    this.props.gadget.listen(this.listener);
   }
 
   componentWillUnmount() {
     try {
-      this.props.gadget.unlisten(this.state.listener);
+      this.props.gadget.unlisten(this.listener);
     } catch (e) {
       // TODO: Why is this happening? It causes the UI to disappear. :-(
       console.warn("Failed to unlisten on", this.props.gadget, e);
+    } finally {
+      this.listener = null;
     }
   }
 
@@ -72,7 +73,7 @@ class RangeSlider extends React.Component {
   }, 10);
 
   onChange = (value) => {
-    this.props.gadget.withoutTriggering(this.state.listener, () => {
+    this.props.gadget.withoutTriggering(this.listener, () => {
       this.props.gadget.value = value;
     });
   };

--- a/src/jsMain/kotlin/baaahs/ui/PatchOverview.kt
+++ b/src/jsMain/kotlin/baaahs/ui/PatchOverview.kt
@@ -81,8 +81,7 @@ val PatchOverview = xComponent<PatchOverviewProps>("PatchOverview") { props ->
                     val contextShaders =
                         mutablePatch.mutableShaderInstances.map { it.mutableShader.build() } + newShader
                     val unresolvedPatch = appContext.autoWirer.autoWire(
-                        *contextShaders.toTypedArray(),
-                        focus = newShader
+                        *contextShaders.toTypedArray()
                     )
                     mutablePatch.addShaderInstance(newShader) {
                         // TODO: Something better than this.

--- a/src/jsMain/kotlin/baaahs/ui/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/ui/ShaderInstanceEditor.kt
@@ -40,7 +40,7 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
         val observer = newEditingShader.addObserver {
             if (it.state == EditingShader.State.Success) {
                 val shader = it.previewShaderBuilder.shader
-                val wiringGuess = appContext.autoWirer.autoWire(shader, focus = shader)
+                val wiringGuess = appContext.autoWirer.autoWire(shader)
                     .acceptSymbolicChannelLinks()
                     .resolve()
                 // TODO Improve on this.


### PR DESCRIPTION
* Initialize color vec4's with a=1.0.
* Clean up how resolution is managed in preview. The `resolution`/`iResolution` uniform will now always be (1,1).
* Add wobbly checkerboard to sample show.