### PR TITLE
More EditableManager fixes

### DIFF
--- a/src/commonMain/kotlin/baaahs/app/ui/editor/Editable.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/Editable.kt
@@ -4,6 +4,7 @@ import baaahs.app.ui.editor.EditableManager
 import baaahs.show.ButtonControl
 import baaahs.show.mutable.MutableButtonControl
 import baaahs.show.mutable.MutableButtonGroupControl
+import baaahs.show.mutable.MutableControl
 import baaahs.show.mutable.MutableShow
 import baaahs.ui.Icon
 import baaahs.ui.Renderer
@@ -19,19 +20,42 @@ interface MutableEditable {
 
 interface EditIntent {
     fun findMutableEditable(mutableShow: MutableShow): MutableEditable
+
+    /**
+     * If a mutation might have changed how we should look up the editable, a new
+     * version of the same EditIntent can be provided here. This is called when pushing
+     * to the [EditableManager]'s [baaahs.util.UndoStack].
+     */
+    fun refreshEditIntent(): EditIntent = this
+
+    /**
+     * If applying [EditableManager] changes performs an action like adding a new control,
+     * and further edits should modify that control but not add yet another one, a new
+     * EditIntent for subsequent edits can be provided here.
+     */
     fun nextEditIntent(): EditIntent = this
 }
 
 class ShowEditIntent : EditIntent {
-
     override fun findMutableEditable(mutableShow: MutableShow): MutableEditable =
         mutableShow
 }
 
-data class ControlEditIntent(private val controlId: String) : EditIntent {
+data class ControlEditIntent(internal val controlId: String) : EditIntent {
+    private lateinit var mutableEditable: MutableControl
 
-    override fun findMutableEditable(mutableShow: MutableShow): MutableEditable =
-        mutableShow.findControl(controlId)
+    override fun findMutableEditable(mutableShow: MutableShow): MutableEditable {
+        mutableEditable = mutableShow.findControl(controlId)
+        return mutableEditable
+    }
+
+    override fun refreshEditIntent(): EditIntent {
+        return copy(controlId = mutableEditable.asBuiltId!!)
+    }
+
+    override fun nextEditIntent(): EditIntent {
+        return ControlEditIntent(mutableEditable.asBuiltId!!)
+    }
 }
 
 data class AddButtonToButtonGroupEditIntent(private val containerId: String) : EditIntent {

--- a/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
@@ -2,9 +2,28 @@ package baaahs.app.ui.editor
 
 import baaahs.app.ui.CommonIcons
 import baaahs.app.ui.EditorPanel
-import baaahs.show.mutable.*
+import baaahs.show.mutable.MutableButtonGroupControl
+import baaahs.show.mutable.MutablePatch
+import baaahs.show.mutable.MutablePatchHolder
+import baaahs.show.mutable.MutableShaderInstance
 import baaahs.ui.Icon
 import baaahs.ui.Renderer
+
+data class GenericPropertiesEditorPanel(
+    val components: List<EditorPanelComponent>
+) : EditorPanel {
+    constructor(vararg components: EditorPanelComponent) : this(components.toList())
+
+    override val title: String
+        get() = "Properties"
+    override val listSubhead: String?
+        get() = null
+    override val icon: Icon?
+        get() = CommonIcons.Settings
+
+    override fun getRenderer(editableManager: EditableManager): Renderer =
+        editorPanelViews.forGenericPropertiesPanel(editableManager, components)
+}
 
 data class PatchHolderEditorPanel(
     private val mutablePatchHolder: MutablePatchHolder
@@ -71,31 +90,24 @@ data class PatchEditorPanel(
     }
 }
 
-data class ShowPropertiesEditorPanel(val mutableShow: MutableShow) : EditorPanel {
-    override val title: String
-        get() = "Properties"
-    override val listSubhead: String?
-        get() = null
-    override val icon: Icon?
-        get() = CommonIcons.Settings
-
-    override fun getRenderer(editableManager: EditableManager): Renderer =
-        editorPanelViews.forShow(editableManager, mutableShow)
+interface EditorPanelComponent {
+    fun getRenderer(editableManager: EditableManager): Renderer
 }
 
-data class ButtonGroupPropertiesEditorPanel(val mutableButtonGroupControl: MutableButtonGroupControl) : EditorPanel {
-    override val title: String
-        get() = "Properties"
-    override val listSubhead: String?
-        get() = null
-    override val icon: Icon?
-        get() = CommonIcons.Settings
+data class TitleEditorPanelComponent(val mutablePatchHolder: MutablePatchHolder) : EditorPanelComponent {
+    override fun getRenderer(editableManager: EditableManager): Renderer =
+        editorPanelViews.forTitleComponent(editableManager, mutablePatchHolder)
+}
 
+data class ButtonGroupDirectionEditorPanelComponent(
+    val mutableButtonGroupControl: MutableButtonGroupControl
+) : EditorPanelComponent {
     override fun getRenderer(editableManager: EditableManager): Renderer =
         editorPanelViews.forButtonGroup(editableManager, mutableButtonGroupControl)
 }
 
 interface EditorPanelViews {
+    fun forGenericPropertiesPanel(editableManager: EditableManager, components: List<EditorPanelComponent>): Renderer
     fun forPatchHolder(editableManager: EditableManager, mutablePatchHolder: MutablePatchHolder): Renderer
     fun forPatch(editableManager: EditableManager, mutablePatch: MutablePatch): Renderer
     fun forShaderInstance(
@@ -103,8 +115,9 @@ interface EditorPanelViews {
         mutablePatch: MutablePatch,
         mutableShaderInstance: MutableShaderInstance
     ): Renderer
-    fun forShow(editableManager: EditableManager, mutableShow: MutableShow): Renderer
     fun forButtonGroup(editableManager: EditableManager, mutableButtonGroupControl: MutableButtonGroupControl): Renderer
+
+    fun forTitleComponent(editableManager: EditableManager, mutablePatchHolder: MutablePatchHolder): Renderer
 }
 
 val editorPanelViews by lazy { getEditorPanelViews() }

--- a/src/commonMain/kotlin/baaahs/show/Show.kt
+++ b/src/commonMain/kotlin/baaahs/show/Show.kt
@@ -6,10 +6,7 @@ import baaahs.camelize
 import baaahs.getBang
 import baaahs.plugin.Plugins
 import baaahs.show.ButtonGroupControl.Direction
-import baaahs.show.mutable.MutablePatch
-import baaahs.show.mutable.MutableShaderInstance
 import baaahs.show.mutable.MutableShow
-import baaahs.show.mutable.ShowBuilder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -63,16 +60,7 @@ data class Show(
 data class Patch(
     val shaderInstanceIds: List<String>,
     val surfaces: Surfaces
-) {
-    companion object {
-        fun from(mutablePatch: MutablePatch, showBuilder: ShowBuilder): Patch {
-            return Patch(
-                mutablePatch.mutableShaderInstances.map { showBuilder.idFor(it.build(showBuilder)) },
-                mutablePatch.surfaces
-            )
-        }
-    }
-}
+)
 
 @Serializable
 data class EventBinding(
@@ -125,12 +113,6 @@ data class ShaderInstance(
 
     fun findDataSourceRefs(): List<DataSourceRef> {
         return incomingLinks.values.filterIsInstance<DataSourceRef>()
-    }
-
-    companion object {
-        fun from(mutableShaderInstance: MutableShaderInstance, showBuilder: ShowBuilder): ShaderInstance {
-            return mutableShaderInstance.build(showBuilder)
-        }
     }
 }
 

--- a/src/commonTest/kotlin/baaahs/app/ui/editor/EditableManagerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/app/ui/editor/EditableManagerSpec.kt
@@ -120,6 +120,26 @@ object EditableManagerSpec : Spek({
                     it("has a different MutableShow") {
                         assertTrue { priorMutableShow !== editableManager.session!!.mutableShow }
                     }
+
+                    context("and user clicks Undo") {
+                        beforeEachTest {
+                            editableManager.undo()
+                        }
+
+                        it("is modified") {
+                            expect(true) { editableManager.isModified() }
+                        }
+
+                        context("and user clicks Redo") {
+                            beforeEachTest {
+                                editableManager.redo()
+                            }
+
+                            it("is not modified") {
+                                expect(false) { editableManager.isModified() }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/commonTest/kotlin/baaahs/app/ui/editor/EditableSpec.kt
+++ b/src/commonTest/kotlin/baaahs/app/ui/editor/EditableSpec.kt
@@ -1,0 +1,42 @@
+package baaahs.app.ui.editor
+
+import baaahs.app.ui.ControlEditIntent
+import baaahs.show.mutable.MutableButtonControl
+import baaahs.show.mutable.MutableShow
+import describe
+import org.spekframework.spek2.Spek
+import kotlin.test.expect
+
+object EditableSpec : Spek({
+    describe<ControlEditIntent> {
+        val baseShow by value {
+            MutableShow("test show") {
+                addButton("main", "main button") { }
+            }.getShow()
+
+                .also { println("it = ${it}") }
+        }
+        val editIntent by value { ControlEditIntent("mainButtonButton") }
+        val editableManager by value {
+            EditableManager { }
+                .apply { openEditor(baseShow, editIntent) }
+        }
+        val mutableButton by value {
+            editableManager.session!!.mutableEditable as MutableButtonControl
+        }
+
+        context("when the id of its control changes") {
+            beforeEachTest {
+                mutableButton.title = "new title for button"
+                editableManager.onChange()
+                editableManager.undo()
+                editableManager.redo()
+            }
+
+            it("provides an appropriate refreshed edit intent for the undo stack") {
+                val newEditIntent = (editableManager.session!!.editIntent as ControlEditIntent)
+                expect("newTitleForButtonButton") { newEditIntent.controlId }
+            }
+        }
+    }
+})

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
@@ -52,9 +52,8 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
     val handleClose = useCallback { event: Event -> props.editableManager.close() }
     val handleApply = useCallback { event: Event -> props.editableManager.applyChanges() }
 
-    val handleTabClick = useCallback { event: Event -> event.preventDefault() }
-
     val editorPanels = props.editableManager.editorPanels
+    val selectedPanel = props.editableManager.selectedPanel
 
     fun RBuilder.recursingList(editorPanels: List<EditorPanel>) {
         list(EditableStyles.tabsList on ListStyle.root) {
@@ -69,7 +68,7 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
 
                 listItem {
                     attrs.button = true
-                    attrs.selected = props.editableManager.selectedPanel == editorPanel
+                    attrs.selected = selectedPanel == editorPanel
                     attrs.onClickFunction = { props.editableManager.openPanel(editorPanel) }
 
                     editorPanel.icon?.let {
@@ -143,7 +142,7 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
                     }
 
                     div(+EditableStyles.editorCol) {
-                        props.editableManager.selectedPanel?.let { editorPanel ->
+                        selectedPanel?.let { editorPanel ->
                             header {
                                 +editorPanel.title
 

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
@@ -1,18 +1,39 @@
 package baaahs.app.ui.editor
 
 import baaahs.show.ButtonGroupControl
-import baaahs.show.mutable.*
+import baaahs.show.mutable.MutableButtonGroupControl
+import baaahs.show.mutable.MutablePatch
+import baaahs.show.mutable.MutablePatchHolder
+import baaahs.show.mutable.MutableShaderInstance
 import baaahs.ui.Renderer
 import kotlinx.html.js.onChangeFunction
+import materialui.components.divider.divider
+import materialui.components.divider.enums.DividerVariant
 import materialui.components.formcontrol.formControl
 import materialui.components.formcontrollabel.formControlLabel
 import materialui.components.formlabel.formLabel
 import materialui.components.radio.radio
 import materialui.components.radiogroup.radioGroup
 import org.w3c.dom.HTMLInputElement
-import react.dom.div
 
 actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
+    override fun forGenericPropertiesPanel(
+        editableManager: EditableManager,
+        components: List<EditorPanelComponent>
+    ): Renderer = renderWrapper {
+        components.forEachIndexed { index, editorPanelComponent ->
+            if (index > 0) {
+                divider {
+                    attrs.variant = DividerVariant.middle
+                }
+            }
+
+            with(editorPanelComponent.getRenderer(editableManager)) {
+                render()
+            }
+        }
+    }
+
     override fun forPatchHolder(
         editableManager: EditableManager,
         mutablePatchHolder: MutablePatchHolder
@@ -48,13 +69,6 @@ actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
             }
         }
 
-    override fun forShow(
-        editableManager: EditableManager,
-        mutableShow: MutableShow
-    ): Renderer = renderWrapper {
-        div {}
-    }
-
     override fun forButtonGroup(
         editableManager: EditableManager,
         mutableButtonGroupControl: MutableButtonGroupControl
@@ -85,6 +99,17 @@ actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
                 }
             }
         }
+    }
 
+    override fun forTitleComponent(
+        editableManager: EditableManager,
+        mutablePatchHolder: MutablePatchHolder
+    ): Renderer = renderWrapper {
+        textFieldEditor {
+            attrs.label = "Title"
+            attrs.getValue = { mutablePatchHolder.title }
+            attrs.setValue = { value -> mutablePatchHolder.title = value }
+            attrs.editableManager = editableManager
+        }
     }
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -10,6 +10,7 @@ import baaahs.show.mutable.ShowBuilder
 import baaahs.ui.*
 import baaahs.ui.preview.gadgetsPreview
 import kotlinx.css.*
+import kotlinx.html.js.onBlurFunction
 import kotlinx.html.js.onChangeFunction
 import materialui.components.divider.divider
 import materialui.components.formcontrol.formControl
@@ -30,7 +31,6 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
         handler("handleShaderUpdate", props.mutableShaderInstance) { block: MutableShaderInstance.() -> Unit ->
             props.mutableShaderInstance.block()
             props.editableManager.onChange()
-            forceRender()
         }
 
     val editingShader = memo(props.mutableShaderInstance) {
@@ -96,10 +96,12 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
                     textField {
                         attrs.autoFocus = false
                         attrs.fullWidth = true
-                        attrs.value = shaderInstance.mutableShader.title
-                        attrs.onChangeFunction = { event: Event ->
-                            val str = event.target!!.asDynamic().value as String
-                            handleUpdate { mutableShader.title = str }
+                        attrs.defaultValue = shaderInstance.mutableShader.title
+                        attrs.onBlurFunction = { event: Event ->
+                            val str = event.target.value
+                            if (shaderInstance.mutableShader.title != str) {
+                                handleUpdate { mutableShader.title = str }
+                            }
                         }
                     }
                     formHelperText { +"Shader Name" }

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -10,7 +10,6 @@ import baaahs.show.mutable.ShowBuilder
 import baaahs.ui.*
 import baaahs.ui.preview.gadgetsPreview
 import kotlinx.css.*
-import kotlinx.html.js.onBlurFunction
 import kotlinx.html.js.onChangeFunction
 import materialui.components.divider.divider
 import materialui.components.formcontrol.formControl
@@ -92,19 +91,11 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
             }
 
             div(+Styles.shaderMeta) {
-                formControl {
-                    textField {
-                        attrs.autoFocus = false
-                        attrs.fullWidth = true
-                        attrs.defaultValue = shaderInstance.mutableShader.title
-                        attrs.onBlurFunction = { event: Event ->
-                            val str = event.target.value
-                            if (shaderInstance.mutableShader.title != str) {
-                                handleUpdate { mutableShader.title = str }
-                            }
-                        }
-                    }
-                    formHelperText { +"Shader Name" }
+                textFieldEditor {
+                    attrs.label = "Shader Name"
+                    attrs.getValue = { shaderInstance.mutableShader.title }
+                    attrs.setValue = { value -> shaderInstance.mutableShader.title = value }
+                    attrs.editableManager = props.editableManager
                 }
 
                 formControl {

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
@@ -20,7 +20,7 @@ val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { prop
         textField {
             attrs.autoFocus = false
             attrs.fullWidth = true
-            attrs.defaultValue = props.getValue()
+            attrs.value = props.getValue()
 
             // Notify EditableManager of changes as we type, but don't push them to the undo stack...
             attrs.onChangeFunction = { event: Event ->

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
@@ -1,0 +1,52 @@
+package baaahs.app.ui.editor
+
+import baaahs.ui.value
+import baaahs.ui.xComponent
+import kotlinx.html.js.onBlurFunction
+import kotlinx.html.js.onChangeFunction
+import materialui.components.formcontrol.formControl
+import materialui.components.formhelpertext.formHelperText
+import materialui.components.textfield.textField
+import org.w3c.dom.events.Event
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+
+val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { props ->
+    val valueOnUndoStack = ref { props.getValue() }
+
+    formControl {
+        textField {
+            attrs.autoFocus = false
+            attrs.fullWidth = true
+            attrs.defaultValue = props.getValue()
+
+            // Notify EditableManager of changes as we type, but don't push them to the undo stack...
+            attrs.onChangeFunction = { event: Event ->
+                props.setValue(event.target.value)
+                props.editableManager.onChange(false)
+            }
+
+            // ... until we lose focus; then, push to the undo stack only if the value would change.
+            attrs.onBlurFunction = { event: Event ->
+                val newValue = event.target.value
+                if (newValue != valueOnUndoStack.current) {
+                    valueOnUndoStack.current = newValue
+                    props.editableManager.onChange()
+                }
+            }
+        }
+        formHelperText { +props.label }
+    }
+}
+
+external interface TextFieldEditorProps : RProps {
+    var label: String
+    var getValue: () -> String
+    var setValue: (String) -> Unit
+    var editableManager: EditableManager
+}
+
+fun RBuilder.textFieldEditor(handler: RHandler<TextFieldEditorProps>) =
+    child(TextFieldEditor, handler = handler)

--- a/src/jsMain/kotlin/baaahs/ui/util.kt
+++ b/src/jsMain/kotlin/baaahs/ui/util.kt
@@ -7,6 +7,7 @@ import kotlinx.css.CSSBuilder
 import kotlinx.css.RuleSet
 import kotlinx.css.StyledElement
 import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventTarget
 import react.RMutableRef
 import react.RProps
 import react.ReactElement
@@ -54,6 +55,9 @@ fun String?.truncate(length: Int): String? {
 
 @Suppress("UNCHECKED_CAST")
 fun Function<*>.withEvent(): (Event) -> Unit = this as (Event) -> Unit
+
+val EventTarget?.value: String
+        get() = asDynamic()!!.value as String
 
 private val jsObj = js("Object")
 fun RProps.copyInto(dest: RProps) {


### PR DESCRIPTION
* `EditIntent`s may implement `refreshEditIntent()` e.g. if the `Editable`'s id might change.
* Fixed `EditableManager.isModified()` to compare to currently applied show so "Apply Changes"
  is properly enabled/disabled after Undo/Redo.
* Created `GenericPropertiesEditorPanel` for editing arbitrary properties (e.g. title).
* Fix panel updates for Undo/Redo.