### PR TITLE
Editor cleanup

### DIFF
--- a/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
@@ -2,17 +2,14 @@ package baaahs.app.ui.editor
 
 import baaahs.app.ui.CommonIcons
 import baaahs.app.ui.EditorPanel
-import baaahs.show.mutable.MutableButtonGroupControl
-import baaahs.show.mutable.MutablePatch
-import baaahs.show.mutable.MutablePatchHolder
-import baaahs.show.mutable.MutableShaderInstance
+import baaahs.show.mutable.*
 import baaahs.ui.Icon
 import baaahs.ui.Renderer
 
 data class GenericPropertiesEditorPanel(
-    val components: List<EditorPanelComponent>
+    val propsEditors: List<PropsEditor>
 ) : EditorPanel {
-    constructor(vararg components: EditorPanelComponent) : this(components.toList())
+    constructor(vararg propsEditors: PropsEditor) : this(propsEditors.toList())
 
     override val title: String
         get() = "Properties"
@@ -22,7 +19,7 @@ data class GenericPropertiesEditorPanel(
         get() = CommonIcons.Settings
 
     override fun getRenderer(editableManager: EditableManager): Renderer =
-        editorPanelViews.forGenericPropertiesPanel(editableManager, components)
+        editorPanelViews.forGenericPropertiesPanel(editableManager, propsEditors)
 }
 
 data class PatchHolderEditorPanel(
@@ -90,24 +87,31 @@ data class PatchEditorPanel(
     }
 }
 
-interface EditorPanelComponent {
+interface PropsEditor {
     fun getRenderer(editableManager: EditableManager): Renderer
 }
 
-data class TitleEditorPanelComponent(val mutablePatchHolder: MutablePatchHolder) : EditorPanelComponent {
+data class TitlePropsEditor(val mutablePatchHolder: MutablePatchHolder) : PropsEditor {
     override fun getRenderer(editableManager: EditableManager): Renderer =
         editorPanelViews.forTitleComponent(editableManager, mutablePatchHolder)
 }
 
-data class ButtonGroupDirectionEditorPanelComponent(
+data class ButtonPropsEditor(
+    val mutableButtonControl: MutableButtonControl
+) : PropsEditor {
+    override fun getRenderer(editableManager: EditableManager): Renderer =
+        editorPanelViews.forButton(editableManager, mutableButtonControl)
+}
+
+data class ButtonGroupPropsEditor(
     val mutableButtonGroupControl: MutableButtonGroupControl
-) : EditorPanelComponent {
+) : PropsEditor {
     override fun getRenderer(editableManager: EditableManager): Renderer =
         editorPanelViews.forButtonGroup(editableManager, mutableButtonGroupControl)
 }
 
 interface EditorPanelViews {
-    fun forGenericPropertiesPanel(editableManager: EditableManager, components: List<EditorPanelComponent>): Renderer
+    fun forGenericPropertiesPanel(editableManager: EditableManager, propsEditors: List<PropsEditor>): Renderer
     fun forPatchHolder(editableManager: EditableManager, mutablePatchHolder: MutablePatchHolder): Renderer
     fun forPatch(editableManager: EditableManager, mutablePatch: MutablePatch): Renderer
     fun forShaderInstance(
@@ -115,6 +119,7 @@ interface EditorPanelViews {
         mutablePatch: MutablePatch,
         mutableShaderInstance: MutableShaderInstance
     ): Renderer
+    fun forButton(editableManager: EditableManager, mutableButtonControl: MutableButtonControl): Renderer
     fun forButtonGroup(editableManager: EditableManager, mutableButtonGroupControl: MutableButtonGroupControl): Renderer
 
     fun forTitleComponent(editableManager: EditableManager, mutablePatchHolder: MutablePatchHolder): Renderer

--- a/src/commonMain/kotlin/baaahs/show/Control.kt
+++ b/src/commonMain/kotlin/baaahs/show/Control.kt
@@ -15,7 +15,9 @@ interface Control : Editable {
     override val title: String
     fun suggestId(): String = "control"
 
-    fun toMutable(mutableShow: MutableShow): MutableControl
+    /** Don't call this directly; use [MutableShow.findControl]. */
+    fun createMutable(mutableShow: MutableShow): MutableControl
+
     fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl
 
     companion object {
@@ -41,7 +43,7 @@ data class GadgetControl(
 
     override fun suggestId(): String = controlledDataSourceId + "Control"
 
-    override fun toMutable(mutableShow: MutableShow): MutableGadgetControl {
+    override fun createMutable(mutableShow: MutableShow): MutableGadgetControl {
         return MutableGadgetControl(gadget, mutableShow.findDataSource(controlledDataSourceId).dataSource)
     }
 
@@ -56,13 +58,20 @@ data class GadgetControl(
 @SerialName("baaahs.Core:Button")
 data class ButtonControl(
     override val title: String,
+    val activationType: ActivationType = ActivationType.Toggle,
     override val patches: List<Patch> = emptyList(),
     override val eventBindings: List<EventBinding> = emptyList(),
     override val controlLayout: Map<String, List<String>> = emptyMap()
 ) : PatchHolder, Control {
+
+    enum class ActivationType {
+        Toggle,
+        Momentary
+    }
+
     override fun suggestId(): String = title.camelize() + "Button"
 
-    override fun toMutable(mutableShow: MutableShow): MutableButtonControl {
+    override fun createMutable(mutableShow: MutableShow): MutableButtonControl {
         return MutableButtonControl(this, mutableShow)
     }
 
@@ -87,7 +96,7 @@ data class ButtonGroupControl(
 
     override fun suggestId(): String = title.camelize() + "ButtonGroup"
 
-    override fun toMutable(mutableShow: MutableShow): MutableButtonGroupControl {
+    override fun createMutable(mutableShow: MutableShow): MutableButtonGroupControl {
         return MutableButtonGroupControl(title, direction, buttonIds.map {
             mutableShow.findControl(it) as MutableButtonControl
         }.toMutableList(), mutableShow)

--- a/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
@@ -40,6 +40,8 @@ class OpenButtonControl(
 ) : OpenPatchHolder(buttonControl, openContext), OpenControl {
     override val gadget: Switch = Switch(buttonControl.title)
 
+    val type get() = buttonControl.activationType
+
     var isPressed: Boolean
         get() = gadget.enabled
         set(value) { gadget.enabled = value }

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
@@ -33,10 +33,12 @@ abstract class MutablePatchHolder(
 
     override fun getEditorPanels(): List<EditorPanel> {
         return listOf(
-            GenericPropertiesEditorPanel(
-                TitleEditorPanelComponent(this)
-            ),
+            GenericPropertiesEditorPanel(getPropertiesComponents()),
             PatchHolderEditorPanel(this))
+    }
+
+    open fun getPropertiesComponents(): List<PropsEditor> {
+        return listOf(TitlePropsEditor(this))
     }
 
     val patches by lazy {
@@ -139,7 +141,7 @@ class MutableShow(
     override val mutableShow: MutableShow get() = this
 
     internal val controls = CacheBuilder<String, MutableControl> { id ->
-        baseShow.controls.getBang(id, "control").toMutable(this)
+        baseShow.controls.getBang(id, "control").createMutable(this)
     }
 
     internal val dataSources = baseShow.dataSources
@@ -379,11 +381,18 @@ class MutableButtonControl(
     baseButtonControl: ButtonControl,
     override val mutableShow: MutableShow
 ) : MutablePatchHolder(baseButtonControl), MutableControl {
+    var activationType: ButtonControl.ActivationType = baseButtonControl.activationType
+
     override var asBuiltId: String? = null
+
+    override fun getPropertiesComponents(): List<PropsEditor> {
+        return super.getPropertiesComponents() + ButtonPropsEditor(this)
+    }
 
     override fun build(showBuilder: ShowBuilder): Control {
         return ButtonControl(
             title,
+            activationType,
             patches = patches.map { it.build(showBuilder) },
             eventBindings = eventBindings,
             controlLayout = buildControlLayout(showBuilder)
@@ -409,7 +418,7 @@ data class MutableButtonGroupControl(
     override fun getEditorPanels(): List<EditorPanel> {
         return listOf(
             GenericPropertiesEditorPanel(
-                ButtonGroupDirectionEditorPanelComponent(this)
+                ButtonGroupPropsEditor(this)
             )
         )
     }

--- a/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
@@ -43,7 +43,6 @@ object ShowSerializationSpec : Spek({
 private fun JsonObjectBuilder.mapTo(k: String, v: JsonElement) = put(k, v)
 
 private fun JsonObjectBuilder.addPatchHolder(patchHolder: PatchHolder) {
-    put("title", patchHolder.title)
     put("patches", patchHolder.patches.jsonMap { jsonFor(it) })
     put("eventBindings", patchHolder.eventBindings.jsonMap { jsonFor(it) })
     put("controlLayout", patchHolder.controlLayout.jsonMap { it.jsonMap { JsonPrimitive(it) } })
@@ -59,6 +58,7 @@ private fun <T> List<T>.jsonMap(block: (T) -> JsonElement): JsonArray {
 
 private fun forJson(show: Show): JsonObject {
     return buildJsonObject {
+        put("title", show.title)
         addPatchHolder(show)
         put("layouts", buildJsonObject {
             put("panelNames", show.layouts.panelNames.jsonMap { JsonPrimitive(it) })
@@ -90,6 +90,8 @@ fun jsonFor(control: Control): JsonElement {
         }
         is ButtonControl -> buildJsonObject {
             put("type", "baaahs.Core:Button")
+            put("title", control.title)
+            put("activationType", control.activationType.name)
             addPatchHolder(control)
         }
         else -> buildJsonObject { put("type", "unknown") }

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -33,7 +33,7 @@ import materialui.components.typography.typographyH6
 import materialui.icon
 import materialui.icons.Icons
 import materialui.lab.components.alert.alert
-import materialui.lab.components.alert.enums.AlertColor
+import materialui.lab.components.alert.enums.AlertSeverity
 import materialui.lab.components.alerttitle.alertTitle
 import materialui.styles.createMuiTheme
 import materialui.styles.muitheme.options.palette
@@ -342,7 +342,7 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
                         div {
                             serverNotices.forEach { serverNotice ->
                                 alert {
-                                    attrs.color = AlertColor.error
+                                    attrs.severity = AlertSeverity.error
                                     attrs.onClose = { webClient.confirmServerNotice(serverNotice.id) }
 
                                     alertTitle {

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -40,7 +40,6 @@ import materialui.styles.muitheme.options.palette
 import materialui.styles.palette.PaletteType
 import materialui.styles.palette.options.type
 import materialui.styles.themeprovider.themeProvider
-import org.w3c.dom.*
 import react.*
 import react.dom.code
 import react.dom.div
@@ -201,24 +200,18 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
     val show = webClient.show
 
     onMount {
-        window.onkeydown = { event ->
-            when (event.target) {
-                is HTMLButtonElement,
-                is HTMLInputElement,
-                is HTMLSelectElement,
-                is HTMLOptionElement,
-                is HTMLTextAreaElement -> {
-                    // Ignore.
-                }
-                else -> {
-                    when (event.key) {
-                        "d" -> editMode = !editMode
-                    }
+        val keyboardShortcutHandler = KeyboardShortcutHandler { event ->
+            when (event.key) {
+                "d" -> {
+                    editMode = !editMode
+                    event.stopPropagation()
                 }
             }
-            true
         }
-        withCleanup { window.onkeydown = null }
+        keyboardShortcutHandler.listen(window)
+        withCleanup {
+            keyboardShortcutHandler.unlisten(window)
+        }
     }
 
     appContext.Provider {

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -305,6 +305,10 @@ object Styles : StyleSheet("app-ui", isStatic = true) {
             )
         }
 
+        descendants(baaahs.app.ui.controls.Styles.editButton) {
+            opacity = .2
+        }
+
         descendants(baaahs.app.ui.controls.Styles.dragHandle) {
             opacity = .2
         }

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/Button.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/Button.kt
@@ -2,23 +2,28 @@ package baaahs.app.ui.controls
 
 import baaahs.app.ui.AppContext
 import baaahs.app.ui.ControlEditIntent
+import baaahs.show.ButtonControl
 import baaahs.show.live.ControlProps
 import baaahs.show.live.ControlView
 import baaahs.show.live.OpenButtonControl
 import baaahs.show.live.OpenControl
 import baaahs.ui.unaryPlus
+import baaahs.ui.withEvent
 import baaahs.ui.xComponent
 import kotlinx.html.js.onClickFunction
+import kotlinx.html.js.onMouseDownFunction
+import kotlinx.html.js.onMouseUpFunction
 import materialui.toggleButton
 import react.FunctionalComponent
 import react.RBuilder
 import react.RHandler
 import react.child
 import react.dom.div
+import materialui.components.button.button as muiButton
 
-class ButtonControlView(val openButtonControl: OpenButtonControl) : ControlView {
+class ButtonControlView(private val openButtonControl: OpenButtonControl) : ControlView {
     override fun <P : ControlProps<in OpenControl>> getReactElement(): FunctionalComponent<P> {
-        return Button.unsafeCast<FunctionalComponent<P>>()
+        return button.unsafeCast<FunctionalComponent<P>>()
     }
 
     override fun onEdit(appContext: AppContext) {
@@ -26,49 +31,49 @@ class ButtonControlView(val openButtonControl: OpenButtonControl) : ControlView 
     }
 }
 
-val Button = xComponent<ButtonProps>("Button") { props ->
+private val button = xComponent<ButtonProps>("Button") { props ->
     val buttonControl = props.control
 
+    val handleToggleClick = handler("toggle click") {
+        buttonControl.click()
+        props.onShowStateChange()
+    }
+
+    val handleMomentaryPress = handler("momentary press") {
+        if (!buttonControl.isPressed) buttonControl.click()
+        props.onShowStateChange()
+    }
+
+    val handleMomentaryRelease = handler("momentary release") {
+        if (buttonControl.isPressed) buttonControl.click()
+        props.onShowStateChange()
+    }
+
     div(+Styles.controlButton) {
-//        ref = sceneDragProvided.innerRef
-//        copyFrom(sceneDragProvided.draggableProps)
+        when (buttonControl.type) {
+            ButtonControl.ActivationType.Toggle ->
+                toggleButton {
+                    attrs["value"] = "n/a"
+                    attrs["selected"] = buttonControl.isPressed
+                    attrs.onClickFunction = handleToggleClick.withEvent()
 
-//        div(+Styles.editButton) {
-//            if (props.editMode) {
-//                attrs.onClickFunction = { event -> handleEditButtonClick(event) }
-//            }
-//
-//            icon(Edit)
-//        }
-//        div(+Styles.dragHandle) {
-////            copyFrom(sceneDragProvided.dragHandleProps)
-//            icon(DragIndicator)
-//        }
+                    +buttonControl.title
+                }
 
-//                            droppable({
-//                                droppableId = sceneDropTargets[index].first
-//                                type = "Patch"
-//                                direction = Direction.vertical.name
-//                                isDropDisabled = !props.editMode
-//                            }) { patchDroppableProvided, _ ->
-        toggleButton {
-//                                    ref = patchDroppableProvided.innerRef
-//                                    copyFrom(patchDroppableProvided.droppableProps)
+            ButtonControl.ActivationType.Momentary ->
+                muiButton {
+                    attrs["value"] = "n/a"
+                    attrs["selected"] = buttonControl.isPressed
+                    attrs.onMouseDownFunction = handleMomentaryPress.withEvent()
+                    attrs.onMouseUpFunction = handleMomentaryRelease.withEvent()
 
-            attrs["value"] = "n/a"
-            attrs["selected"] = buttonControl.isPressed
-            attrs.onClickFunction = {
-                buttonControl.click()
-                props.onShowStateChange()
-            }
-
-            +buttonControl.title
+                    +buttonControl.title
+                }
         }
-//                            }
     }
 }
 
 external interface ButtonProps : ControlProps<OpenButtonControl>
 
 fun RBuilder.button(handler: RHandler<ButtonProps>) =
-    child(Button, handler = handler)
+    child(button, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ButtonGroupPropsEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ButtonGroupPropsEditor.kt
@@ -1,0 +1,69 @@
+package baaahs.app.ui.editor
+
+import baaahs.show.ButtonGroupControl
+import baaahs.show.mutable.MutableButtonGroupControl
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
+import kotlinx.html.js.onChangeFunction
+import materialui.components.formcontrol.formControl
+import materialui.components.formcontrollabel.formControlLabel
+import materialui.components.formlabel.formLabel
+import materialui.components.radio.radio
+import materialui.components.radiogroup.radioGroup
+import org.w3c.dom.HTMLInputElement
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+import react.dom.div
+
+private val buttonGroupPropsEditor =
+    xComponent<ButtonGroupPropsEditorProps>("ButtonGroupPropsEditor") { props ->
+        div(+EditableStyles.propertiesSection) {
+            textFieldEditor {
+                attrs.label = "Title"
+                attrs.helperText = "Not actually displayed anywhere"
+                attrs.autoFocus = true
+                attrs.getValue = { props.mutableButtonGroupControl.title }
+                attrs.setValue = { value -> props.mutableButtonGroupControl.title = value }
+                attrs.editableManager = props.editableManager
+            }
+        }
+
+        div(+EditableStyles.propertiesSection) {
+            formControl {
+                formLabel {
+                    attrs.component = "legend"
+                    +"Direction"
+                }
+
+                radioGroup {
+                    attrs.value(props.mutableButtonGroupControl.direction.name)
+                    attrs.onChangeFunction = {
+                        val value = (it.target as HTMLInputElement).value
+                        props.mutableButtonGroupControl.direction = ButtonGroupControl.Direction.valueOf(value)
+                        props.editableManager.onChange()
+                    }
+
+                    formControlLabel {
+                        attrs.value = "Horizontal"
+                        attrs.control = radio {}
+                        attrs.label { +"Horizontal" }
+                    }
+                    formControlLabel {
+                        attrs.value = "Vertical"
+                        attrs.control = radio {}
+                        attrs.label { +"Vertical" }
+                    }
+                }
+            }
+        }
+    }
+
+external interface ButtonGroupPropsEditorProps : RProps {
+    var editableManager: EditableManager
+    var mutableButtonGroupControl: MutableButtonGroupControl
+}
+
+fun RBuilder.buttonGroupPropsEditor(handler: RHandler<ButtonGroupPropsEditorProps>) =
+    child(buttonGroupPropsEditor, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ButtonPropsEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ButtonPropsEditor.kt
@@ -1,0 +1,58 @@
+package baaahs.app.ui.editor
+
+import baaahs.show.ButtonControl
+import baaahs.show.mutable.MutableButtonControl
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
+import kotlinx.html.js.onChangeFunction
+import materialui.components.formcontrol.formControl
+import materialui.components.formcontrollabel.formControlLabel
+import materialui.components.formlabel.formLabel
+import materialui.components.radio.radio
+import materialui.components.radiogroup.radioGroup
+import org.w3c.dom.HTMLInputElement
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+import react.dom.div
+
+private val buttonPropsEditor =
+    xComponent<ButtonPropsEditorProps>("ButtonPropsEditor") { props ->
+        div(+EditableStyles.propertiesSection) {
+            formControl {
+                formLabel {
+                    attrs.component = "legend"
+                    +"Button Type"
+                }
+
+                radioGroup {
+                    attrs.value(props.mutableButtonControl.activationType.name)
+                    attrs.onChangeFunction = {
+                        val value = (it.target as HTMLInputElement).value
+                        props.mutableButtonControl.activationType = ButtonControl.ActivationType.valueOf(value)
+                        props.editableManager.onChange()
+                    }
+
+                    formControlLabel {
+                        attrs.value = "Toggle"
+                        attrs.control = radio {}
+                        attrs.label { +"Toggle" }
+                    }
+                    formControlLabel {
+                        attrs.value = "Momentary"
+                        attrs.control = radio {}
+                        attrs.label { +"Momentary" }
+                    }
+                }
+            }
+        }
+    }
+
+external interface ButtonPropsEditorProps : RProps {
+    var editableManager: EditableManager
+    var mutableButtonControl: MutableButtonControl
+}
+
+fun RBuilder.buttonPropsEditor(handler: RHandler<ButtonPropsEditorProps>) =
+    child(buttonPropsEditor, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
@@ -15,6 +15,7 @@ import materialui.components.drawer.enums.DrawerStyle
 import materialui.components.drawer.enums.DrawerVariant
 import materialui.components.iconbutton.enums.IconButtonStyle
 import materialui.components.iconbutton.iconButton
+import materialui.components.link.link
 import materialui.components.list.enums.ListStyle
 import materialui.components.list.list
 import materialui.components.listitem.listItem
@@ -23,9 +24,13 @@ import materialui.components.listitemtext.listItemText
 import materialui.components.listsubheader.enums.ListSubheaderStyle
 import materialui.components.listsubheader.listSubheader
 import materialui.components.portal.portal
+import materialui.components.snackbar.snackbar
 import materialui.components.typography.typographyH6
 import materialui.icon
 import materialui.icons.Icons
+import materialui.lab.components.alert.alert
+import materialui.lab.components.alert.enums.AlertSeverity
+import materialui.lab.components.alerttitle.alertTitle
 import org.w3c.dom.events.Event
 import react.RBuilder
 import react.RHandler
@@ -43,8 +48,20 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
 //        forceRender()
 //    }
 
-    val handleFormSubmit = useCallback { event: Event -> event.preventDefault() }
-    val handleDrawerClose = useCallback { event: Event -> event.preventDefault() }
+    var showModifiedWarning by state { false }
+
+    val handleFormSubmit = useCallback { event: Event ->
+        if (props.editableManager.isModified()) {
+            props.editableManager.applyChanges()
+        }
+    }
+    val handleDrawerClose = useCallback { event: Event ->
+        if (props.editableManager.isModified()) {
+            showModifiedWarning = true
+        } else {
+            props.editableManager.close()
+        }
+    }
 
     val handleUndo = useCallback { event: Event -> props.editableManager.undo() }
     val handleRedo = useCallback { event: Event -> props.editableManager.redo() }
@@ -101,30 +118,26 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
                 attrs.open = props.editableManager.isEditing()
                 attrs.onClose = handleDrawerClose
 
-                dialogTitle {
-                    +props.editableManager.uiTitle
-//                    textField {
-//                        attrs.autoFocus = true
-//                        attrs.variant = FormControlVariant.outlined
-//                        attrs.label { +"Title" }
-//                        attrs.value = props.mutablePatchHolder.title
-//                        attrs.onChangeFunction = handleTitleChange
-//                    }
+                dialogTitle(+EditableStyles.dialogTitle) {
+                    attrs.disableTypography = true
+                    typographyH6 { +props.editableManager.uiTitle }
 
-                    iconButton(Styles.buttons on IconButtonStyle.root) {
-                        icon(Icons.Undo)
-                        attrs["disabled"] = !props.editableManager.canUndo()
-                        attrs.onClickFunction = handleUndo
+                    div(+EditableStyles.dialogTitleButtons) {
+                        iconButton(Styles.buttons on IconButtonStyle.root) {
+                            icon(Icons.Undo)
+                            attrs["disabled"] = !props.editableManager.canUndo()
+                            attrs.onClickFunction = handleUndo
 
-                        typographyH6 { +"Undo" }
-                    }
+                            typographyH6 { +"Undo" }
+                        }
 
-                    iconButton(Styles.buttons on IconButtonStyle.root) {
-                        icon(Icons.Redo)
-                        attrs["disabled"] = !props.editableManager.canRedo()
-                        attrs.onClickFunction = handleRedo
+                        iconButton(Styles.buttons on IconButtonStyle.root) {
+                            icon(Icons.Redo)
+                            attrs["disabled"] = !props.editableManager.canRedo()
+                            attrs.onClickFunction = handleRedo
 
-                        typographyH6 { +"Redo" }
+                            typographyH6 { +"Redo" }
+                        }
                     }
                 }
 
@@ -159,6 +172,36 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
                 }
 
                 dialogActions {
+                    if (showModifiedWarning) {
+                        snackbar {
+                            attrs.open = true
+                            attrs.onClose = { _, _ -> showModifiedWarning = false }
+
+                            alert {
+                                attrs.severity = AlertSeverity.error
+                                attrs.onClose = { showModifiedWarning = false }
+
+                                alertTitle {
+                                    link {
+                                        attrs.onClickFunction = {
+                                            props.editableManager.applyChanges()
+                                            props.editableManager.close()
+                                        }
+                                        +"Apply changes and close"
+                                    }
+                                    +" or "
+                                    link {
+                                        attrs.onClickFunction = {
+                                            props.editableManager.close()
+                                        }
+                                        +"abandon changes and close"
+                                    }
+                                    +"."
+                                }
+                            }
+                        }
+                    }
+
                     button {
                         if (props.editableManager.isModified()) {
                             +"Abandon Changes"

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditableStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditableStyles.kt
@@ -81,4 +81,9 @@ object EditableStyles : StyleSheet("app-ui-Editable", isStatic = true) {
             padding(0.px)
         }
     }
+
+    val propertiesSection by css {
+        paddingTop = .5.em
+        paddingBottom = 1.em
+    }
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditableStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditableStyles.kt
@@ -16,6 +16,16 @@ object EditableStyles : StyleSheet("app-ui-Editable", isStatic = true) {
         important(::maxHeight, 85.vh)
     }
 
+    val dialogTitle by css {
+        position = Position.relative
+    }
+
+    val dialogTitleButtons by css {
+        position = Position.absolute
+        top = 1.em
+        right = 1.em
+    }
+
     val dialogContent by css {
         display = Display.flex
         alignItems = Align.stretch

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
@@ -1,28 +1,19 @@
 package baaahs.app.ui.editor
 
-import baaahs.show.ButtonGroupControl
 import baaahs.show.ShaderChannel
-import baaahs.show.mutable.MutableButtonGroupControl
-import baaahs.show.mutable.MutablePatch
-import baaahs.show.mutable.MutablePatchHolder
-import baaahs.show.mutable.MutableShaderInstance
+import baaahs.show.mutable.*
 import baaahs.ui.Renderer
-import kotlinx.html.js.onChangeFunction
+import baaahs.ui.unaryPlus
 import materialui.components.divider.divider
 import materialui.components.divider.enums.DividerVariant
-import materialui.components.formcontrol.formControl
-import materialui.components.formcontrollabel.formControlLabel
-import materialui.components.formlabel.formLabel
-import materialui.components.radio.radio
-import materialui.components.radiogroup.radioGroup
-import org.w3c.dom.HTMLInputElement
+import react.dom.div
 
 actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
     override fun forGenericPropertiesPanel(
         editableManager: EditableManager,
-        components: List<EditorPanelComponent>
+        propsEditors: List<PropsEditor>
     ): Renderer = renderWrapper {
-        components.forEachIndexed { index, editorPanelComponent ->
+        propsEditors.forEachIndexed { index, editorPanelComponent ->
             if (index > 0) {
                 divider {
                     attrs.variant = DividerVariant.middle
@@ -70,35 +61,23 @@ actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
             }
         }
 
+    override fun forButton(
+        editableManager: EditableManager,
+        mutableButtonControl: MutableButtonControl
+    ) = renderWrapper {
+        buttonPropsEditor {
+            attrs.editableManager = editableManager
+            attrs.mutableButtonControl = mutableButtonControl
+        }
+    }
+
     override fun forButtonGroup(
         editableManager: EditableManager,
         mutableButtonGroupControl: MutableButtonGroupControl
     ) = renderWrapper {
-        formControl {
-            formLabel {
-                attrs.component = "legend"
-                +"Direction"
-            }
-
-            radioGroup {
-                attrs.value(mutableButtonGroupControl.direction.name)
-                attrs.onChangeFunction = {
-                    val value = (it.target as HTMLInputElement).value
-                    mutableButtonGroupControl.direction = ButtonGroupControl.Direction.valueOf(value)
-                    editableManager.onChange()
-                }
-
-                formControlLabel {
-                    attrs.value = "Horizontal"
-                    attrs.control = radio {}
-                    attrs.label { +"Horizontal" }
-                }
-                formControlLabel {
-                    attrs.value = "Vertical"
-                    attrs.control = radio {}
-                    attrs.label { +"Vertical" }
-                }
-            }
+        buttonGroupPropsEditor {
+            attrs.editableManager = editableManager
+            attrs.mutableButtonGroupControl = mutableButtonGroupControl
         }
     }
 
@@ -106,11 +85,15 @@ actual fun getEditorPanelViews(): EditorPanelViews = object : EditorPanelViews {
         editableManager: EditableManager,
         mutablePatchHolder: MutablePatchHolder
     ): Renderer = renderWrapper {
-        textFieldEditor {
-            attrs.label = "Title"
-            attrs.getValue = { mutablePatchHolder.title }
-            attrs.setValue = { value -> mutablePatchHolder.title = value }
-            attrs.editableManager = editableManager
+        div(+EditableStyles.propertiesSection) {
+            textFieldEditor {
+                attrs.label = "Title"
+                attrs.helperText = "Visible on the button"
+
+                attrs.getValue = { mutablePatchHolder.title }
+                attrs.setValue = { value -> mutablePatchHolder.title = value }
+                attrs.editableManager = editableManager
+            }
         }
     }
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditor.kt
@@ -40,7 +40,7 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
                 EditingShader.State.Errors -> {
                     val lineCount = editor.getSession().getLength().toInt()
                     setAnnotations(editingShader.previewShaderBuilder.glslErrors.map { error ->
-                        jsObject<Annotation> {
+                        jsObject {
                             row = (error.row).boundedBy(0 until lineCount)
                             column = 0
                             text = error.message
@@ -63,7 +63,7 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
     val glslNumberRegex = Regex("[0-9.]")
     val glslIllegalRegex = Regex("[A-Za-z_]")
     val glslFloatOrIntRegex = Regex("^([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+|[0-9]+)$")
-    val handleCursorChange = baaahs.ui.useCallback { value: Any, _: Any ->
+    val handleCursorChange = useCallback { value: Any, _: Any ->
         @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
         val selection = value as Selection
         val session = selection.session
@@ -99,7 +99,7 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
         Unit
     }
 
-    val extractUniform = baaahs.ui.useCallback { _: Event ->
+    val extractUniform = useCallback { _: Event ->
         val extraction = extractionCandidate ?: return@useCallback
 
         val editor = aceEditor?.editor ?: return@useCallback

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
@@ -18,8 +18,9 @@ val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { prop
 
     formControl {
         textField {
-            attrs.autoFocus = false
+            attrs.autoFocus = props.autoFocus == true
             attrs.fullWidth = true
+            attrs.label { +props.label }
             attrs.value = props.getValue()
 
             // Notify EditableManager of changes as we type, but don't push them to the undo stack...
@@ -37,12 +38,17 @@ val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { prop
                 }
             }
         }
-        formHelperText { +props.label }
+
+        props.helperText?.let { helperText ->
+            formHelperText { +helperText }
+        }
     }
 }
 
 external interface TextFieldEditorProps : RProps {
     var label: String
+    var helperText: String?
+    var autoFocus: Boolean?
     var getValue: () -> String
     var setValue: (String) -> Unit
     var editableManager: EditableManager

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/TextFieldEditor.kt
@@ -4,6 +4,7 @@ import baaahs.ui.value
 import baaahs.ui.xComponent
 import kotlinx.html.js.onBlurFunction
 import kotlinx.html.js.onChangeFunction
+import kotlinx.html.js.onKeyDownFunction
 import materialui.components.formcontrol.formControl
 import materialui.components.formhelpertext.formHelperText
 import materialui.components.textfield.textField
@@ -16,6 +17,25 @@ import react.child
 val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { props ->
     val valueOnUndoStack = ref { props.getValue() }
 
+    val handleChange = handler("on change", props.setValue, props.editableManager) { event: Event ->
+        props.setValue(event.target.value)
+        props.editableManager.onChange(false)
+    }
+
+    val handleBlur = handler("on blur", props.editableManager) { event: Event ->
+        val newValue = event.target.value
+        if (newValue != valueOnUndoStack.current) {
+            valueOnUndoStack.current = newValue
+            props.editableManager.onChange()
+        }
+    }
+
+    val handleKeyDown = handler("on keydown", props.editableManager) { event: Event ->
+        if (event.asDynamic().keyCode == 13) {
+            handleBlur(event)
+        }
+    }
+
     formControl {
         textField {
             attrs.autoFocus = props.autoFocus == true
@@ -24,19 +44,11 @@ val TextFieldEditor = xComponent<TextFieldEditorProps>("TextFieldEditor") { prop
             attrs.value = props.getValue()
 
             // Notify EditableManager of changes as we type, but don't push them to the undo stack...
-            attrs.onChangeFunction = { event: Event ->
-                props.setValue(event.target.value)
-                props.editableManager.onChange(false)
-            }
+            attrs.onChangeFunction = handleChange
 
-            // ... until we lose focus; then, push to the undo stack only if the value would change.
-            attrs.onBlurFunction = { event: Event ->
-                val newValue = event.target.value
-                if (newValue != valueOnUndoStack.current) {
-                    valueOnUndoStack.current = newValue
-                    props.editableManager.onChange()
-                }
-            }
+            // ... until we lose focus or hit return; then, push to the undo stack only if the value would change.
+            attrs.onBlurFunction = handleBlur
+            attrs.onKeyDownFunction = handleKeyDown
         }
 
         props.helperText?.let { helperText ->

--- a/src/jsMain/kotlin/baaahs/ui/KeyboardShortcutHandler.kt
+++ b/src/jsMain/kotlin/baaahs/ui/KeyboardShortcutHandler.kt
@@ -1,0 +1,30 @@
+package baaahs.ui
+
+import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.HTMLTextAreaElement
+import org.w3c.dom.events.EventListener
+import org.w3c.dom.events.EventTarget
+import org.w3c.dom.events.KeyboardEvent
+
+class KeyboardShortcutHandler(private val handler: (event: KeyboardEvent) -> Unit) {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    private val handleKeyDown = { event: KeyboardEvent ->
+        when (event.target) {
+//            is HTMLButtonElement,
+            is HTMLInputElement,
+//            is HTMLSelectElement,
+//            is HTMLOptionElement,
+            is HTMLTextAreaElement -> {} // Ignore
+
+            else -> handler(event)
+        }
+    } as EventListener
+
+    fun listen(target: EventTarget) {
+        target.addEventListener("keydown", handleKeyDown)
+    }
+
+    fun unlisten(target: EventTarget) {
+        target.removeEventListener("keydown", handleKeyDown)
+    }
+}

--- a/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
@@ -116,6 +116,8 @@ class Visualizer(model: Model<*>): JsMapperUi.StatusListener {
         controls = OrbitControls(camera, container!!).apply {
             minPolarAngle = PI / 2 - .25 // radians
             maxPolarAngle = PI / 2 + .25 // radians
+
+            enableKeys = false
         }
 
         resize()

--- a/src/jsMain/kotlin/three/BufferGeometryUtils.kt
+++ b/src/jsMain/kotlin/three/BufferGeometryUtils.kt
@@ -16,5 +16,7 @@ open external class OrbitControls(camera: Any, thing: Any) {
     var minPolarAngle: Double
     var maxPolarAngle: Double
     var target: Any
+    var enableKeys: Boolean
+
     fun update()
 }


### PR DESCRIPTION
* Buttons can be toggle or momentary.
* Add property editors for button activation and button group title.
* Extract `KeyboardShortcutHandler` from `AppIndex`.
* Fix arrow key event stealing by `OrbitControls`.
* Right-justify dialog title actions (Undo/Redo).
* Handle dialog close by displaying snackbar (Apply/Abandon) if there are modifications.
* Push to undo stack on hitting return in text field.