### PR TITLE
Prep stuff for supporting moving heads

### DIFF
--- a/src/commonMain/kotlin/baaahs/BrainManager.kt
+++ b/src/commonMain/kotlin/baaahs/BrainManager.kt
@@ -1,0 +1,207 @@
+package baaahs
+
+import baaahs.fixtures.AnonymousFixture
+import baaahs.fixtures.Fixture
+import baaahs.fixtures.FixtureManager
+import baaahs.fixtures.IdentifiedFixture
+import baaahs.geom.Vector2F
+import baaahs.geom.Vector3F
+import baaahs.io.ByteArrayReader
+import baaahs.io.ByteArrayWriter
+import baaahs.mapper.MappingResults
+import baaahs.model.Model
+import baaahs.net.Network
+import baaahs.proto.*
+import baaahs.shaders.PixelBrainShader
+
+class BrainManager(
+    private val fixtureManager: FixtureManager,
+    private val firmwareDaddy: FirmwareDaddy,
+    private val model: Model<*>,
+    private val mappingResults: MappingResults,
+    private val udpSocket: Network.UdpSocket,
+    private val networkStats: Pinky.NetworkStats
+) {
+    internal val brainInfos: MutableMap<BrainId, BrainInfo> = mutableMapOf()
+    private val pendingBrainInfos: MutableMap<BrainId, BrainInfo> = mutableMapOf()
+    private val listeningVisualizers = hashSetOf<Pinky.ListeningVisualizer>()
+
+    val brainCount: Int
+        get() = brainInfos.size
+
+    /**
+     * Incorporate any pending brain changes.
+     *
+     * @return true if anything changed.
+     */
+    fun updateFixtures(): Boolean {
+        if (pendingBrainInfos.isEmpty())
+            return false
+
+        val brainFixturesToRemove = mutableListOf<ShowRunner.FixtureReceiver>()
+        val brainFixturesToAdd = mutableListOf<ShowRunner.FixtureReceiver>()
+
+        pendingBrainInfos.forEach { (brainId, incomingBrainInfo) ->
+            val priorBrainInfo = brainInfos[brainId]
+            if (priorBrainInfo != null) {
+                brainFixturesToRemove.add(priorBrainInfo.fixtureReceiver)
+            }
+
+            if (incomingBrainInfo.hadException) {
+                // Existing Brain has had exceptions so we're forgetting about it.
+                brainInfos.remove(brainId)
+            } else {
+                brainFixturesToAdd.add(incomingBrainInfo.fixtureReceiver)
+                brainInfos[brainId] = incomingBrainInfo
+            }
+        }
+
+        fixtureManager.fixturesChanged(brainFixturesToAdd, brainFixturesToRemove)
+        listeningVisualizers.forEach { listeningVisualizer ->
+            brainFixturesToAdd.forEach {
+                listeningVisualizer.sendPixelData(it.fixture)
+            }
+        }
+
+        pendingBrainInfos.clear()
+
+        return true
+    }
+
+    fun foundBrain(
+        brainAddress: Network.Address,
+        msg: BrainHelloMessage,
+        isSimulatedBrain: Boolean = false
+    ) {
+        val brainId = BrainId(msg.brainId)
+        val surfaceName = msg.surfaceName
+
+        Pinky.logger.debug {
+            "Hello from ${brainId.uuid}" +
+                    " (${mappingResults.dataFor(brainId)?.surface?.name ?: "[unknown]"})" +
+                    " at $brainAddress: $msg"
+        }
+        if (firmwareDaddy.doesntLikeThisVersion(msg.firmwareVersion)) {
+            // You need the new hotness bro
+            Pinky.logger.debug {
+                "The firmware daddy doesn't like $brainId" +
+                        " (${mappingResults.dataFor(brainId)?.surface?.name ?: "[unknown]"})" +
+                        " having ${msg.firmwareVersion}" +
+                        " so we'll send ${firmwareDaddy.urlForPreferredVersion}"
+            }
+            val newHotness = UseFirmwareMessage(firmwareDaddy.urlForPreferredVersion)
+            udpSocket.sendUdp(brainAddress, Ports.BRAIN, newHotness)
+        }
+
+
+        // println("Heard from brain $brainId at $brainAddress for $surfaceName")
+        val dataFor = mappingResults.dataFor(brainId)
+            ?: mappingResults.dataFor(msg.surfaceName ?: "__nope")
+            ?: msg.surfaceName?.let { MappingResults.Info(model.findModelSurface(it), null) }
+
+        val fixture = dataFor?.let {
+            val pixelLocations = dataFor.pixelLocations?.map { it ?: Vector3F(0f, 0f, 0f) } ?: emptyList()
+            val pixelCount = dataFor.pixelLocations?.size ?: SparkleMotion.MAX_PIXEL_COUNT
+
+            if (msg.surfaceName != dataFor.surface.name) {
+                val mappingMsg = BrainMappingMessage(
+                    brainId, dataFor.surface.name, null, Vector2F(0f, 0f),
+                    Vector2F(0f, 0f), pixelCount, pixelLocations
+                )
+                udpSocket.sendUdp(brainAddress, Ports.BRAIN, mappingMsg)
+            }
+
+            IdentifiedFixture(dataFor.surface, pixelCount, dataFor.pixelLocations)
+        } ?: AnonymousFixture(brainId)
+
+
+        val priorBrainInfo = brainInfos[brainId]
+        if (priorBrainInfo != null) {
+            if (priorBrainInfo.brainId == brainId && priorBrainInfo.fixture == fixture) {
+                // Duplicate packet?
+//                logger.debug(
+//                    "Ignore ${priorBrainInfo.brainId} ${priorBrainInfo.surface.describe()} ->" +
+//                            " ${surface.describe()} because probably duplicate?"
+//                )
+                return
+            }
+
+//            logger.debug(
+//                "Remapping ${priorBrainInfo.brainId} from ${priorBrainInfo.surface.describe()} ->" +
+//                        " ${surface.describe()}"
+//            )
+        }
+
+        val sendFn: (BrainShader.Buffer) -> Unit = { shaderBuffer ->
+            val message = BrainShaderMessage(shaderBuffer.brainShader, shaderBuffer).toBytes()
+            try {
+                if (!isSimulatedBrain)
+                    udpSocket.sendUdp(brainAddress, Ports.BRAIN, message)
+            } catch (e: Exception) {
+                // Couldn't send to Brain? Schedule to remove it.
+                val brainInfo = brainInfos[brainId]!!
+                brainInfo.hadException = true
+                pendingBrainInfos[brainId] = brainInfo
+
+                Pinky.logger.error("Error sending to $brainId, will take offline", e)
+            }
+
+            networkStats.packetsSent++
+            networkStats.bytesSent += message.size
+        }
+
+        val pixelShader = PixelBrainShader(PixelBrainShader.Encoding.DIRECT_RGB)
+        val fixtureReceiver = object : ShowRunner.FixtureReceiver {
+            override val fixture = fixture
+            private val pixelBuffer = pixelShader.createBuffer(fixture)
+
+            override fun send(pixels: Pixels) {
+                pixelBuffer.indices.forEach { i ->
+                    pixelBuffer.colors[i] = pixels[i]
+                }
+                sendFn(pixelBuffer)
+
+                updateListeningVisualizers(fixture, pixelBuffer.colors)
+            }
+        }
+
+        val brainInfo = BrainInfo(brainAddress, brainId, fixture, msg.firmwareVersion, msg.idfVersion, fixtureReceiver)
+//        logger.debug("Map ${brainInfo.brainId} to ${brainInfo.surface.describe()}")
+        pendingBrainInfos[brainId] = brainInfo
+
+        // Decide whether or not to tell this brain it should use a different firmware
+    }
+
+    /** If we want a pong back from a [BrainShaderMessage], send this. */
+    private fun generatePongPayload(): ByteArray {
+        return ByteArrayWriter().apply {
+            writeLong(getTimeMillis())
+        }.toBytes()
+    }
+
+    fun receivedPing(fromAddress: Network.Address, message: PingMessage) {
+        if (message.isPong) {
+            val originalSentAt = ByteArrayReader(message.data).readLong()
+            val elapsedMs = getTimeMillis() - originalSentAt
+            Pinky.logger.debug { "Shader pong from $fromAddress took ${elapsedMs}ms" }
+        }
+    }
+
+    fun addListeningVisualizer(listeningVisualizer: Pinky.ListeningVisualizer) {
+        listeningVisualizers.add(listeningVisualizer)
+
+        brainInfos.values.forEach { listeningVisualizer.sendPixelData(it.fixture) }
+    }
+
+    fun removeListeningVisualizer(listeningVisualizer: Pinky.ListeningVisualizer) {
+        listeningVisualizers.remove(listeningVisualizer)
+    }
+
+    private fun updateListeningVisualizers(fixture: Fixture, colors: List<Color>) {
+        if (listeningVisualizers.isNotEmpty()) {
+            listeningVisualizers.forEach {
+                it.sendFrame(fixture, colors)
+            }
+        }
+    }
+}

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -8,7 +8,7 @@ import baaahs.fixtures.IdentifiedFixture
 import baaahs.geom.Vector2F
 import baaahs.geom.Vector3F
 import baaahs.gl.glsl.CompilationException
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import baaahs.io.Fs
@@ -40,7 +40,7 @@ class Pinky(
     soundAnalyzer: SoundAnalyzer,
     private val switchShowAfterIdleSeconds: Int? = 600,
     private val adjustShowAfterIdleSeconds: Int? = null,
-    modelRenderer: ModelRenderer,
+    renderEngine: RenderEngine,
     val plugins: Plugins,
     val pinkyMainDispatcher: CoroutineDispatcher
 ) : CoroutineScope, Network.UdpListener {
@@ -60,10 +60,10 @@ class Pinky(
     private val pubSub: PubSub.Server = PubSub.Server(httpServer, coroutineContext)
 //    private val gadgetManager = GadgetManager(pubSub)
     private val movingHeadManager = MovingHeadManager(fs, pubSub, model.movingHeads)
-    internal val fixtureManager = FixtureManager(modelRenderer)
+    internal val fixtureManager = FixtureManager(renderEngine)
 
     var stageManager: StageManager = StageManager(
-        plugins, modelRenderer, pubSub, storage, fixtureManager, dmxUniverse, movingHeadManager, clock, model,
+        plugins, renderEngine, pubSub, storage, fixtureManager, dmxUniverse, movingHeadManager, clock, model,
         coroutineContext
     )
 

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -1,15 +1,12 @@
 package baaahs
 
 import baaahs.api.ws.WebSocketRouter
-import baaahs.fixtures.AnonymousFixture
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.FixtureManager
 import baaahs.fixtures.IdentifiedFixture
-import baaahs.geom.Vector2F
 import baaahs.geom.Vector3F
 import baaahs.gl.glsl.CompilationException
 import baaahs.gl.render.RenderEngine
-import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
 import baaahs.io.Fs
 import baaahs.mapper.MappingResults
@@ -21,7 +18,6 @@ import baaahs.net.FragmentingUdpLink
 import baaahs.net.Network
 import baaahs.plugin.Plugins
 import baaahs.proto.*
-import baaahs.shaders.PixelBrainShader
 import baaahs.show.Show
 import baaahs.util.Framerate
 import baaahs.util.Logger
@@ -46,7 +42,7 @@ class Pinky(
 ) : CoroutineScope, Network.UdpListener {
     val facade = Facade()
     private val storage = Storage(fs, plugins)
-    private lateinit var mappingResults: MappingResults
+    private val mappingResults = FutureMappingResults()
 
     private val link = FragmentingUdpLink(network.link("pinky"))
     val httpServer = link.startHttpServer(Ports.PINKY_UI_TCP)
@@ -73,8 +69,6 @@ class Pinky(
 
 //    private var selectedNewShowAt = DateTime.now()
 
-    private val brainInfos: MutableMap<BrainId, BrainInfo> = mutableMapOf()
-    private val pendingBrainInfos: MutableMap<BrainId, BrainInfo> = mutableMapOf()
     var pixelCount: Int = 0
 
     val address: Network.Address get() = link.myAddress
@@ -82,8 +76,8 @@ class Pinky(
 
     // This needs to go last-ish, otherwise we start getting network traffic too early.
     private val udpSocket = link.listenUdp(Ports.PINKY, this)
-
-    private val listeningVisualizers = hashSetOf<ListeningVisualizer>()
+    private val brainManager =
+        BrainManager(fixtureManager, firmwareDaddy, model, mappingResults, udpSocket, networkStats)
 
     private val serverNotices = arrayListOf<ServerNotice>()
     private val serverNoticesChannel = pubSub.publish(Topics.serverNotices, serverNotices) {
@@ -125,7 +119,7 @@ class Pinky(
         val fakeAddress = object : Network.Address {}
         val mappingInfos = (mappingResults as SessionMappingResults).brainData
         mappingInfos.forEach { (brainId, info) ->
-            foundBrain(
+            brainManager.foundBrain(
                 fakeAddress, BrainHelloMessage(brainId.uuid, info.surface.name, null, null),
                 isSimulatedBrain = true
             )
@@ -168,7 +162,7 @@ class Pinky(
             CoroutineScope(coroutineContext).launch {
                 launch { firmwareDaddy.start() }
                 launch { movingHeadManager.start() }
-                launch { mappingResults = storage.loadMappingData(model) }
+                launch { mappingResults.actualMappingResults = storage.loadMappingData(model) }
                 launch { loadConfig() }
             }.join()
 
@@ -189,9 +183,9 @@ class Pinky(
             launch {
                 while (true) {
                     if (mapperIsRunning) {
-                        logger.info { "Mapping ${brainInfos.size} brains..." }
+                        logger.info { "Mapping ${brainManager.brainCount} brains..." }
                     } else {
-                        logger.info { "Sending to ${brainInfos.size} brains..." }
+                        logger.info { "Sending to ${brainManager.brainCount} brains..." }
                     }
                     delay(10000)
                 }
@@ -222,34 +216,7 @@ class Pinky(
     }
 
     internal fun updateFixtures() {
-        if (pendingBrainInfos.isNotEmpty()) {
-            val brainFixturesToRemove = mutableListOf<ShowRunner.FixtureReceiver>()
-            val brainFixturesToAdd = mutableListOf<ShowRunner.FixtureReceiver>()
-
-            pendingBrainInfos.forEach { (brainId, incomingBrainInfo) ->
-                val priorBrainInfo = brainInfos[brainId]
-                if (priorBrainInfo != null) {
-                    brainFixturesToRemove.add(priorBrainInfo.fixtureReceiver)
-                }
-
-                if (incomingBrainInfo.hadException) {
-                    // Existing Brain has had exceptions so we're forgetting about it.
-                    brainInfos.remove(brainId)
-                } else {
-                    brainFixturesToAdd.add(incomingBrainInfo.fixtureReceiver)
-                    brainInfos[brainId] = incomingBrainInfo
-                }
-            }
-
-            fixtureManager.fixturesChanged(brainFixturesToAdd, brainFixturesToRemove)
-            listeningVisualizers.forEach { listeningVisualizer ->
-                brainFixturesToAdd.forEach {
-                    listeningVisualizer.sendPixelData(it.fixture)
-                }
-            }
-
-            pendingBrainInfos.clear()
-
+        if (brainManager.updateFixtures()) {
             facade.notifyChanged()
         }
     }
@@ -264,132 +231,14 @@ class Pinky(
         CoroutineScope(coroutineContext).launch {
             val message = parse(bytes)
             when (message) {
-                is BrainHelloMessage -> foundBrain(fromAddress, message)
+                is BrainHelloMessage -> brainManager.foundBrain(fromAddress, message)
+                is PingMessage -> brainManager.receivedPing(fromAddress, message)
                 is MapperHelloMessage -> {
                     logger.debug { "Mapper isRunning=${message.isRunning}" }
                     mapperIsRunning = message.isRunning
                 }
-                is PingMessage -> if (message.isPong) receivedPong(message, fromAddress)
             }
         }
-    }
-
-    private fun foundBrain(
-        brainAddress: Network.Address,
-        msg: BrainHelloMessage,
-        isSimulatedBrain: Boolean = false
-    ) {
-        val brainId = BrainId(msg.brainId)
-        val surfaceName = msg.surfaceName
-
-        logger.debug {
-            "Hello from ${brainId.uuid}" +
-                    " (${mappingResults.dataFor(brainId)?.surface?.name ?: "[unknown]"})" +
-                    " at $brainAddress: $msg"
-        }
-        if (firmwareDaddy.doesntLikeThisVersion(msg.firmwareVersion)) {
-            // You need the new hotness bro
-            logger.debug {
-                "The firmware daddy doesn't like $brainId" +
-                        " (${mappingResults.dataFor(brainId)?.surface?.name ?: "[unknown]"})" +
-                        " having ${msg.firmwareVersion}" +
-                        " so we'll send ${firmwareDaddy.urlForPreferredVersion}"
-            }
-            val newHotness = UseFirmwareMessage(firmwareDaddy.urlForPreferredVersion)
-            udpSocket.sendUdp(brainAddress, Ports.BRAIN, newHotness)
-        }
-
-
-        // println("Heard from brain $brainId at $brainAddress for $surfaceName")
-        val dataFor = mappingResults.dataFor(brainId)
-            ?: mappingResults.dataFor(msg.surfaceName ?: "__nope")
-            ?: msg.surfaceName?.let { MappingResults.Info(model.findModelSurface(it), null) }
-
-        val fixture = dataFor?.let {
-            val pixelLocations = dataFor.pixelLocations?.map { it ?: Vector3F(0f, 0f, 0f) } ?: emptyList()
-            val pixelCount = dataFor.pixelLocations?.size ?: SparkleMotion.MAX_PIXEL_COUNT
-
-            if (msg.surfaceName != dataFor.surface.name) {
-                val mappingMsg = BrainMappingMessage(
-                    brainId, dataFor.surface.name, null, Vector2F(0f, 0f),
-                    Vector2F(0f, 0f), pixelCount, pixelLocations
-                )
-                udpSocket.sendUdp(brainAddress, Ports.BRAIN, mappingMsg)
-            }
-
-            IdentifiedFixture(dataFor.surface, pixelCount, dataFor.pixelLocations)
-        } ?: AnonymousFixture(brainId)
-
-
-        val priorBrainInfo = brainInfos[brainId]
-        if (priorBrainInfo != null) {
-            if (priorBrainInfo.brainId == brainId && priorBrainInfo.fixture == fixture) {
-                // Duplicate packet?
-//                logger.debug(
-//                    "Ignore ${priorBrainInfo.brainId} ${priorBrainInfo.surface.describe()} ->" +
-//                            " ${surface.describe()} because probably duplicate?"
-//                )
-                return
-            }
-
-//            logger.debug(
-//                "Remapping ${priorBrainInfo.brainId} from ${priorBrainInfo.surface.describe()} ->" +
-//                        " ${surface.describe()}"
-//            )
-        }
-
-        val sendFn: (BrainShader.Buffer) -> Unit = { shaderBuffer ->
-            val message = BrainShaderMessage(shaderBuffer.brainShader, shaderBuffer).toBytes()
-            try {
-                if (!isSimulatedBrain)
-                    udpSocket.sendUdp(brainAddress, Ports.BRAIN, message)
-            } catch (e: Exception) {
-                // Couldn't send to Brain? Schedule to remove it.
-                val brainInfo = brainInfos[brainId]!!
-                brainInfo.hadException = true
-                pendingBrainInfos[brainId] = brainInfo
-
-                logger.error("Error sending to $brainId, will take offline", e)
-            }
-
-            networkStats.packetsSent++
-            networkStats.bytesSent += message.size
-        }
-
-        val pixelShader = PixelBrainShader(PixelBrainShader.Encoding.DIRECT_RGB)
-        val fixtureReceiver = object : ShowRunner.FixtureReceiver {
-            override val fixture = fixture
-            private val pixelBuffer = pixelShader.createBuffer(fixture)
-
-            override fun send(pixels: Pixels) {
-                pixelBuffer.indices.forEach { i ->
-                    pixelBuffer.colors[i] = pixels[i]
-                }
-                sendFn(pixelBuffer)
-
-                updateListeningVisualizers(fixture, pixelBuffer.colors)
-            }
-        }
-
-        val brainInfo = BrainInfo(brainAddress, brainId, fixture, msg.firmwareVersion, msg.idfVersion, fixtureReceiver)
-//        logger.debug("Map ${brainInfo.brainId} to ${brainInfo.surface.describe()}")
-        pendingBrainInfos[brainId] = brainInfo
-
-        // Decide whether or not to tell this brain it should use a different firmware
-
-    }
-
-    /** If we want a pong back from a [BrainShaderMessage], send this. */
-    private fun generatePongPayload(): ByteArray {
-        return ByteArrayWriter().apply {
-            writeLong(getTimeMillis())
-        }.toBytes()
-    }
-
-    private fun receivedPong(message: PingMessage, fromAddress: Network.Address) {
-        val originalSentAt = ByteArrayReader(message.data).readLong()
-        val elapsedMs = getTimeMillis() - originalSentAt
-        logger.debug { "Shader pong from $fromAddress took ${elapsedMs}ms" }
     }
 
     inner class PinkyBeatDisplayer(private val beatSource: BeatSource) {
@@ -420,9 +269,7 @@ class Pinky(
 
         override fun connected(tcpConnection: Network.TcpConnection) {
             this.tcpConnection = tcpConnection
-            listeningVisualizers.add(this)
-
-            brainInfos.values.forEach { sendPixelData(it.fixture) }
+            brainManager.addListeningVisualizer(this)
         }
 
         override fun receive(tcpConnection: Network.TcpConnection, bytes: ByteArray) {
@@ -430,7 +277,7 @@ class Pinky(
         }
 
         override fun reset(tcpConnection: Network.TcpConnection) {
-            listeningVisualizers.remove(this)
+            brainManager.removeListeningVisualizer(this)
         }
 
         fun sendPixelData(fixture: Fixture) {
@@ -458,14 +305,6 @@ class Pinky(
                     it.serializeWithoutAlpha(out)
                 }
                 tcpConnection.send(out.toBytes())
-            }
-        }
-    }
-
-    private fun updateListeningVisualizers(fixture: Fixture, colors: List<Color>) {
-        if (listeningVisualizers.isNotEmpty()) {
-            listeningVisualizers.forEach {
-                it.sendFrame(fixture, colors)
             }
         }
     }
@@ -512,7 +351,7 @@ class Pinky(
             get() = this@Pinky.networkStats
 
         val brains: List<BrainInfo>
-            get() = this@Pinky.brainInfos.values.toList()
+            get() = this@Pinky.brainManager.brainInfos.values.toList()
 
         val beatData: BeatData
             get() = this@Pinky.beatSource.getBeatData()
@@ -549,4 +388,22 @@ enum class PinkyState {
     Initializing,
     Running,
     ShuttingDown
+}
+
+private class FutureMappingResults : MappingResults {
+    var actualMappingResults: MappingResults? = null
+
+    override fun dataFor(brainId: BrainId): MappingResults.Info? {
+        if (actualMappingResults == null) {
+            Pinky.logger.warn { "Mapping results for $brainId requested before available." }
+        }
+        return actualMappingResults?.dataFor(brainId)
+    }
+
+    override fun dataFor(surfaceName: String): MappingResults.Info? {
+        if (actualMappingResults == null) {
+            Pinky.logger.warn { "Mapping results for $surfaceName requested before available." }
+        }
+        return actualMappingResults?.dataFor(surfaceName)
+    }
 }

--- a/src/commonMain/kotlin/baaahs/ShowPlayer.kt
+++ b/src/commonMain/kotlin/baaahs/ShowPlayer.kt
@@ -28,6 +28,7 @@ interface ShowPlayer {
         return try {
             openShader(shader, addToCache)
         } catch (e: AnalysisException) {
+            logger.debug(e) { "Failed to analyze shader \"${shader.title}\"" }
             null
         }
     }
@@ -37,6 +38,10 @@ interface ShowPlayer {
         ShowOpener(GlslAnalyzer(plugins), show, this).openShow(showState)
 
     fun releaseUnused()
+
+    companion object {
+        private val logger = Logger("ShowPlayer")
+    }
 }
 
 abstract class BaseShowPlayer(

--- a/src/commonMain/kotlin/baaahs/ShowPlayer.kt
+++ b/src/commonMain/kotlin/baaahs/ShowPlayer.kt
@@ -12,6 +12,7 @@ import baaahs.show.Shader
 import baaahs.show.Show
 import baaahs.show.live.OpenShow
 import baaahs.show.live.ShowOpener
+import baaahs.util.Logger
 
 interface ShowPlayer {
     val plugins: Plugins

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -6,7 +6,7 @@ import baaahs.gl.glsl.CompilationException
 import baaahs.gl.glsl.GlslException
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.ContentType
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.glsl.GuruMeditationError
 import baaahs.show.ShaderChannel
 import baaahs.show.Show
@@ -22,7 +22,7 @@ class ShowRunner(
 //    private val dmxUniverse: Dmx.Universe,
 //    private val movingHeadManager: MovingHeadManager,
     internal val clock: Clock,
-    private val modelRenderer: ModelRenderer,
+    private val renderEngine: RenderEngine,
     private val fixtureManager: FixtureManager,
     private val autoWirer: AutoWirer
 ) {
@@ -66,7 +66,7 @@ class ShowRunner(
     /** @return `true` if a frame was rendered and should be sent to fixtures. */
     fun renderNextFrame(): Boolean {
         return if (currentRenderPlan != null) {
-            modelRenderer.draw()
+            renderEngine.draw()
             true
         } else false
     }
@@ -128,7 +128,7 @@ class ShowRunner(
             val linkedPatches = autoWirer.merge(*activePatchHolders.toTypedArray()).mapValues { (_, portDiagram) ->
                 portDiagram.resolvePatch(ShaderChannel.Main, ContentType.ColorStream)
             }
-            val glslContext = modelRenderer.gl
+            val glslContext = renderEngine.gl
             val activeDataSources = mutableSetOf<String>()
             val programs = linkedPatches.mapNotNull { (_, linkedPatch) ->
                 linkedPatch?.let { it to it.createProgram(glslContext, openShow.dataFeeds) }
@@ -139,7 +139,7 @@ class ShowRunner(
             if (e is CompilationException) {
                 e.source?.let { logger.info { it } }
             }
-            return GuruMeditationError.createRenderPlan(modelRenderer.gl)
+            return GuruMeditationError.createRenderPlan(renderEngine.gl)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/StageManager.kt
+++ b/src/commonMain/kotlin/baaahs/StageManager.kt
@@ -5,7 +5,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.LinkedPatch
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.io.Fs
 import baaahs.io.FsServerSideSerializer
 import baaahs.io.PubSubRemoteFsServerBackend
@@ -28,7 +28,7 @@ import kotlin.coroutines.CoroutineContext
 
 class StageManager(
     plugins: Plugins,
-    private val modelRenderer: ModelRenderer,
+    private val renderEngine: RenderEngine,
     private val pubSub: PubSub.Server,
     private val storage: Storage,
     private val fixtureManager: FixtureManager,
@@ -41,7 +41,7 @@ class StageManager(
     val facade = Facade()
     private val autoWirer = AutoWirer(plugins)
     override val glContext: GlContext
-        get() = modelRenderer.gl
+        get() = renderEngine.gl
     private var showRunner: ShowRunner? = null
     private val gadgets: MutableMap<String, GadgetManager.GadgetInfo> = mutableMapOf()
     var lastUserInteraction = DateTime.now()
@@ -116,7 +116,7 @@ class StageManager(
     ) {
         val newShowRunner = newShow?.let {
             val openShow = openShow(newShow, newShowState)
-            ShowRunner(newShow, newShowState, openShow, clock, modelRenderer, fixtureManager, autoWirer)
+            ShowRunner(newShow, newShowState, openShow, clock, renderEngine, fixtureManager, autoWirer)
         }
 
         showRunner?.release()

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -6,10 +6,10 @@ import baaahs.ShowRunner
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.render.FixtureRenderPlan
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 
 class FixtureManager(
-    private val modelRenderer: ModelRenderer
+    private val renderEngine: RenderEngine
 ) {
     private val changedFixtures = mutableListOf<ShowRunner.FixturesChanges>()
     private val fixtureRenderPlans: MutableMap<Fixture, FixtureRenderPlan> = hashMapOf()
@@ -72,7 +72,7 @@ class FixtureManager(
     private fun addReceiver(receiver: ShowRunner.FixtureReceiver) {
         val fixture = receiver.fixture
         val fixtureRenderPlan = fixtureRenderPlans.getOrPut(fixture) {
-            modelRenderer.addFixture(fixture)
+            renderEngine.addFixture(fixture)
         }
         fixtureRenderPlan.receivers.add(receiver)
 
@@ -89,7 +89,7 @@ class FixtureManager(
         }
 
         if (fixtureRenderPlan.receivers.isEmpty()) {
-            modelRenderer.removeFixture(fixtureRenderPlan)
+            renderEngine.removeFixture(fixtureRenderPlan)
             fixtureRenderPlan.release()
             fixtureRenderPlans.remove(fixture)
         }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
@@ -4,7 +4,7 @@ import baaahs.RefCounted
 import baaahs.RefCounter
 import baaahs.gl.GlContext
 import baaahs.gl.patch.LinkedPatch
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.glsl.Uniform
 import baaahs.show.DataSource
 import baaahs.show.OutputPortRef
@@ -42,7 +42,7 @@ class GlslProgram(
             .filterIsInstance<T>()
     }
 
-    val arrangementListeners: List<ModelRenderer.ArrangementListener>
+    val arrangementListeners: List<RenderEngine.ArrangementListener>
         get() = bindingsOf()
 
     val resolutionListeners: List<ResolutionListener>

--- a/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
@@ -50,8 +50,7 @@ class AutoWirer(
                 val unresolvedShaderInstance = UnresolvedShaderInstance(
                     MutableShader(openShader.shader),
                     openShader.inputPorts
-                        .map { it.id }
-                        .associateWith { hashSetOf<MutablePort>() },
+                        .associateWith { hashSetOf() },
                     shaderChannel,
                     0f
                 )
@@ -77,8 +76,7 @@ class AutoWirer(
             openShader.inputPorts.forEach { inputPort ->
                 val suggestions = collectLinkOptions(inputPort, locallyAvailable)
 
-                unresolvedShaderInstance.incomingLinksOptions
-                    .getBang(inputPort.id, "port")
+                unresolvedShaderInstance.linkOptionsFor(inputPort)
                     .addAll(suggestions.filter {
                         // Don't suggest linking back to ourself.
                         !(it is UnresolvedShaderOutPort &&

--- a/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
@@ -2,6 +2,7 @@ package baaahs.gl.patch
 
 import baaahs.show.Shader
 import baaahs.show.Surfaces
+import baaahs.show.mutable.MutableConstPort
 import baaahs.show.mutable.MutablePatch
 import baaahs.show.mutable.MutableShaderChannel
 import baaahs.show.mutable.MutableShaderInstance
@@ -29,8 +30,10 @@ class UnresolvedPatch(private val unresolvedShaderInstances: List<UnresolvedShad
         val shaderInstances = unresolvedShaderInstances.associate {
             it.mutableShader.build() to MutableShaderInstance(
                 it.mutableShader,
-                it.incomingLinksOptions.mapValues { (_, fromPortOptions) ->
-                    fromPortOptions.first()
+                it.incomingLinksOptions.entries.associate { (port, fromPortOptions) ->
+                    port.id to
+                            (fromPortOptions.firstOrNull()
+                                ?: MutableConstPort(port.type.defaultInitializer()))
                 }.toMutableMap(),
                 MutableShaderChannel(it.shaderChannel.id),
                 it.priority

--- a/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedShaderInstance.kt
@@ -1,13 +1,15 @@
 package baaahs.gl.patch
 
+import baaahs.gl.shader.InputPort
 import baaahs.show.ShaderChannel
 import baaahs.show.mutable.MutablePort
 import baaahs.show.mutable.MutableShader
 import baaahs.show.mutable.MutableShaderChannel
+import baaahs.unknown
 
 class UnresolvedShaderInstance(
     val mutableShader: MutableShader,
-    val incomingLinksOptions: Map<String, MutableSet<MutablePort>>,
+    val incomingLinksOptions: Map<InputPort, MutableSet<MutablePort>>,
     var shaderChannel: ShaderChannel = ShaderChannel.Main,
     var priority: Float
 ) {
@@ -31,6 +33,15 @@ class UnresolvedShaderInstance(
             }
         }
     }
+
+    fun linkOptionsFor(portId: String): MutableSet<MutablePort> {
+        val key = incomingLinksOptions.keys.find { it.id == portId }
+            ?: throw error(unknown("port", portId, incomingLinksOptions.keys.map { it.id }))
+        return linkOptionsFor(key)
+    }
+
+    fun linkOptionsFor(inputPort: InputPort) =
+        incomingLinksOptions.getValue(inputPort)
 
     override fun toString(): String {
         return "UnresolvedShaderInstance(shader=${mutableShader.title})"

--- a/src/commonMain/kotlin/baaahs/gl/render/FixtureRenderPlan.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/FixtureRenderPlan.kt
@@ -30,12 +30,12 @@ class FixtureRenderPlan(
 }
 
 class FixturePixels(
-    private val modelRenderer: ModelRenderer,
+    private val renderEngine: RenderEngine,
     override val size: Int,
     override val bufferOffset: Int
 ) : Pixels, RenderResult {
     override fun get(i: Int): Color {
-        val pixelBuffer = modelRenderer.arrangement.resultBuffer as ByteBuffer
+        val pixelBuffer = renderEngine.arrangement.resultBuffer as ByteBuffer
         val offset = (bufferOffset + i) * 4
         return Color(
             red = pixelBuffer[offset],

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
@@ -3,7 +3,7 @@ package baaahs.gl.render
 import baaahs.fixtures.Fixture
 import baaahs.geom.Vector3F
 import baaahs.gl.GlContext
-import baaahs.gl.render.ModelRenderer.GlConst.GL_RGBA8
+import baaahs.gl.render.RenderEngine.GlConst.GL_RGBA8
 import baaahs.glsl.LinearSurfacePixelStrategy
 import baaahs.model.ModelInfo
 import baaahs.timeSync
@@ -12,7 +12,7 @@ import com.danielgergely.kgl.*
 import kotlin.math.max
 import kotlin.math.min
 
-open class ModelRenderer(
+open class RenderEngine(
     val gl: GlContext,
     private val modelInfo: ModelInfo,
     private val resultFormat: ResultFormat = BytesResultFormat
@@ -155,7 +155,7 @@ open class ModelRenderer(
     }
 
     companion object {
-        private val logger = Logger("GlslRenderer")
+        private val logger = Logger("RenderEngine")
 
         /** Resulting Rect is in pixel coordinates starting at (0,0) with Y increasing. */
         internal fun mapFixturePixelsToRects(nextPix: Int, pixWidth: Int, fixture: Fixture): List<Quad.Rect> {
@@ -295,7 +295,7 @@ open class ModelRenderer(
         val readPixelFormat: Int
         val readType: Int
 
-        fun createRenderResult(modelRenderer: ModelRenderer, size: Int, nextPixelOffset: Int): RenderResult
+        fun createRenderResult(renderEngine: RenderEngine, size: Int, nextPixelOffset: Int): RenderResult
         fun createBuffer(size: Int): Buffer
     }
 
@@ -307,8 +307,8 @@ open class ModelRenderer(
         override val readType: Int
             get() = GL_UNSIGNED_BYTE
 
-        override fun createRenderResult(modelRenderer: ModelRenderer, size: Int, nextPixelOffset: Int): RenderResult {
-            return FixturePixels(modelRenderer, size, nextPixelOffset)
+        override fun createRenderResult(renderEngine: RenderEngine, size: Int, nextPixelOffset: Int): RenderResult {
+            return FixturePixels(renderEngine, size, nextPixelOffset)
         }
 
         override fun createBuffer(size: Int): Buffer {

--- a/src/commonMain/kotlin/baaahs/model/ObjModel.kt
+++ b/src/commonMain/kotlin/baaahs/model/ObjModel.kt
@@ -5,18 +5,17 @@ import baaahs.getResource
 import baaahs.util.Logger
 
 abstract class ObjModel<T : Model.Surface>(val objResourceName: String) : Model<T>() {
+    override val movingHeads: List<MovingHead>
+        get() = emptyList()
     override val geomVertices: List<Vector3F> get() = vertices
     lateinit var vertices: List<Vector3F>
     lateinit var panels: List<T>
-
-    lateinit var eyes: List<MovingHead>
 
     val allPanels: List<T>
         get() = panels
     val partySide: List<T>
         get() = panels.filter { panel -> Regex("P$").matches(panel.name) }
 
-    override val movingHeads: List<MovingHead> get() = eyes
     override val allSurfaces get() = allPanels
     lateinit var surfaceNeighbors: Map<T, List<T>>
     private val surfacesByName = mutableMapOf<String, T>()
@@ -96,17 +95,6 @@ abstract class ObjModel<T : Model.Surface>(val objResourceName: String) : Model<
         }
 
         surfaceNeighbors = allPanels.associateWith { neighborsOf(it) }
-
-        eyes = arrayListOf(
-            MovingHead(
-                "leftEye",
-                Vector3F(0f, 204.361f, 48.738f)
-            ),
-            MovingHead(
-                "rightEye",
-                Vector3F(0f, 204.361f, -153.738f)
-            )
-        )
     }
 
     fun neighborsOf(panel: T) = surfaceNeighbors[panel] ?: emptyList()

--- a/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
@@ -10,7 +10,7 @@ import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslProgram.DataFeed
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.gl.shader.InputPort
 import baaahs.glsl.Uniform
 import baaahs.show.DataSource
@@ -194,12 +194,12 @@ class CorePlugin : Plugin {
         override fun suggestId(): String = "pixelCoordsTexture"
 
         override fun createFeed(showPlayer: ShowPlayer, plugin: Plugin, id: String): DataFeed =
-            object : DataFeed, ModelRenderer.ArrangementListener, RefCounted by RefCounter() {
+            object : DataFeed, RenderEngine.ArrangementListener, RefCounted by RefCounter() {
                 private val gl = showPlayer.glContext
                 private val uvCoordTextureUnit = gl.getTextureUnit(PixelCoordsTextureDataSource::class)
                 private val uvCoordTexture = gl.check { createTexture() }
 
-                override fun onArrangementChange(arrangement: ModelRenderer.Arrangement) {
+                override fun onArrangementChange(arrangement: RenderEngine.Arrangement) {
                     if (arrangement.pixelCoords.isEmpty()) return
 
                     val pixWidth = arrangement.pixWidth

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -1,7 +1,6 @@
 package baaahs.show
 
 import baaahs.Color
-import baaahs.getBang
 import baaahs.gl.patch.AutoWirer
 import baaahs.glsl.Shaders
 import baaahs.plugin.CorePlugin
@@ -231,7 +230,7 @@ object SampleData {
         val unresolvedPatch = autoWirer.autoWire(shader)
         unresolvedPatch.editShader(shader).apply {
             ports.forEach { (portId, port) ->
-                incomingLinksOptions.getBang(portId, "port").apply {
+                linkOptionsFor(portId).apply {
                     clear()
                     add(port)
                 }

--- a/src/commonTest/kotlin/baaahs/PinkySpec.kt
+++ b/src/commonTest/kotlin/baaahs/PinkySpec.kt
@@ -4,7 +4,7 @@ import baaahs.fixtures.AnonymousFixture
 import baaahs.fixtures.IdentifiedFixture
 import baaahs.geom.Matrix4
 import baaahs.gl.override
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.mapper.MappingSession
 import baaahs.mapper.Storage
 import baaahs.model.Model
@@ -49,7 +49,7 @@ object PinkySpec : Spek({
                 fakeFs,
                 PermissiveFirmwareDaddy(),
                 StubSoundAnalyzer(),
-                modelRenderer = ModelRenderer(fakeGlslContext, ModelInfo.Empty),
+                renderEngine = RenderEngine(fakeGlslContext, ModelInfo.Empty),
                 plugins = Plugins.safe(),
                 pinkyMainDispatcher = object : CoroutineDispatcher() {
                     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/src/commonTest/kotlin/baaahs/PinkySpec.kt
+++ b/src/commonTest/kotlin/baaahs/PinkySpec.kt
@@ -36,7 +36,7 @@ object PinkySpec : Spek({
         val clientPort = 1234
 
         val panel17 = SheepModel.Panel("17")
-        val model = SheepModel().apply { panels = listOf(panel17); eyes = emptyList() } as Model<*>
+        val model = SheepModel().apply { panels = listOf(panel17) } as Model<*>
 
         val fakeFs by value { FakeFs() }
         val pinky by value {

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -6,7 +6,7 @@ import baaahs.fixtures.FixtureManager
 import baaahs.fixtures.IdentifiedFixture
 import baaahs.gadgets.Slider
 import baaahs.gl.render.FixtureRenderPlan
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.mapper.Storage
 import baaahs.model.ModelInfo
 import baaahs.models.SheepModel
@@ -53,11 +53,11 @@ class ShowRunnerTest {
         fakeGlslContext = FakeGlContext()
         dmxUniverse = FakeDmxUniverse()
         dmxUniverse.reader(1, 1) { dmxEvents.add("dmx frame sent") }
-        val glslRenderer = ModelRenderer(fakeGlslContext, ModelInfo.Empty)
-        fixtureManager = FixtureManager(glslRenderer)
+        val renderEngine = RenderEngine(fakeGlslContext, ModelInfo.Empty)
+        fixtureManager = FixtureManager(renderEngine)
         val movingHeadManager = MovingHeadManager(fs, server, emptyList())
         stageManager = StageManager(
-            Plugins.safe(), glslRenderer, server, Storage(fs, Plugins.safe()), fixtureManager,
+            Plugins.safe(), renderEngine, server, Storage(fs, Plugins.safe()), fixtureManager,
             dmxUniverse, movingHeadManager, FakeClock(), sheepModel, testCoroutineContext
         )
         stageManager.switchTo(SampleData.sampleShow)

--- a/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
@@ -1,7 +1,7 @@
 package baaahs
 
 import baaahs.fixtures.FixtureManager
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.io.FakeRemoteFsBackend
 import baaahs.io.FsClientSideSerializer
 import baaahs.mapper.Storage
@@ -31,16 +31,16 @@ object StageManagerSpec : Spek({
         val fakeFs by value { FakeFs() }
         val pubSub by value { TestPubSub() }
         val fakeGlslContext by value { FakeGlContext() }
-        val modelRenderer by value { ModelRenderer(fakeGlslContext, ModelInfo.Empty) }
+        val renderEngine by value { RenderEngine(fakeGlslContext, ModelInfo.Empty) }
         val baseShow by value { SampleData.sampleShow }
 
         val stageManager by value {
             StageManager(
                 plugins,
-                modelRenderer,
+                renderEngine,
                 pubSub.server,
                 Storage(fakeFs, plugins),
-                FixtureManager(modelRenderer),
+                FixtureManager(renderEngine),
                 FakeDmxUniverse(),
                 MovingHeadManager(fakeFs, pubSub.server, emptyList()),
                 FakeClock(),

--- a/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
@@ -25,7 +25,7 @@ import kotlin.test.expect
 object StageManagerSpec : Spek({
     describe<StageManager> {
         val panel17 = SheepModel.Panel("17")
-        val model = SheepModel().apply { panels = listOf(panel17); eyes = emptyList() } as Model<*>
+        val model = SheepModel().apply { panels = listOf(panel17) } as Model<*>
 
         val plugins by value { Plugins.safe() }
         val fakeFs by value { FakeFs() }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -39,10 +39,12 @@ object GlslAnalyzerSpec : Spek({
                     //   key2=value2
                     uniform vec2  resolution;
                     
-                    struct MovingHead {
+                    // @@AnotherClass key=value key2=value2
+                    uniform struct MovingHead {
                         float pan;
                         float tilt;
-                    };
+                    } leftEye;
+
                     void mainFunc( out vec4 fragColor, in vec2 fragCoord )
                     {
                         vec2 uv = fragCoord.xy / resolution.xy;
@@ -76,22 +78,23 @@ object GlslAnalyzerSpec : Spek({
                                 comments = listOf(" @@HintClass", "   key=value", "   key2=value2")
                             ),
                             GlslStatement(
-                                "struct MovingHead {\n" +
+                                "uniform struct MovingHead {\n" +
                                         "    float pan;\n" +
                                         "    float tilt;\n" +
-                                        "};", lineNumber = 12
+                                        "} leftEye;", lineNumber = 12,
+                                comments = listOf("@@AnotherClass key=value key2=value2")
                             ),
                             GlslStatement(
                                 "void mainFunc( out vec4 fragColor, in vec2 fragCoord )\n" +
                                         "{\n" +
                                         "    vec2 uv = fragCoord.xy / resolution.xy;\n" +
                                         "    fragColor = vec4(uv.xy, 0., 1.);\n" +
-                                        "}", lineNumber = 16
+                                        "}", lineNumber = 18
                             ),
                             GlslStatement(
                                 "void main() {\n" +
                                         "    mainFunc(gl_FragColor, gl_FragCoord);\n" +
-                                        "}", lineNumber = 22
+                                        "}", lineNumber = 24
                             )
                         ), { glslAnalyzer.findStatements(shaderText) }, true
                     )
@@ -109,6 +112,12 @@ object GlslAnalyzerSpec : Spek({
                                 GlslType.Vec2, "resolution",
                                 fullText = " \n\n\n\nuniform vec2  resolution;", isUniform = true, lineNumber = 5,
                                 comments = listOf(" @@HintClass", "   key=value", "   key2=value2")
+                            ),
+                            GlslCode.GlslVar(
+                                GlslType.from("struct MovingHead {\n    float pan;\n    float tilt;\n}"),
+                                "leftEye",
+                                fullText = "uniform MovingHead leftEye;", lineNumber = 12,
+                                comments = listOf(" @@AnotherClass key=value key2=value2")
                             )
                         )
                     ) { glslCode.globalVars.toList() }
@@ -126,7 +135,7 @@ object GlslAnalyzerSpec : Spek({
                 it("finds the structs") {
                     expect(
                         listOf(
-                            "struct MovingHead {\n    float pan;\n    float tilt;\n};"
+                            "\nuniform struct MovingHead {\n    float pan;\n    float tilt;\n} leftEye;"
                         )
                     ) { glslCode.structs.map { it.fullText } }
                 }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslCodeSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslCodeSpec.kt
@@ -65,13 +65,48 @@ object GlslCodeSpec : Spek({
         context("struct") {
             val struct by value { statement.asStructOrNull() }
 
-            context("uniform") {
-                override(text) { "struct MovingHead {\n  float pan;\n  float tilt;\n};" }
-                expectValue(
+            override(text) {
+                """
+                        struct MovingHead {
+                            float pan; // in radians
+                            float tilt; // in radians
+                        };
+                    """.trimIndent()
+            }
+
+            it("should return a GlslStruct") {
+                expect(
                     GlslCode.GlslStruct(
-                        "MovingHead", "struct MovingHead {\n  float pan;\n  float tilt;\n};"
+                        "MovingHead",
+                        mapOf("pan" to GlslType.Float, "tilt" to GlslType.Float),
+                        null,
+                        false,
+                        text
                     )
                 ) { struct }
+            }
+
+            context("also declaring a variable") {
+                override(text) {
+                    """
+                        struct MovingHead {
+                            float pan; // in radians
+                            float tilt; // in radians
+                        } movingHead;
+                    """.trimIndent()
+                }
+
+                it("should return a GlslStruct") {
+                    expect(
+                        GlslCode.GlslStruct(
+                            "MovingHead",
+                            mapOf("pan" to GlslType.Float, "tilt" to GlslType.Float),
+                            "movingHead",
+                            false,
+                            text
+                        )
+                    ) { struct }
+                }
             }
         }
     }

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
@@ -22,7 +22,7 @@ import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.*
 
-class ModelRendererTest {
+class RenderEngineTest {
     // assumeTrue() doesn't work in js runners; instead, bail manually.
     // TODO: Do something better.
 //    @BeforeTest
@@ -37,14 +37,14 @@ class ModelRendererTest {
     }
 
     private lateinit var glContext: GlContext
-    private lateinit var modelRenderer: ModelRenderer
+    private lateinit var renderEngine: RenderEngine
     private lateinit var fakeShowPlayer: FakeShowPlayer
 
     @BeforeTest
     fun setUp() {
         if (glslAvailable()) {
             glContext = GlBase.manager.createContext()
-            modelRenderer = ModelRenderer(glContext, ModelInfoForTest)
+            renderEngine = RenderEngine(glContext, ModelInfoForTest)
             fakeShowPlayer = FakeShowPlayer(glContext)
         }
     }
@@ -53,7 +53,7 @@ class ModelRendererTest {
     fun tearDown() {
         if (glslAvailable()) {
             glContext.release()
-            modelRenderer.release()
+            renderEngine.release()
         }
     }
 
@@ -73,9 +73,9 @@ class ModelRendererTest {
             """.trimIndent()
 
         val glslProgram = compileAndBind(program)
-        val fixtureRenderPlan = modelRenderer.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan = renderEngine.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
 
-        modelRenderer.draw()
+        renderEngine.draw()
 
         expectColor(listOf(
             Color(0f, .1f, .5f),
@@ -102,7 +102,7 @@ class ModelRendererTest {
             """.trimIndent()
 
         val glslProgram = compileAndBind(program)
-        val fixtureRenderPlan = modelRenderer.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan = renderEngine.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
 
         fakeShowPlayer.getGadget<Slider>("glsl_in_blue").value = .1f
         fakeShowPlayer.drawFrame()
@@ -138,11 +138,11 @@ class ModelRendererTest {
 
         val glslProgram = compileAndBind(program)
 
-        val fixtureRenderPlan1 = modelRenderer.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
-        val fixtureRenderPlan2 = modelRenderer.addFixture(identifiedSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
-        val fixtureRenderPlan3 = modelRenderer.addFixture(anonymousSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan1 = renderEngine.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan2 = renderEngine.addFixture(identifiedSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan3 = renderEngine.addFixture(anonymousSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
 
-        modelRenderer.draw()
+        renderEngine.draw()
 
         expectColor(listOf(
             Color(0f, .1f, .5f),
@@ -184,14 +184,14 @@ class ModelRendererTest {
 
         val glslProgram = compileAndBind(program)
 
-        val fixtureRenderPlan1 = modelRenderer.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
-        val fixtureRenderPlan2 = modelRenderer.addFixture(identifiedSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan1 = renderEngine.addFixture(surfaceWithThreePixels()).apply { this.program = glslProgram }
+        val fixtureRenderPlan2 = renderEngine.addFixture(identifiedSurfaceWithThreeUnmappedPixels()).apply { this.program = glslProgram }
 
         // TODO: yuck, let's not do this [first part]
 //        fixtureRenderPlan1.uniforms.updateFrom(arrayOf(1f, 1f, 1f, 1f, 1f, 1f, .2f))
 //        fixtureRenderPlan2.uniforms.updateFrom(arrayOf(1f, 1f, 1f, 1f, 1f, 1f, .3f))
 
-        modelRenderer.draw()
+        renderEngine.draw()
 
         expectColor(listOf(
             Color(0f, .1f, .2f),
@@ -214,7 +214,7 @@ class ModelRendererTest {
         // xxx.
         expect(listOf(
             Quad.Rect(1f, 0f, 2f, 3f)
-        )) { ModelRenderer.mapFixturePixelsToRects(4, 4, createSurface("A", 3)) }
+        )) { RenderEngine.mapFixturePixelsToRects(4, 4, createSurface("A", 3)) }
 
         // ...x
         // xxxx
@@ -223,7 +223,7 @@ class ModelRendererTest {
             Quad.Rect(0f, 3f, 1f, 4f),
             Quad.Rect(1f, 0f, 2f, 4f),
             Quad.Rect(2f, 0f, 3f, 2f)
-        )) { ModelRenderer.mapFixturePixelsToRects(3, 4, createSurface("A", 7)) }
+        )) { RenderEngine.mapFixturePixelsToRects(3, 4, createSurface("A", 7)) }
     }
 
     private fun surfaceWithThreePixels(): IdentifiedFixture {

--- a/src/commonTest/kotlin/baaahs/show/live/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/TestUtil.kt
@@ -1,7 +1,6 @@
 package baaahs.show.live
 
 import baaahs.ShowState
-import baaahs.getBang
 import baaahs.gl.patch.AutoWirer
 import baaahs.plugin.CorePlugin
 import baaahs.plugin.Plugins
@@ -18,7 +17,7 @@ fun AutoWirer.wireUp(shader: Shader, ports: Map<String, MutablePort> = emptyMap(
     val unresolvedPatch = autoWire(shader)
     unresolvedPatch.editShader(shader).apply {
         ports.forEach { (portId, port) ->
-            incomingLinksOptions.getBang(portId, "port").apply {
+            linkOptionsFor(portId).apply {
                 clear()
                 add(port)
             }

--- a/src/commonTest/kotlin/baaahs/shows/FakeShowPlayer.kt
+++ b/src/commonTest/kotlin/baaahs/shows/FakeShowPlayer.kt
@@ -77,7 +77,7 @@ class FakeShowPlayer(
 //        renderSurfaces.values.forEach { renderSurface ->
 //            renderSurface.updateRenderSurface()
 //        }
-//        glslRenderer.draw()
+//        renderEngine.draw()
     }
 
     fun <T : Gadget> getGadget(name: String): T {

--- a/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
@@ -5,7 +5,7 @@ import baaahs.geom.Vector3F
 import baaahs.gl.GlContext.Companion.GL_RGB32F
 import baaahs.gl.override
 import baaahs.gl.patch.AutoWirer
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.glsl.Shaders
 import baaahs.mapper.Storage
 import baaahs.model.Model
@@ -77,12 +77,12 @@ object ShowRunnerSpec : Spek({
         }
         val testCoroutineContext by value { TestCoroutineContext("Test") }
         val pubSub by value { PubSub.Server(FakeNetwork().link("test").startHttpServer(0), testCoroutineContext) }
-        val glslRenderer by value { ModelRenderer(fakeGlslContext, ModelInfo.Empty) }
-        val fixtureManager by value { FixtureManager(glslRenderer) }
+        val renderEngine by value { RenderEngine(fakeGlslContext, ModelInfo.Empty) }
+        val fixtureManager by value { FixtureManager(renderEngine) }
         val stageManager by value {
             val fs = FakeFs()
             StageManager(
-                Plugins.safe(), glslRenderer, pubSub, Storage(fs, Plugins.safe()), fixtureManager, FakeDmxUniverse(),
+                Plugins.safe(), renderEngine, pubSub, Storage(fs, Plugins.safe()), fixtureManager, FakeDmxUniverse(),
                 MovingHeadManager(fs, pubSub, emptyList()), FakeClock(), model, testCoroutineContext
             )
         }

--- a/src/jsMain/kotlin/baaahs/SheepSimulator.kt
+++ b/src/jsMain/kotlin/baaahs/SheepSimulator.kt
@@ -4,7 +4,7 @@ import baaahs.client.WebClient
 import baaahs.geom.Matrix4
 import baaahs.geom.Vector3F
 import baaahs.gl.GlBase
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.mapper.MappingSession
 import baaahs.mapper.MappingSession.SurfaceData.PixelData
 import baaahs.mapper.Storage
@@ -70,7 +70,7 @@ class SheepSimulator(val model: Model<*>) {
         fs,
         PermissiveFirmwareDaddy(),
         bridgeClient.soundAnalyzer,
-        modelRenderer = ModelRenderer(glslContext, model),
+        renderEngine = RenderEngine(glslContext, model),
         pinkyMainDispatcher = Dispatchers.Main,
         plugins = plugins
     )

--- a/src/jvmMain/kotlin/baaahs/PinkyMain.kt
+++ b/src/jvmMain/kotlin/baaahs/PinkyMain.kt
@@ -2,7 +2,7 @@ package baaahs
 
 import baaahs.dmx.DmxDevice
 import baaahs.gl.GlBase
-import baaahs.gl.render.ModelRenderer
+import baaahs.gl.render.RenderEngine
 import baaahs.io.RealFs
 import baaahs.net.JvmNetwork
 import baaahs.plugin.BeatLinkPlugin
@@ -72,12 +72,12 @@ class PinkyMain(private val args: Args) {
 
         val pinky = runBlocking(pinkyMainDispatcher) {
             val glslContext = GlBase.manager.createContext()
-            val glslRenderer = ModelRenderer(glslContext, model)
+            val renderEngine = RenderEngine(glslContext, model)
             Pinky(
                 model, network, dmxUniverse, beatSource, clock, fs,
                 daddy, soundAnalyzer, switchShowAfterIdleSeconds = args.switchShowAfter,
                 adjustShowAfterIdleSeconds = args.adjustShowAfter,
-                modelRenderer = glslRenderer,
+                renderEngine = renderEngine,
                 plugins = plugins,
                 pinkyMainDispatcher = pinkyMainDispatcher
             )

--- a/src/jvmTest/kotlin/baaahs/RunOpenGLTests.kt
+++ b/src/jvmTest/kotlin/baaahs/RunOpenGLTests.kt
@@ -1,7 +1,7 @@
 package baaahs
 
 import baaahs.gl.LwjglGlManager
-import baaahs.gl.render.ModelRendererTest
+import baaahs.gl.render.RenderEngineTest
 import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.LauncherDiscoveryRequest
@@ -13,7 +13,7 @@ import org.junit.platform.launcher.listeners.SummaryGeneratingListener
 import java.io.PrintWriter
 
 val testsRequiringOpenGL = listOf(
-    ModelRendererTest::class
+    RenderEngineTest::class
 )
 
 fun main() {


### PR DESCRIPTION
* Declare BAAAHS' eyes in `SheepModel`, not `ObjModel`.
* `GlslAnalyzer` now has a deeper understanding of structs.
* Rename `ModelRenderer` to more the magnificently imposing `RenderEngine`.
* Pull Brain management out of `Pinky` into `BrainManager`.