### PR TITLE
Moving heads can be controlled from shaders

### DIFF
--- a/src/commonMain/kotlin/baaahs/Config.kt
+++ b/src/commonMain/kotlin/baaahs/Config.kt
@@ -1,13 +1,24 @@
 package baaahs
 
-public class Config {
+import baaahs.dmx.Dmx
+import baaahs.dmx.Shenzarpy
+import baaahs.model.MovingHead
+
+class Config {
     companion object {
-        val DMX_DEVICES: Map<String, Int> = mapOf(
-            Pair("leftEye", 1),
-            Pair("rightEye", 17)
-        )
+        private val DMX_DEVICE_MAP = listOf(
+            DmxChannelMapping("leftEye", 1, 16, Shenzarpy),
+            DmxChannelMapping("rightEye", 17, 16, Shenzarpy)
+        ).associateBy { it.modelEntityName }
+
+        fun findDmxChannelMapping(movingHead: MovingHead) =
+            DMX_DEVICE_MAP.getBang(movingHead.name, "dmx device base channel")
     }
 
-
-    class MovingHeadConfig(val deviceType: Dmx.DeviceType, val baseChannel: Int)
+    data class DmxChannelMapping(
+        val modelEntityName: String,
+        val baseChannel: Int,
+        val channelCount: Int,
+        val adapter: Dmx.AdapterBuilder
+    )
 }

--- a/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
+++ b/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
@@ -4,6 +4,7 @@ import baaahs.dmx.Dmx
 import baaahs.fixtures.*
 import baaahs.io.Fs
 import baaahs.model.MovingHead
+import baaahs.util.Logger
 import kotlinx.serialization.json.Json
 
 class MovingHeadManager(
@@ -23,12 +24,13 @@ class MovingHeadManager(
         val buffer = dmxUniverse.writer(dmxChannelMapping.baseChannel, dmxChannelMapping.channelCount)
         val adapter = dmxChannelMapping.adapter.build(buffer) as MovingHead.Buffer
 
-        Fixture(movingHead, 0, emptyList(), MovingHeadDevice, transport = object : Transport {
+        Fixture(movingHead, 1, emptyList(), MovingHeadDevice, transport = object : Transport {
             override val name: String
                 get() = "DMX Transport"
 
             override fun send(fixture: Fixture, resultViews: List<ResultView>) {
                 val panAndTilt = MovingHeadDevice.getResults(resultViews)[0]
+                logger.info { "Pan and tilt on ${movingHead.name} -> $panAndTilt" }
                 adapter.pan = panAndTilt.x
                 adapter.tilt = panAndTilt.y
 
@@ -58,5 +60,9 @@ class MovingHeadManager(
 
     fun listen(movingHead: MovingHead, onUpdate: (MovingHead.MovingHeadPosition) -> Unit) {
         listeners[movingHead] = onUpdate
+    }
+
+    companion object {
+        private val logger = Logger<MovingHeadManager>()
     }
 }

--- a/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
+++ b/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
@@ -1,13 +1,42 @@
 package baaahs
 
+import baaahs.dmx.Dmx
+import baaahs.fixtures.*
 import baaahs.io.Fs
 import baaahs.model.MovingHead
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import kotlin.js.JsName
 
-class MovingHeadManager(private val fs: Fs, private val pubSub: PubSub.Server, movingHeads: List<MovingHead>) {
+class MovingHeadManager(
+    private val fixtureManager: FixtureManager,
+    private val dmxUniverse: Dmx.Universe,
+    movingHeads: List<MovingHead>,
+    private val fs: Fs
+) {
+    init {
+        fixtureManager.addFrameListener {
+            dmxUniverse.sendFrame()
+        }
+    }
+
+    private val fixtures = movingHeads.map { movingHead ->
+        val dmxChannelMapping = Config.findDmxChannelMapping(movingHead)
+        val buffer = dmxUniverse.writer(dmxChannelMapping.baseChannel, dmxChannelMapping.channelCount)
+        val adapter = dmxChannelMapping.adapter.build(buffer) as MovingHead.Buffer
+
+        Fixture(movingHead, 0, emptyList(), MovingHeadDevice, transport = object : Transport {
+            override val name: String
+                get() = "DMX Transport"
+
+            override fun send(fixture: Fixture, resultViews: List<ResultView>) {
+                val panAndTilt = MovingHeadDevice.getResults(resultViews)[0]
+                adapter.pan = panAndTilt.x
+                adapter.tilt = panAndTilt.y
+
+                adapter.dimmer = 1f
+            }
+        })
+    }
+
     private val defaultPosition = MovingHead.MovingHeadPosition(127, 127)
     private val currentPositions = mutableMapOf<MovingHead, MovingHead.MovingHeadPosition>()
     private val listeners = mutableMapOf<MovingHead, (MovingHead.MovingHeadPosition) -> Unit>()
@@ -18,6 +47,8 @@ class MovingHeadManager(private val fs: Fs, private val pubSub: PubSub.Server, m
     private val presetsFileName = fs.resolve("presets/moving-head-positions.json")
 
     suspend fun start() {
+        fixtureManager.fixturesChanged(fixtures, emptyList())
+
         val presetsJson = fs.loadFile(presetsFileName)
         if (presetsJson != null) {
             val map = json.decodeFromString(Topics.movingHeadPresets.serializer, presetsJson)
@@ -25,111 +56,7 @@ class MovingHeadManager(private val fs: Fs, private val pubSub: PubSub.Server, m
         }
     }
 
-    private val movingHeadPresetsChannel =
-        pubSub.publish(
-            Topics.movingHeadPresets, mutableMapOf(
-                "Disco Balls" to MovingHead.MovingHeadPosition(123, 200)
-            )
-        ) { map ->
-            GlobalScope.launch {
-                fs.saveFile(presetsFileName, json.encodeToString(Topics.movingHeadPresets.serializer, map), true)
-                println("Saved $map to disk!")
-            }
-        }
-
-    init {
-        movingHeads.map { movingHead ->
-            val topic = PubSub.Topic("movingHead/${movingHead.name}", MovingHead.MovingHeadPosition.serializer())
-
-            currentPositions[movingHead] = defaultPosition
-            pubSub.publish(topic, defaultPosition) { onUpdate ->
-                currentPositions[movingHead] = onUpdate
-                listeners[movingHead]?.invoke(onUpdate)
-            }
-        }
-    }
-
     fun listen(movingHead: MovingHead, onUpdate: (MovingHead.MovingHeadPosition) -> Unit) {
         listeners[movingHead] = onUpdate
     }
-}
-
-class MovingHeadDisplay(val pubSub: PubSub.Client, onUpdatedMovingHeads: (Array<Wrapper>) -> Unit) {
-    init {
-//        pubSub.subscribe(Topics.movingHeads) { movingHeads ->
-//            val wrappers = movingHeads.map { movingHead -> Wrapper(movingHead, pubSub) }
-//            onUpdatedMovingHeads(wrappers.toTypedArray())
-//        }
-    }
-
-    private val presets = mutableMapOf<String, MovingHead.MovingHeadPosition>()
-    private val presetsListeners = mutableListOf<(String) -> Unit>()
-
-    private val movingHeadPresetsChannel =
-        pubSub.subscribe(Topics.movingHeadPresets) { map ->
-            presets.clear()
-            presets.putAll(map)
-            notifyPresetsListeners()
-        }
-
-    private fun notifyPresetsListeners() {
-        val json = Json.encodeToString(Topics.movingHeadPresets.serializer, presets)
-        presetsListeners.forEach { it.invoke(json) }
-    }
-
-    @JsName("savePreset")
-    fun savePreset(name: String, position: MovingHead.MovingHeadPosition) {
-        presets[name] = position
-        movingHeadPresetsChannel.onChange(presets)
-        notifyPresetsListeners()
-    }
-
-    @JsName("addPresetsListener")
-    fun addPresetsListener(callback: (String) -> Unit) {
-        presetsListeners.add(callback)
-    }
-
-    @JsName("removePresetsListener")
-    fun removePresetsListener(callback: (String) -> Unit) {
-        presetsListeners.remove(callback)
-    }
-
-    class Wrapper(val movingHead: MovingHead, pubSub: PubSub.Client) {
-        private val topic = PubSub.Topic("movingHead/${movingHead.name}", MovingHead.MovingHeadPosition.serializer())
-        private val listeners = mutableListOf<(MovingHead.MovingHeadPosition) -> Unit>()
-        private val channel: PubSub.Channel<MovingHead.MovingHeadPosition>? =
-            pubSub.subscribe(topic) { onUpdate ->
-                // TODO: the second time a moving head editor opens, this fires before channel has been set;
-                // TODO: onUpdate should be deferred until after subscribe() exits.
-                position = onUpdate
-            }
-
-        @JsName("name")
-        val name: String
-            get() = movingHead.name
-
-        @JsName("position")
-        var position: MovingHead.MovingHeadPosition? = null
-            set(value) {
-                field = value
-                if (value != null) notifyListeners(value)
-            }
-
-        private fun notifyListeners(value: MovingHead.MovingHeadPosition) {
-            // TODO: channel.onChange() is causing circular updates to PubSub server
-            channel?.onChange(value)
-            listeners.forEach { it.invoke(value) }
-        }
-
-        @JsName("addListener")
-        fun addListener(callback: (MovingHead.MovingHeadPosition) -> Unit) {
-            listeners.add(callback)
-        }
-
-        @JsName("removeListener")
-        fun removeListener(callback: (MovingHead.MovingHeadPosition) -> Unit) {
-            listeners.remove(callback)
-        }
-    }
-
 }

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -1,6 +1,7 @@
 package baaahs
 
 import baaahs.api.ws.WebSocketRouter
+import baaahs.dmx.Dmx
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.FixtureManager
 import baaahs.gl.glsl.CompilationException
@@ -53,12 +54,10 @@ class Pinky(
 
     private val pubSub: PubSub.Server = PubSub.Server(httpServer, coroutineContext)
 //    private val gadgetManager = GadgetManager(pubSub)
-    private val movingHeadManager = MovingHeadManager(fs, pubSub, model.movingHeads)
     internal val fixtureManager = FixtureManager(renderManager)
 
     var stageManager: StageManager = StageManager(
-        plugins, renderManager, pubSub, storage, fixtureManager, dmxUniverse, movingHeadManager, clock, model,
-        coroutineContext
+        plugins, renderManager, pubSub, storage, fixtureManager, clock, model, coroutineContext
     )
 
     fun switchTo(newShow: Show?, file: Fs.File? = null) {
@@ -76,6 +75,7 @@ class Pinky(
     private val udpSocket = link.listenUdp(Ports.PINKY, this)
     private val brainManager =
         BrainManager(fixtureManager, firmwareDaddy, model, mappingResults, udpSocket, networkStats)
+    private val movingHeadManager = MovingHeadManager(fixtureManager, dmxUniverse, model.movingHeads, fs)
 
     private val serverNotices = arrayListOf<ServerNotice>()
     private val serverNoticesChannel = pubSub.publish(Topics.serverNotices, serverNotices) {

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -1,14 +1,9 @@
 package baaahs
 
-import baaahs.fixtures.DeviceType
 import baaahs.fixtures.FixtureManager
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
-import baaahs.gl.patch.ContentType
-import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.render.RenderManager
 import baaahs.show.Show
-import baaahs.show.live.ActiveSet
 import baaahs.show.live.OpenShow
 import baaahs.util.Logger
 
@@ -25,7 +20,7 @@ class ShowRunner(
     private val autoWirer: AutoWirer
 ) {
     private var showState: ShowState = initialShowState ?: openShow.getShowState()
-    private var activeSetChanged: Boolean = true
+    private var activePatchSetChanged: Boolean = true
 
     // TODO: Get beat sync working again.
 //    // Continuous from [0.0 ... 3.0] (0 is first beat in a measure, 3 is last)
@@ -55,7 +50,7 @@ class ShowRunner(
 
     fun switchTo(newShowState: ShowState) {
         this.showState = newShowState
-        activeSetChanged = true
+        activePatchSetChanged = true
     }
 
     /** @return `true` if a frame was rendered and should be sent to fixtures. */
@@ -67,12 +62,12 @@ class ShowRunner(
     }
 
     fun onSelectedPatchesChanged() {
-        activeSetChanged = true
+        activePatchSetChanged = true
     }
 
     fun housekeeping(): Boolean {
-        if (activeSetChanged) {
-            fixtureManager.activeSetChanged(openShow.activeSet())
+        if (activePatchSetChanged) {
+            fixtureManager.activePatchSetChanged(openShow.activePatchSet())
         }
 
         return fixtureManager.maybeUpdateRenderPlans { id, dataSource ->
@@ -92,8 +87,3 @@ class ShowRunner(
         val logger = Logger("ShowRunner")
     }
 }
-
-class RenderPlan(
-    val programs: Map<DeviceType, List<Pair<LinkedPatch, GlslProgram>>>,
-    val activeSet: ActiveSet
-)

--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -1,8 +1,10 @@
 package baaahs
 
+import baaahs.fixtures.DeviceType
 import baaahs.fixtures.FixtureManager
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
+import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.render.RenderManager
 import baaahs.show.Show
@@ -92,6 +94,6 @@ class ShowRunner(
 }
 
 class RenderPlan(
-    val programs: List<Pair<LinkedPatch, GlslProgram>>,
+    val programs: Map<DeviceType, List<Pair<LinkedPatch, GlslProgram>>>,
     val activeSet: ActiveSet
 )

--- a/src/commonMain/kotlin/baaahs/StageManager.kt
+++ b/src/commonMain/kotlin/baaahs/StageManager.kt
@@ -28,8 +28,6 @@ class StageManager(
     private val pubSub: PubSub.Server,
     private val storage: Storage,
     private val fixtureManager: FixtureManager,
-    private val dmxUniverse: Dmx.Universe,
-    private val movingHeadManager: MovingHeadManager,
     private val clock: Clock,
     modelInfo: ModelInfo,
     private val coroutineContext: CoroutineContext
@@ -149,7 +147,6 @@ class StageManager(
 
             if (showRunner.renderNextFrame()) {
                 fixtureManager.sendFrame()
-                dmxUniverse.sendFrame()
             }
 
             if (!dontProcrastinate) housekeeping()

--- a/src/commonMain/kotlin/baaahs/StageManager.kt
+++ b/src/commonMain/kotlin/baaahs/StageManager.kt
@@ -1,6 +1,7 @@
 package baaahs
 
 import baaahs.fixtures.FixtureManager
+import baaahs.fixtures.RenderPlan
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.render.RenderManager
 import baaahs.io.Fs
@@ -12,7 +13,6 @@ import baaahs.model.ModelInfo
 import baaahs.plugin.Plugins
 import baaahs.show.DataSource
 import baaahs.show.Show
-import baaahs.show.Surfaces
 import baaahs.show.buildEmptyShow
 import com.soywiz.klock.DateTime
 import kotlinx.coroutines.CoroutineScope
@@ -222,16 +222,8 @@ class StageManager(
         val currentShow: Show?
             get() = this@StageManager.showRunner?.show
 
-        val currentGlsl: List<Pair<String, String>>?
-            get() {
-                val glsls = arrayListOf<Pair<String, String>>()
-                this@StageManager.fixtureManager.currentRenderPlan?.programs?.forEach { (deviceType, entries) ->
-                        entries.map { (patch, program) ->
-                            glsls.add("${deviceType::class.simpleName} (${patch.surfaces.name})" to program.fragShader.source)
-                        }
-                    }
-                return glsls
-            }
+        val currentRenderPlan: RenderPlan?
+            get() = this@StageManager.fixtureManager.currentRenderPlan
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/StageManager.kt
+++ b/src/commonMain/kotlin/baaahs/StageManager.kt
@@ -222,11 +222,16 @@ class StageManager(
         val currentShow: Show?
             get() = this@StageManager.showRunner?.show
 
-        val currentGlsl: Map<Surfaces, String>?
-            get() = this@StageManager.fixtureManager.currentRenderPlan
-                ?.programs?.map { (patch, program) ->
-                    patch.surfaces to program.fragShader.source
-                }?.associate { it }
+        val currentGlsl: List<Pair<String, String>>?
+            get() {
+                val glsls = arrayListOf<Pair<String, String>>()
+                this@StageManager.fixtureManager.currentRenderPlan?.programs?.forEach { (deviceType, entries) ->
+                        entries.map { (patch, program) ->
+                            glsls.add("${deviceType::class.simpleName} (${patch.surfaces.name})" to program.fragShader.source)
+                        }
+                    }
+                return glsls
+            }
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/app/ui/PlatformIcons.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/PlatformIcons.kt
@@ -25,15 +25,6 @@ interface PlatformIcons {
     val ButtonGroup: Icon
     val ColorPalette: Icon
     val Visualizer: Icon
-
-    fun forShader(shaderType: ShaderType): Icon {
-        return when (shaderType) {
-            ShaderType.Projection -> ProjectionShader
-            ShaderType.Distortion -> DistortionShader
-            ShaderType.Paint -> PaintShader
-            ShaderType.Filter -> FilterShader
-        }
-    }
 }
 
 expect fun getCommonIcons(): PlatformIcons

--- a/src/commonMain/kotlin/baaahs/app/ui/PlatformIcons.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/PlatformIcons.kt
@@ -1,6 +1,5 @@
 package baaahs.app.ui
 
-import baaahs.show.ShaderType
 import baaahs.ui.Icon
 
 
@@ -15,10 +14,11 @@ interface PlatformIcons {
     val Settings: Icon
     val None: Icon
 
+    val ProjectionShader: Icon
     val DistortionShader: Icon
     val FilterShader: Icon
     val PaintShader: Icon
-    val ProjectionShader: Icon
+    val MoverShader: Icon
 
     val BeatLinkControl: Icon
     val Button: Icon

--- a/src/commonMain/kotlin/baaahs/dmx/Dmx.kt
+++ b/src/commonMain/kotlin/baaahs/dmx/Dmx.kt
@@ -1,4 +1,4 @@
-package baaahs
+package baaahs.dmx
 
 interface Dmx {
     abstract class Universe {
@@ -7,7 +7,11 @@ interface Dmx {
         abstract fun allOff()
     }
 
-    class Buffer(private val channels: ByteArray, val baseChannel: Int, val channelCount: Int) {
+    class Buffer(
+        private val channels: ByteArray,
+        val baseChannel: Int,
+        val channelCount: Int
+    ) {
         operator fun get(channel: Channel): Byte = get(channel.offset)
 
         operator fun get(index: Int): Byte {
@@ -24,7 +28,7 @@ interface Dmx {
 
         private fun boundsCheck(index: Int) {
             if (index < 0 || index >= channelCount) {
-                throw Exception("index out of bounds: $index >= ${channelCount}")
+                throw Exception("index out of bounds: $index >= $channelCount")
             }
         }
     }
@@ -33,5 +37,9 @@ interface Dmx {
         val offset: Int
     }
 
-    open class DeviceType(val channelCount: Int)
+    interface Adapter
+
+    interface AdapterBuilder {
+        fun build(buffer: Buffer): Adapter
+    }
 }

--- a/src/commonMain/kotlin/baaahs/dmx/LixadaMiniMovingHead.kt
+++ b/src/commonMain/kotlin/baaahs/dmx/LixadaMiniMovingHead.kt
@@ -1,10 +1,10 @@
 package baaahs.dmx
 
 import baaahs.Color
-import baaahs.Dmx
 import baaahs.model.MovingHead
+import baaahs.toRadians
 
-class LixadaMiniMovingHead(override val buffer: Dmx.Buffer) : Dmx.DeviceType(9), MovingHead.Buffer {
+class LixadaMiniMovingHead(override val buffer: Dmx.Buffer) : Dmx.Adapter, MovingHead.Buffer {
     override val panChannel get() = Channel.PAN
     override val panFineChannel: Dmx.Channel? get() = null /*Channel.PAN_FINE*/
     override val tiltChannel: Dmx.Channel get() = Channel.TILT
@@ -21,6 +21,11 @@ class LixadaMiniMovingHead(override val buffer: Dmx.Buffer) : Dmx.DeviceType(9),
     override val colorMode: MovingHead.ColorMode get() = MovingHead.ColorMode.RGBW
     override val colorWheelColors: List<Shenzarpy.WheelColor>
         get() = throw UnsupportedOperationException()
+
+    override val panRange: ClosedRange<Float> =
+        toRadians(0f)..toRadians(540f)
+    override val tiltRange: ClosedRange<Float> =
+        toRadians(-110f)..toRadians(110f)
 
     init {
         dimmer = 134 * 256 / 65535f
@@ -47,5 +52,9 @@ class LixadaMiniMovingHead(override val buffer: Dmx.Buffer) : Dmx.DeviceType(9),
         COLOR_RESET;
 
         override val offset = ordinal
+    }
+
+    companion object : Dmx.AdapterBuilder {
+        override fun build(buffer: Dmx.Buffer) = LixadaMiniMovingHead(buffer)
     }
 }

--- a/src/commonMain/kotlin/baaahs/dmx/Shenzarpy.kt
+++ b/src/commonMain/kotlin/baaahs/dmx/Shenzarpy.kt
@@ -1,15 +1,14 @@
 package baaahs.dmx
 
 import baaahs.Color
-import baaahs.Dmx
 import baaahs.model.MovingHead
 import baaahs.toRadians
 
-class Shenzarpy(override val buffer: Dmx.Buffer) : Dmx.DeviceType(16), MovingHead.Buffer {
+class Shenzarpy(override val buffer: Dmx.Buffer) : Dmx.Adapter, MovingHead.Buffer {
     override val panChannel get() = Channel.PAN
-    override val panFineChannel: Dmx.Channel? get() = Channel.PAN_FINE
+    override val panFineChannel: Dmx.Channel get() = Channel.PAN_FINE
     override val tiltChannel: Dmx.Channel get() = Channel.TILT
-    override val tiltFineChannel: Dmx.Channel? get() = Channel.TILT_FINE
+    override val tiltFineChannel: Dmx.Channel get() = Channel.TILT_FINE
     override val dimmerChannel: Dmx.Channel get() = Channel.DIMMER
     override var color: Color
         get() = WheelColor.values[colorWheel.toInt()].color
@@ -18,9 +17,13 @@ class Shenzarpy(override val buffer: Dmx.Buffer) : Dmx.DeviceType(16), MovingHea
     override val colorMode: MovingHead.ColorMode get() = MovingHead.ColorMode.ColorWheel
     override val colorWheelColors: List<WheelColor> = WheelColor.values.toList()
 
-    companion object {
-        val panRange = toRadians(0f)..toRadians(540f)
-        val tiltRange = toRadians(-110f)..toRadians(110f)
+    override val panRange: ClosedRange<Float> =
+        toRadians(0f)..toRadians(540f)
+    override val tiltRange: ClosedRange<Float> =
+        toRadians(-110f)..toRadians(110f)
+
+    companion object : Dmx.AdapterBuilder {
+        override fun build(buffer: Dmx.Buffer) = Shenzarpy(buffer)
     }
 
     enum class WheelColor(val color: Color) {

--- a/src/commonMain/kotlin/baaahs/fixtures/DeviceType.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/DeviceType.kt
@@ -4,6 +4,7 @@ import baaahs.getBang
 import baaahs.gl.GlContext
 import baaahs.gl.data.ProgramFeed
 import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.patch.ContentType
 import baaahs.gl.render.RenderTarget
 import baaahs.glsl.Uniform
 import baaahs.show.DataSource
@@ -22,6 +23,7 @@ interface DeviceType {
     val title: String
     val dataSources: List<DataSource>
     val resultParams: List<ResultParam>
+    val resultContentType: ContentType
 
     companion object {
         private val knownDeviceTypes = listOf(

--- a/src/commonMain/kotlin/baaahs/fixtures/DeviceType.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/DeviceType.kt
@@ -8,6 +8,7 @@ import baaahs.gl.patch.ContentType
 import baaahs.gl.render.RenderTarget
 import baaahs.glsl.Uniform
 import baaahs.show.DataSource
+import baaahs.show.Shader
 import com.danielgergely.kgl.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
@@ -24,6 +25,7 @@ interface DeviceType {
     val dataSources: List<DataSource>
     val resultParams: List<ResultParam>
     val resultContentType: ContentType
+    val errorIndicatorShader: Shader
 
     companion object {
         private val knownDeviceTypes = listOf(

--- a/src/commonMain/kotlin/baaahs/fixtures/Fixture.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/Fixture.kt
@@ -19,4 +19,6 @@ class Fixture(
 ) {
     val title: String get() =
         "$name: ${deviceType.title} with $pixelCount pixels at ${transport.name}"
+
+    override fun toString() = "Fixture[${hashCode()} $title]"
 }

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -14,6 +14,7 @@ import baaahs.util.Logger
 class FixtureManager(
     private val renderManager: RenderManager
 ) {
+    private val frameListeners: MutableList<() -> Unit> = arrayListOf()
     private val changedFixtures = mutableListOf<FixturesChanges>()
     private val renderTargets: MutableMap<Fixture, RenderTarget> = hashMapOf()
     private var totalFixtures = 0
@@ -21,6 +22,10 @@ class FixtureManager(
     private var currentActiveSet: ActiveSet = ActiveSet(emptyList())
     private var activeSetChanged = false
     internal var currentRenderPlan: RenderPlan? = null
+
+    fun addFrameListener(callback: () -> Unit) {
+        frameListeners.add(callback)
+    }
 
     fun getRenderTargets_ForTestOnly(): Map<Fixture, RenderTarget> {
         return renderTargets
@@ -67,6 +72,7 @@ class FixtureManager(
             // from the list of fixtures. I'm not quite sure the best way to do that so I'm leaving this note.
             renderTarget.sendFrame()
         }
+        frameListeners.forEach { it.invoke() }
     }
 
     private fun addFixture(fixture: Fixture) {

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -3,6 +3,7 @@ package baaahs.fixtures
 import baaahs.RenderPlan
 import baaahs.gl.glsl.FeedResolver
 import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.patch.PatchResolver
 import baaahs.gl.render.RenderManager
@@ -50,9 +51,14 @@ class FixtureManager(
 
     fun remap(renderPlan: RenderPlan) {
         renderTargets.forEach { (fixture, renderTarget) ->
-            renderPlan.programs.forEach { (patch: LinkedPatch, program: GlslProgram) ->
-                if (patch.matches(fixture)) {
-                    renderTarget.useProgram(program)
+            renderPlan.programs.forEach { (deviceType, patches) ->
+                if (fixture.deviceType == deviceType) {
+                    patches.forEach { (patch, program) ->
+                        if (patch.matches(fixture)) {
+                            renderTarget.useProgram(program)
+                        }
+
+                    }
                 }
             }
         }

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -1,5 +1,6 @@
 package baaahs.fixtures
 
+import baaahs.gl.patch.ContentType
 import baaahs.show.DataSource
 
 object MovingHeadDevice : DeviceType {
@@ -11,6 +12,8 @@ object MovingHeadDevice : DeviceType {
     override val resultParams: List<ResultParam> get() = listOf(
         ResultParam("Pan/Tilt", Vec2ResultType)
     )
+    override val resultContentType: ContentType
+        get() = ContentType.PanAndTilt
 
     fun getResults(resultViews: List<ResultView>) =
         resultViews[0] as Vec2ResultType.Vec2ResultView

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -11,4 +11,7 @@ object MovingHeadDevice : DeviceType {
     override val resultParams: List<ResultParam> get() = listOf(
         ResultParam("Pan/Tilt", Vec2ResultType)
     )
+
+    fun getResults(resultViews: List<ResultView>) =
+        resultViews[0] as Vec2ResultType.Vec2ResultView
 }

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -2,6 +2,8 @@ package baaahs.fixtures
 
 import baaahs.gl.patch.ContentType
 import baaahs.show.DataSource
+import baaahs.show.Shader
+import baaahs.show.ShaderType
 
 object MovingHeadDevice : DeviceType {
     override val id: String get() = "MovingHead"
@@ -15,6 +17,23 @@ object MovingHeadDevice : DeviceType {
     override val resultContentType: ContentType
         get() = ContentType.PanAndTilt
 
+    override val errorIndicatorShader: Shader
+        get() = Shader(
+            "Ω Guru Meditation Error Ω",
+            ShaderType.Mover,
+            /**language=glsl*/
+            """
+                uniform float time;
+                void main() {
+                    gl_FragColor = (mod(time, 2.) < 1.)
+                        ? vec4(.45, .45, 0., 0.)
+                        : vec4(.55, .55, 0., 0.);
+                }
+            """.trimIndent()
+        )
+
     fun getResults(resultViews: List<ResultView>) =
         resultViews[0] as Vec2ResultType.Vec2ResultView
+
+    override fun toString(): String = id
 }

--- a/src/commonMain/kotlin/baaahs/fixtures/PixelArrayDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/PixelArrayDevice.kt
@@ -13,6 +13,8 @@ import baaahs.glsl.Uniform
 import baaahs.plugin.CorePlugin
 import baaahs.plugin.Plugin
 import baaahs.show.DataSource
+import baaahs.show.Shader
+import baaahs.show.ShaderType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -33,8 +35,26 @@ object PixelArrayDevice : DeviceType {
     override val resultContentType: ContentType
         get() = ContentType.ColorStream
 
+    override val errorIndicatorShader: Shader
+        get() = Shader(
+            "Ω Guru Meditation Error Ω",
+            ShaderType.Paint,
+            /**language=glsl*/
+            """
+                uniform float time;
+                void main() {
+                    gl_FragColor = (mod(time, 2.) < 1.)
+                        ? vec4(.75, 0., 0., 1.)
+                        : vec4(.25, 0., 0., 1.);
+                }
+            """.trimIndent()
+        )
+
+
     fun getColorResults(resultViews: List<ResultView>) =
         resultViews[0] as ColorResultType.ColorResultView
+
+    override fun toString(): String = id
 }
 
 @Serializable

--- a/src/commonMain/kotlin/baaahs/fixtures/PixelArrayDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/PixelArrayDevice.kt
@@ -30,6 +30,9 @@ object PixelArrayDevice : DeviceType {
         ResultParam("Pixel Color", ColorResultType)
     )
 
+    override val resultContentType: ContentType
+        get() = ContentType.ColorStream
+
     fun getColorResults(resultViews: List<ResultView>) =
         resultViews[0] as ColorResultType.ColorResultView
 }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/CompiledShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/CompiledShader.kt
@@ -35,6 +35,10 @@ class CompiledShader(
         }
     }
 
+    fun release() {
+        gl.runInContext { gl.check { deleteShader(shaderId) } }
+    }
+
     companion object {
         val logger = Logger("CompiledShader")
     }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
@@ -17,6 +17,8 @@ class GlslProgram(
     private val linkedPatch: LinkedPatch,
     engineFeedResolver: EngineFeedResolver
 ) {
+    val title: String get() = linkedPatch.shaderInstance.shader.title
+
     private val vertexShader =
         gl.createVertexShader(
             "#version ${gl.glslVersion}\n${GlslProgram.vertexShader}"

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
@@ -93,7 +93,16 @@ class GlslProgram(
 
     fun release() {
         feeds.forEach { it.release() }
-//        TODO gl.runInContext { gl.check { deleteProgram } }
+
+        gl.runInContext {
+            gl.useProgram(this)
+//            TODO: gl.check { detachShader(vertexShader) }
+            vertexShader.release()
+//            TODO: gl.check { detachShader(fragShader) }
+            fragShader.release()
+
+        }
+//        TODO gl.runInContext { gl.check { deleteProgram(id) } }
     }
 
     fun getUniform(name: String): Uniform? = gl.runInContext {

--- a/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
@@ -65,6 +65,8 @@ class ContentType(
         val Int = ContentType("Integer", GlslType.Int)
         val Media = ContentType("Media", GlslType.Sampler2D)
 
+        val PanAndTilt = ContentType("Pan & Tilt", GlslType.Vec4)
+
         val coreTypes = listOf(
             PixelCoordinatesTexture,
             PreviewResolution,
@@ -83,7 +85,9 @@ class ContentType(
             Time,
             Float,
             Int,
-            Media
+            Media,
+
+            PanAndTilt
         )
     }
 }

--- a/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
@@ -1,5 +1,6 @@
 package baaahs.gl.patch
 
+import baaahs.fixtures.DeviceType
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.PixelArrayDevice
 import baaahs.getBang
@@ -125,9 +126,9 @@ class LinkedPatch(
         return "#version ${glslVersion}\n\n${toGlsl()}\n"
     }
 
-    fun createProgram(renderManager: RenderManager, feedResolver: FeedResolver): GlslProgram {
+    fun createProgram(renderManager: RenderManager, deviceType: DeviceType, feedResolver: FeedResolver): GlslProgram {
         // TODO: not just PixelArrayDevice!
-        val renderEngine = renderManager.getEngineFor(PixelArrayDevice)
+        val renderEngine = renderManager.getEngineFor(deviceType)
         return renderEngine.compile(this, feedResolver)
     }
 

--- a/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
@@ -1,14 +1,7 @@
 package baaahs.gl.patch
 
-import baaahs.fixtures.DeviceType
-import baaahs.fixtures.Fixture
-import baaahs.fixtures.PixelArrayDevice
 import baaahs.getBang
-import baaahs.gl.glsl.FeedResolver
-import baaahs.gl.glsl.GlslProgram
-import baaahs.gl.render.RenderManager
 import baaahs.show.ShaderChannel
-import baaahs.show.Surfaces
 import baaahs.show.live.LiveShaderInstance
 import baaahs.show.live.LiveShaderInstance.*
 import baaahs.show.mutable.ShowBuilder
@@ -17,10 +10,7 @@ import baaahs.util.Logger
 import kotlin.collections.component1
 import kotlin.collections.component2
 
-class LinkedPatch(
-    val shaderInstance: LiveShaderInstance,
-    val surfaces: Surfaces
-) {
+class LinkedPatch(val shaderInstance: LiveShaderInstance) {
     internal val dataSourceLinks: Set<DataSourceLink>
     private val componentBuilder: CacheBuilder<LiveShaderInstance, Component>
     private val components: List<Component>
@@ -125,14 +115,6 @@ class LinkedPatch(
     fun toFullGlsl(glslVersion: String): String {
         return "#version ${glslVersion}\n\n${toGlsl()}\n"
     }
-
-    fun createProgram(renderManager: RenderManager, deviceType: DeviceType, feedResolver: FeedResolver): GlslProgram {
-        // TODO: not just PixelArrayDevice!
-        val renderEngine = renderManager.getEngineFor(deviceType)
-        return renderEngine.compile(this, feedResolver)
-    }
-
-    fun matches(fixture: Fixture): Boolean = this.surfaces.matches(fixture)
 
     companion object {
         private val logger = Logger("OpenPatch")

--- a/src/commonMain/kotlin/baaahs/gl/patch/PatchResolver.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/PatchResolver.kt
@@ -1,9 +1,10 @@
 package baaahs.gl.patch
 
-import baaahs.RenderPlan
 import baaahs.ShowRunner
-import baaahs.fixtures.MovingHeadDevice
-import baaahs.fixtures.PixelArrayDevice
+import baaahs.fixtures.DeviceType
+import baaahs.fixtures.DeviceTypeRenderPlan
+import baaahs.fixtures.ProgramRenderPlan
+import baaahs.fixtures.RenderPlan
 import baaahs.gl.glsl.CompilationException
 import baaahs.gl.glsl.FeedResolver
 import baaahs.gl.glsl.GlslException
@@ -11,61 +12,76 @@ import baaahs.gl.render.RenderManager
 import baaahs.gl.render.RenderTarget
 import baaahs.glsl.GuruMeditationError
 import baaahs.show.ShaderChannel
-import baaahs.show.Surfaces
-import baaahs.show.live.ActiveSet
+import baaahs.show.live.ActivePatchSet
 import baaahs.show.live.OpenPatch
 
 class PatchResolver(
-    val renderTargets: Collection<RenderTarget>,
-    val activeSet: ActiveSet
+    private val renderManager: RenderManager,
+    private val renderTargets: Collection<RenderTarget>,
+    private val activePatchSet: ActivePatchSet
 ) {
-    val portDiagrams: Map<Surfaces, PortDiagram> = run {
-        val activePatchHolders = activeSet.getPatchHolders()
-        println("active patches = ${activePatchHolders.map { it.title }}")
+    init {
 
-        val patchesBySurfaces = mutableMapOf<Surfaces, MutableList<OpenPatch>>()
-        activePatchHolders.forEach { openPatchHolder ->
-            openPatchHolder.patches.forEach { patch ->
-                patchesBySurfaces.getOrPut(patch.surfaces) { arrayListOf() }
-                    .add(patch)
+    }
+    val portDiagrams =
+        renderTargets
+            .groupBy { it.fixture.deviceType }
+            .mapValues { (_, renderTargets) ->
+                val patchSetsByKey = mutableMapOf<String, PatchSet>()
+                val renderTargetsByKey = mutableMapOf<String, MutableList<RenderTarget>>()
+
+                renderTargets.forEach { renderTarget ->
+                    val patchSet = activePatchSet.activePatches
+                        .filter { patch -> patch.matches(renderTarget.fixture) }
+                    val key = patchSet.joinToString(":") { it.serial.toString(16) }
+
+                    patchSetsByKey[key] = patchSet
+                    renderTargetsByKey.getOrPut(key) { mutableListOf() }
+                        .add(renderTarget)
+                }
+
+                patchSetsByKey.map { (key, patchSet) ->
+                    PortDiagram(patchSet) to renderTargetsByKey[key]!! as List<RenderTarget>
+                }
             }
-        }
 
-        patchesBySurfaces.mapValues { (_, openPatches) ->
-            buildPortDiagram(*openPatches.toTypedArray())
-        }
+    fun createRenderPlan(feedResolver: FeedResolver): RenderPlan {
+        return RenderPlan(
+            portDiagrams.mapValues { (deviceType, devicePortDiagrams) ->
+                val programsRenderPlans = devicePortDiagrams.map { (portDiagram, renderTargets) ->
+                    val linkedPatch = portDiagram.resolvePatch(ShaderChannel.Main, deviceType.resultContentType)
+                    val program = linkedPatch?.let {
+                        buildProgram(it, deviceType, feedResolver)
+                    }
+
+                    ProgramRenderPlan(program, renderTargets)
+                }
+
+                DeviceTypeRenderPlan(programsRenderPlans)
+            }
+        )
     }
 
-    fun createRenderPlan(renderManager: RenderManager, feedResolver: FeedResolver): RenderPlan {
-        return RenderPlan(
-            listOf(PixelArrayDevice, MovingHeadDevice).associateWith { deviceType ->
-                val linkedPatches = portDiagrams.mapValues { (_, portDiagram) ->
-                    portDiagram.resolvePatch(ShaderChannel.Main, deviceType.resultContentType)
-                }
-                val activeDataSources = mutableSetOf<String>()
-                linkedPatches.mapNotNull { (_, linkedPatch) ->
-                    try {
-                        linkedPatch?.let { it to it.createProgram(renderManager, deviceType, feedResolver) }
-                    } catch (e: GlslException) {
-                        ShowRunner.logger.error("Error preparing program", e)
-                        if (e is CompilationException) {
-                            e.source?.let { ShowRunner.logger.info { it } }
-                        }
-                        return GuruMeditationError.createRenderPlan(renderManager)
-                    }
-                }
-            },
-            activeSet
+    private fun buildProgram(
+        linkedPatch: LinkedPatch,
+        deviceType: DeviceType,
+        feedResolver: FeedResolver
+    ) = try {
+        renderManager.compile(deviceType, linkedPatch, feedResolver)
+    } catch (e: GlslException) {
+        ShowRunner.logger.error("Error preparing program", e)
+        if (e is CompilationException) {
+            e.source?.let { ShowRunner.logger.info { it } }
+        }
+
+        renderManager.compile(
+            deviceType, GuruMeditationError(deviceType).linkedPatch, feedResolver
         )
     }
 
     companion object {
-        fun buildPortDiagram(vararg patches: OpenPatch): PortDiagram {
-            val portDiagram = PortDiagram()
-            patches.forEach { patch ->
-                portDiagram.add(patch)
-            }
-            return portDiagram
-        }
+        fun buildPortDiagram(vararg patches: OpenPatch) = PortDiagram(patches.toList())
     }
 }
+
+private typealias PatchSet = List<OpenPatch>

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
@@ -31,7 +31,7 @@ class ShaderInstanceOptions(
         parentMutablePatch?.mutableShaderInstances?.forEach { shaderInstance ->
             val openShader = glslAnalyzer.openShader(shaderInstance.mutableShader.build())
 
-            openShader.shaderType.defaultUpstreams.forEach { (contentType, shaderChannel) ->
+            openShader.defaultUpstreams.forEach { (contentType, shaderChannel) ->
                 shaderChannels.getOrPut(contentType) { mutableSetOf() }
                     .add(MutableShaderChannel(shaderChannel.id))
             }

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -4,10 +4,7 @@ import baaahs.BaseShowPlayer
 import baaahs.Gadget
 import baaahs.fixtures.*
 import baaahs.gl.data.Feed
-import baaahs.gl.glsl.FeedResolver
-import baaahs.gl.glsl.GlslError
-import baaahs.gl.glsl.GlslException
-import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.*
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
@@ -106,6 +103,7 @@ class PreviewShaderBuilder(
                 ShaderType.Distortion -> arrayOf(screenCoordsProjection, openShader, smpteColorBars)
                 ShaderType.Paint -> arrayOf(screenCoordsProjection, openShader)
                 ShaderType.Filter -> arrayOf(screenCoordsProjection, openShader, smpteColorBars)
+                ShaderType.Mover -> arrayOf(openShader)
             }
 
             val defaultPorts = when (shader.type) {
@@ -200,6 +198,8 @@ object ProjectionPreviewDevice: DeviceType {
         get() = listOf(
             ResultParam("Vertex Location", Vec2ResultType)
         )
+    override val resultContentType: ContentType
+        get() = ContentType.UvCoordinateStream
 
     fun getVertexLocations(resultViews: List<ResultView>): Vec2ResultType.Vec2ResultView {
         return resultViews[0] as Vec2ResultType.Vec2ResultView

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -4,7 +4,10 @@ import baaahs.BaseShowPlayer
 import baaahs.Gadget
 import baaahs.fixtures.*
 import baaahs.gl.data.Feed
-import baaahs.gl.glsl.*
+import baaahs.gl.glsl.FeedResolver
+import baaahs.gl.glsl.GlslError
+import baaahs.gl.glsl.GlslException
+import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
@@ -201,7 +204,17 @@ object ProjectionPreviewDevice: DeviceType {
     override val resultContentType: ContentType
         get() = ContentType.UvCoordinateStream
 
+    override val errorIndicatorShader: Shader
+        get() = Shader(
+            "Ω Guru Meditation Error Ω",
+            ShaderType.Paint,
+            /**language=glsl*/
+            ""
+        )
+
     fun getVertexLocations(resultViews: List<ResultView>): Vec2ResultType.Vec2ResultView {
         return resultViews[0] as Vec2ResultType.Vec2ResultView
     }
+
+    override fun toString(): String = id
 }

--- a/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
@@ -6,6 +6,9 @@ import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeed
 import baaahs.gl.data.Feed
 import baaahs.gl.data.PerPixelEngineFeed
+import baaahs.gl.glsl.FeedResolver
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.patch.LinkedPatch
 import baaahs.model.ModelInfo
 import baaahs.show.DataSource
 import baaahs.util.Logger
@@ -78,6 +81,11 @@ class ModelRenderEngine(
         renderTargetsToRemove.add(renderTarget)
     }
 
+    override fun compile(linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
+        logger.info { "Compiling ${linkedPatch.shaderInstance.shader.title} on ${deviceType::class.simpleName}"}
+        return super.compile(linkedPatch, feedResolver)
+    }
+
     override fun resolve(id: String, dataSource: DataSource): Feed? {
         return fixtureFeeds[dataSource]
     }
@@ -108,7 +116,7 @@ class ModelRenderEngine(
 
     override fun render() {
         gl.setViewport(0, 0, arrangement.pixWidth, arrangement.pixHeight)
-        gl.check { clearColor(0f, .5f, 0f, 1f) }
+        gl.check { clearColor(.1f, .2f, 0f, 1f) }
         gl.check { clear(GL_COLOR_BUFFER_BIT or GL_DEPTH_BUFFER_BIT) }
 
         arrangement.render()
@@ -199,6 +207,7 @@ class ModelRenderEngine(
                 .groupBy { it.program }
                 .forEach { (program, renderTargets) ->
                     if (program != null) {
+//                        logger.info { "Using ${program.title} on ${deviceType::class.simpleName}"}
                         gl.useProgram(program)
                         program.aboutToRenderFrame()
 

--- a/src/commonMain/kotlin/baaahs/gl/render/PreviewRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/PreviewRenderEngine.kt
@@ -40,7 +40,7 @@ class PreviewRenderEngine(
     override fun onBind(engineFeed: EngineFeed) {
     }
 
-    override fun prepare() {
+    override fun beforeFrame() {
     }
 
     override fun bindResults() {
@@ -62,7 +62,7 @@ class PreviewRenderEngine(
         }
     }
 
-    override fun retrieveResults() {
+    override fun afterFrame() {
     }
 
     override fun onRelease() {

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
@@ -38,18 +38,18 @@ abstract class RenderEngine(val gl: GlContext) {
 
     fun draw() {
         gl.runInContext {
-            stats.prepareMs += timeSync { prepare() }
+            stats.prepareMs += timeSync { beforeFrame() }
             bindResults()
             stats.renderMs += timeSync { wrappedRender() }
             stats.finishMs += timeSync { gl.check { finish() } }
-            stats.readPxMs += timeSync { retrieveResults() }
+            stats.readPxMs += timeSync { afterFrame() }
         }
 
         stats.frameCount++
     }
 
     /** This is run from within a GL context. */
-    abstract fun prepare()
+    abstract fun beforeFrame()
 
     /** This is run from within a GL context. */
     abstract fun bindResults()
@@ -64,7 +64,7 @@ abstract class RenderEngine(val gl: GlContext) {
     abstract fun render()
 
     /** This is run from within a GL context. */
-    abstract fun retrieveResults()
+    abstract fun afterFrame()
 
     fun release() {
         gl.runInContext {

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
@@ -23,7 +23,7 @@ abstract class RenderEngine(val gl: GlContext) {
 
     abstract fun resolve(id: String, dataSource: DataSource): Feed?
 
-    fun compile(linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
+    open fun compile(linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
         return GlslProgram(gl, linkedPatch) { id: String, dataSource: DataSource ->
             val feed = resolve(id, dataSource) ?: feedResolver.openFeed(id, dataSource)
 

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
@@ -2,9 +2,14 @@ package baaahs.gl.render
 
 import baaahs.fixtures.DeviceType
 import baaahs.fixtures.Fixture
+import baaahs.fixtures.RenderPlan
 import baaahs.getBang
 import baaahs.gl.GlContext
+import baaahs.gl.glsl.FeedResolver
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.patch.LinkedPatch
 import baaahs.model.Model
+import baaahs.util.Logger
 
 class RenderManager(
     private val model: Model,
@@ -26,5 +31,23 @@ class RenderManager(
 
     fun removeRenderTarget(renderTarget: RenderTarget) {
         getEngineFor(renderTarget.fixture.deviceType).removeRenderTarget(renderTarget)
+    }
+
+    fun compile(deviceType: DeviceType, linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
+        return getEngineFor(deviceType).compile(linkedPatch, feedResolver)
+    }
+
+    fun setRenderPlan(renderPlan: RenderPlan) {
+        renderEngines.forEach { (deviceType, engine) ->
+            val deviceTypeRenderPlan = renderPlan.deviceTypes[deviceType]
+            engine.setRenderPlan(deviceTypeRenderPlan)
+            if (deviceTypeRenderPlan == null) {
+                logger.debug { "No render plan for ${deviceType.title}" }
+            }
+        }
+    }
+
+    companion object {
+        private val logger = Logger<RenderManager>()
     }
 }

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
@@ -15,20 +15,24 @@ class RenderTarget(
     resultBuffers: List<ResultBuffer>
 ) {
     var program: GlslProgram? = null
+        private set
 
     val resultViews = resultBuffers.map { it.getView(pixel0Index, pixelCount) }
-
-    fun useProgram(program: GlslProgram?) {
-        if (program != null && this.program != null)
-            throw IllegalStateException("buffer already bound")
-        this.program = program
-    }
 
     fun sendFrame() {
         fixture.transport.send(fixture, resultViews)
     }
 
     fun release() {
-        useProgram(null)
+        program = null
+    }
+
+    /** Only call me from [RenderEngine]! */
+    internal fun usingProgram(program: GlslProgram?) {
+        this.program = program
+    }
+
+    override fun toString(): String {
+        return "RenderTarget(fixture=$fixture, rect0Index=$rect0Index, rects=$rects, pixel0Index=$pixel0Index)"
     }
 }

--- a/src/commonMain/kotlin/baaahs/gl/shader/DistortionShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/DistortionShader.kt
@@ -6,7 +6,6 @@ import baaahs.gl.glsl.LinkException
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
-import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
 class DistortionShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenShader.Base(shader, glslCode, plugins) {
@@ -24,8 +23,7 @@ class DistortionShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : O
 //                        varying vec2 surfacePosition; TODO
         ).associateBy { it.id }
 
-        val outputPort: OutputPort =
-            OutputPort(GlslType.Vec2, ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinateStream)
+        val outputPort: OutputPort = OutputPort(ContentType.UvCoordinateStream)
     }
 
     override val shaderType: ShaderType

--- a/src/commonMain/kotlin/baaahs/gl/shader/FilterShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/FilterShader.kt
@@ -6,7 +6,6 @@ import baaahs.gl.glsl.LinkException
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
-import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
 class FilterShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenShader.Base(shader, glslCode, plugins) {
@@ -24,8 +23,7 @@ class FilterShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenS
 //                        varying vec2 surfacePosition; TODO
         ).associateBy { it.id }
 
-        val outputPort =
-            OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Output Color", ContentType.ColorStream)
+        val outputPort = OutputPort(ContentType.ColorStream)
     }
 
     override val shaderType: ShaderType

--- a/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
@@ -1,0 +1,47 @@
+package baaahs.gl.shader
+
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.glsl.LinkException
+import baaahs.gl.patch.ContentType
+import baaahs.plugin.Plugins
+import baaahs.show.Shader
+import baaahs.show.ShaderOutPortRef
+import baaahs.show.ShaderType
+
+class MoverShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenShader.Base(shader, glslCode, plugins) {
+    companion object {
+        val proFormaInputPorts = listOf(
+            InputPort("gl_FragColor", GlslType.Vec4, "Input Color", ContentType.ColorStream)
+        )
+
+        val wellKnownInputPorts = listOf(
+            InputPort("position", GlslType.Vec3, "Position", ContentType.XyzCoordinate),
+            InputPort("orientation", GlslType.Vec3, "Orientation", ContentType.XyzCoordinate),
+            InputPort("time", GlslType.Float, "Time", ContentType.Time)
+        ).associateBy { it.id }
+
+        val outputPort =
+            OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Moving Head Output", ContentType.PanAndTilt)
+    }
+
+    override val shaderType: ShaderType
+        get() = ShaderType.Mover
+
+    override val entryPointName: String get() = "mainMover"
+
+    override val proFormaInputPorts: List<InputPort>
+        get() = MoverShader.proFormaInputPorts
+    override val wellKnownInputPorts: Map<String, InputPort>
+        get() = MoverShader.wellKnownInputPorts
+    override val outputPort: OutputPort
+        get() = MoverShader.outputPort
+
+    override fun invocationGlsl(
+        namespace: GlslCode.Namespace,
+        resultVar: String,
+        portMap: Map<String, String>
+    ): String {
+        return resultVar + " = " + namespace.qualify(entryPoint.name) + "()"
+    }
+}

--- a/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
@@ -2,11 +2,9 @@ package baaahs.gl.shader
 
 import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslType
-import baaahs.gl.glsl.LinkException
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
-import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
 class MoverShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenShader.Base(shader, glslCode, plugins) {
@@ -21,8 +19,7 @@ class MoverShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenSh
             InputPort("time", GlslType.Float, "Time", ContentType.Time)
         ).associateBy { it.id }
 
-        val outputPort =
-            OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Moving Head Output", ContentType.PanAndTilt)
+        val outputPort = OutputPort(ContentType.PanAndTilt)
     }
 
     override val shaderType: ShaderType

--- a/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
@@ -5,8 +5,10 @@ import baaahs.RefCounter
 import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslCode.GlslFunction
 import baaahs.gl.glsl.GlslCode.Namespace
+import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
+import baaahs.show.ShaderChannel
 import baaahs.show.ShaderType
 import baaahs.unknown
 import kotlin.collections.set
@@ -16,14 +18,14 @@ interface OpenShader : RefCounted {
     val src: String get() = glslCode.src
     val glslCode: GlslCode
     val title: String
-    val shaderType: ShaderType
     val entryPointName: String
     val entryPoint: GlslFunction
         get() = glslCode.findFunction(entryPointName)
 
     val inputPorts: List<InputPort>
     val outputPort: OutputPort
-//    TODO val inputDefaults: Map<String, InputDefault>
+    val defaultPriority: Int
+    val defaultUpstreams: Map<ContentType, ShaderChannel>
 
     fun findInputPort(portId: String): InputPort
     fun toGlsl(namespace: Namespace, portMap: Map<String, String> = emptyMap()): String
@@ -51,6 +53,12 @@ interface OpenShader : RefCounted {
                             ?: toInputPort(it)
                     }
         }
+
+        abstract val shaderType: ShaderType
+        override val defaultPriority: Int
+            get() = shaderType.priority
+        override val defaultUpstreams: Map<ContentType, ShaderChannel>
+            get() = shaderType.defaultUpstreams
 
         protected fun toInputPort(glslVar: GlslCode.GlslVar): InputPort {
             return glslVar.toInputPort(plugins)

--- a/src/commonMain/kotlin/baaahs/gl/shader/OutputPort.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/OutputPort.kt
@@ -5,10 +5,10 @@ import baaahs.gl.patch.ContentType
 import baaahs.show.ShaderOutPortRef
 
 data class OutputPort(
-    val dataType: GlslType,
-    val id: String,
-    val description: String?,
-    val contentType: ContentType
+    val contentType: ContentType,
+    val description: String? = contentType.description,
+    val id: String = ShaderOutPortRef.ReturnValue,
+    val dataType: GlslType = contentType.glslType
 ) {
     fun isReturnValue() = id == ShaderOutPortRef.ReturnValue
 }

--- a/src/commonMain/kotlin/baaahs/gl/shader/PaintShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/PaintShader.kt
@@ -5,7 +5,6 @@ import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
-import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
 abstract class PaintShader(
@@ -68,8 +67,7 @@ class ShaderToyPaintShader(
             InputPort("iChannel3", GlslType.Sampler2D, "Channel 3", ContentType.Media)
         ).associateBy { it.id }
 
-        val outputPort: OutputPort =
-            OutputPort(GlslType.Vec4, ShaderOutPortRef.ReturnValue, "Output Color", ContentType.ColorStream)
+        val outputPort: OutputPort = OutputPort(ContentType.ColorStream, "Output Color")
     }
 
     override val entryPointName: String
@@ -127,7 +125,7 @@ class GenericPaintShader(
         ).associateBy { it.id }
 
         val outputPort =
-            OutputPort(GlslType.Vec4, "gl_FragColor", "Output Color", ContentType.ColorStream)
+            OutputPort(ContentType.ColorStream, "Output Color", "gl_FragColor")
     }
 
     override val proFormaInputPorts: List<InputPort>

--- a/src/commonMain/kotlin/baaahs/gl/shader/ProjectionShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/ProjectionShader.kt
@@ -5,7 +5,6 @@ import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
-import baaahs.show.ShaderOutPortRef
 import baaahs.show.ShaderType
 
 class ProjectionShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : OpenShader.Base(shader, glslCode, plugins) {
@@ -18,8 +17,7 @@ class ProjectionShader(shader: Shader, glslCode: GlslCode, plugins: Plugins) : O
             InputPort("previewResolution", GlslType.Vec2, "Preview Resolution", ContentType.PreviewResolution)
         ).associateBy { it.id }
 
-        val outputPort =
-            OutputPort(GlslType.Vec2, ShaderOutPortRef.ReturnValue, "U/V Coordinate", ContentType.UvCoordinateStream)
+        val outputPort = OutputPort(ContentType.UvCoordinateStream)
 
     }
 

--- a/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
@@ -1,6 +1,7 @@
 package baaahs.glsl
 
 import baaahs.*
+import baaahs.fixtures.PixelArrayDevice
 import baaahs.gl.data.Feed
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.ContentType
@@ -59,9 +60,12 @@ object GuruMeditationError {
 
         // TODO: Should maybe display error state for whatever device type failed? Or everywhere?
         return RenderPlan(
-            listOf(linkedPatch to linkedPatch.createProgram(renderManager) { _, dataSource ->
-                feeds.getBang(dataSource, "data feed")
-            }),
+            mapOf(
+                PixelArrayDevice to
+                        listOf(linkedPatch to linkedPatch.createProgram(renderManager, PixelArrayDevice) { _, dataSource ->
+                            feeds.getBang(dataSource, "data feed")
+                        })
+            ),
             ActiveSet(emptyList())
         )
     }

--- a/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
@@ -1,41 +1,25 @@
 package baaahs.glsl
 
-import baaahs.*
-import baaahs.fixtures.PixelArrayDevice
+import baaahs.BaseShowPlayer
+import baaahs.Gadget
+import baaahs.fixtures.DeviceType
 import baaahs.gl.data.Feed
 import baaahs.gl.patch.AutoWirer
-import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.patch.PatchResolver
-import baaahs.gl.render.RenderManager
 import baaahs.model.ModelInfo
+import baaahs.only
 import baaahs.plugin.Plugins
 import baaahs.show.DataSource
-import baaahs.show.Shader
 import baaahs.show.ShaderChannel
-import baaahs.show.ShaderType
-import baaahs.show.live.ActiveSet
 import baaahs.show.live.ShowOpener
 import baaahs.show.mutable.MutableShow
 import baaahs.show.mutable.ShowBuilder
 
-object GuruMeditationError {
-    private val shader = Shader(
-        "Ω Guru Meditation Error Ω",
-        ShaderType.Paint,
-        /**language=glsl*/
-        """
-            uniform float time;
-            void main() {
-                gl_FragColor = (mod(time, 2.) < 1.)
-                    ? vec4(.75, 0., 0., 1.)
-                    : vec4(.25, 0., 0., 1.);
-            }
-        """.trimIndent()
-    )
-
-    private val linkedPatch: LinkedPatch?
+class GuruMeditationError(deviceType: DeviceType) {
+    private val shader = deviceType.errorIndicatorShader
     private val feeds: Map<DataSource, Feed>
+    val linkedPatch: LinkedPatch
 
     init {
         val autoWirer = AutoWirer(Plugins.safe())
@@ -52,22 +36,8 @@ object GuruMeditationError {
         feeds = openShow.feeds
         val openPatch = openShow.patches.only("patch")
         linkedPatch = PatchResolver.buildPortDiagram(openPatch)
-            .resolvePatch(ShaderChannel.Main, ContentType.ColorStream)
-    }
-
-    fun createRenderPlan(renderManager: RenderManager): RenderPlan {
-        linkedPatch ?: error("Couldn't build guru meditation error patch.")
-
-        // TODO: Should maybe display error state for whatever device type failed? Or everywhere?
-        return RenderPlan(
-            mapOf(
-                PixelArrayDevice to
-                        listOf(linkedPatch to linkedPatch.createProgram(renderManager, PixelArrayDevice) { _, dataSource ->
-                            feeds.getBang(dataSource, "data feed")
-                        })
-            ),
-            ActiveSet(emptyList())
-        )
+            .resolvePatch(ShaderChannel.Main, deviceType.resultContentType)
+            ?: error("Couldn't build guru meditation error patch.")
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/model/Model.kt
+++ b/src/commonMain/kotlin/baaahs/model/Model.kt
@@ -9,7 +9,7 @@ abstract class Model : ModelInfo {
     abstract val name: String
     abstract val movingHeads: List<MovingHead>
     abstract val allSurfaces: List<Surface>
-    val allEntities: List<Entity> get() = allSurfaces + movingHeads
+    abstract val allEntities: List<Entity>
 
     abstract val geomVertices: List<Vector3F>
 

--- a/src/commonMain/kotlin/baaahs/model/MovingHead.kt
+++ b/src/commonMain/kotlin/baaahs/model/MovingHead.kt
@@ -1,7 +1,7 @@
 package baaahs.model
 
 import baaahs.Color
-import baaahs.Dmx
+import baaahs.dmx.Dmx
 import baaahs.dmx.Shenzarpy
 import baaahs.fixtures.DeviceType
 import baaahs.fixtures.MovingHeadDevice
@@ -11,8 +11,8 @@ import kotlinx.serialization.Serializable
 class MovingHead(
     override val name: String,
     override val description: String,
-    val origin: Vector3F
-    /*, val heading: Vector3F*/
+    val origin: Vector3F,
+    val heading: Vector3F
 ) : Model.Entity {
     enum class ColorMode {
         ColorWheel,
@@ -35,9 +35,13 @@ class MovingHead(
             get() = getFloat(panChannel, panFineChannel)
             set(value) = setFloat(panChannel, panFineChannel, value)
 
+        val panRange: ClosedRange<Float>
+
         var tilt: Float
             get() = getFloat(tiltChannel, tiltFineChannel)
             set(value) = setFloat(tiltChannel, tiltFineChannel, value)
+
+        val tiltRange: ClosedRange<Float>
 
         var dimmer: Float
             get() = getFloat(dimmerChannel)

--- a/src/commonMain/kotlin/baaahs/model/ObjModel.kt
+++ b/src/commonMain/kotlin/baaahs/model/ObjModel.kt
@@ -12,6 +12,7 @@ abstract class ObjModel(private val objResourceName: String) : Model() {
     lateinit var surfaces: List<Surface>
 
     override val allSurfaces get() = surfaces
+    override val allEntities: List<Entity> get() = allSurfaces + movingHeads
     private val surfacesByName = mutableMapOf<String, Surface>()
 
     abstract fun createSurface(name: String, faces: List<Face>, lines: List<Line>): Surface

--- a/src/commonMain/kotlin/baaahs/models/SheepModel.kt
+++ b/src/commonMain/kotlin/baaahs/models/SheepModel.kt
@@ -5,6 +5,7 @@ import baaahs.geom.Vector3F
 import baaahs.getResource
 import baaahs.model.MovingHead
 import baaahs.model.ObjModel
+import kotlin.math.PI
 
 class SheepModel : ObjModel("baaahs-model.obj") {
     override val name: String = "BAAAHS"
@@ -14,12 +15,14 @@ class SheepModel : ObjModel("baaahs-model.obj") {
             MovingHead(
                 "leftEye",
                 "Left Eye",
-                Vector3F(0f, 204.361f, 48.738f)
+                origin = Vector3F(489.0f,202.361f, 27.5f),
+                heading = Vector3F(0f, 0f, (PI / 2).toFloat())
             ),
             MovingHead(
                 "rightEye",
                 "Right Eye",
-                Vector3F(0f, 204.361f, -153.738f)
+                origin = Vector3F(489.0f,202.361f, -24.5f),
+                heading = Vector3F(0f, 0f, (PI / 2).toFloat())
             )
         )
 

--- a/src/commonMain/kotlin/baaahs/show/ShaderType.kt
+++ b/src/commonMain/kotlin/baaahs/show/ShaderType.kt
@@ -100,10 +100,10 @@ enum class ShaderType(
         4, mapOf(ContentType.ColorStream to ShaderChannel.Main),
         ContentType.ColorStream,  CommonIcons.FilterShader,
         """
-        vec4 mainFilter(vec4 inColor) {
-            return inColor;
-        }
-    """.trimIndent()
+            vec4 mainFilter(vec4 inColor) {
+                return inColor;
+            }
+        """.trimIndent()
     ) {
         override fun matches(glslCode: GlslCode): Boolean {
             return glslCode.functionNames.contains("mainFilter")
@@ -111,6 +111,23 @@ enum class ShaderType(
 
         override fun open(shader: Shader, glslCode: GlslCode, plugins: Plugins) =
             FilterShader(shader, glslCode, plugins)
+    },
+
+    Mover(
+        0, emptyMap(), ContentType.PanAndTilt,
+        CommonIcons.None,
+        """
+            vec4 mainMover() {
+                return vec4(0., .5);
+            }
+        """.trimIndent()
+    ) {
+        override fun matches(glslCode: GlslCode): Boolean {
+            return glslCode.functionNames.contains("mainFilter")
+        }
+
+        override fun open(shader: Shader, glslCode: GlslCode, plugins: Plugins) =
+            MoverShader(shader, glslCode, plugins)
     };
 
     abstract fun matches(glslCode: GlslCode): Boolean

--- a/src/commonMain/kotlin/baaahs/show/ShowMigrator.kt
+++ b/src/commonMain/kotlin/baaahs/show/ShowMigrator.kt
@@ -9,9 +9,12 @@ object ShowMigrator : JsonTransformingSerializer<Show>(Show.serializer()) {
     override fun transformDeserialize(element: JsonElement): JsonElement {
         if (element !is JsonObject) return element
         val fromVersion = element[versionKey]?.jsonPrimitive?.int ?: 0
-        if (fromVersion == currentVersion) return element
+        if (fromVersion == currentVersion)
+            return element.toMutableMap()
+                .apply { remove(versionKey) }.toJsonObj()
 
         val newJson = element.toMutableMap()
+        newJson.remove(versionKey)
 
         if (fromVersion < 1) {
             FromV0.apply(newJson)

--- a/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
@@ -21,7 +21,7 @@ interface OpenControl {
     fun getState(): Map<String, JsonElement>? = gadget?.state
     fun applyState(state: Map<String, JsonElement>) = gadget?.applyState(state)
     fun controlledDataSources(): Set<DataSource> = emptySet()
-    fun addTo(activeSetBuilder: ActiveSetBuilder, panelId: String, depth: Int) {}
+    fun addTo(activePatchSetBuilder: ActivePatchSetBuilder, panelId: String, depth: Int) {}
     fun applyConstraints() {}
     fun toNewMutable(mutableShow: MutableShow): MutableControl
     fun getRenderer(controlProps: ControlProps): Renderer
@@ -60,9 +60,9 @@ class OpenButtonControl(
 
     override fun isActive(): Boolean = isPressed
 
-    override fun addTo(activeSetBuilder: ActiveSetBuilder, panelId: String, depth: Int) {
+    override fun addTo(activePatchSetBuilder: ActivePatchSetBuilder, panelId: String, depth: Int) {
         if (isPressed) {
-            addTo(activeSetBuilder, depth)
+            addTo(activePatchSetBuilder, depth)
         }
     }
 
@@ -121,8 +121,8 @@ class OpenButtonGroupControl(
         }
     }
 
-    override fun addTo(activeSetBuilder: ActiveSetBuilder, panelId: String, depth: Int) {
-        buttons.forEach { it.addTo(activeSetBuilder, panelId, depth + 1) }
+    override fun addTo(activePatchSetBuilder: ActivePatchSetBuilder, panelId: String, depth: Int) {
+        buttons.forEach { it.addTo(activePatchSetBuilder, panelId, depth + 1) }
     }
 
     fun createDropTarget(controlDisplay: ControlDisplay) =

--- a/src/commonMain/kotlin/baaahs/show/live/OpenPatch.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenPatch.kt
@@ -1,5 +1,6 @@
 package baaahs.show.live
 
+import baaahs.fixtures.Fixture
 import baaahs.show.Patch
 import baaahs.show.Surfaces
 
@@ -7,6 +8,8 @@ class OpenPatch(
     val shaderInstances: List<LiveShaderInstance>,
     val surfaces: Surfaces
 ) {
+    val serial = nextSerial++
+
     constructor(patch: Patch, openContext: OpenContext): this(
         patch.shaderInstanceIds.map {
             openContext.getShaderInstance(it)
@@ -16,5 +19,11 @@ class OpenPatch(
 
     override fun toString(): String {
         return "OpenPatch(shaderInstances=$shaderInstances, surfaces=$surfaces)"
+    }
+
+    fun matches(fixture: Fixture) = surfaces.matches(fixture)
+
+    companion object {
+        private var nextSerial = 0
     }
 }

--- a/src/commonMain/kotlin/baaahs/show/live/OpenPatchHolder.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenPatchHolder.kt
@@ -14,11 +14,11 @@ open class OpenPatchHolder(
             controlRefs.map { openContext.getControl(it) }
         }
 
-    fun addTo(activeSetBuilder: ActiveSetBuilder, depth: Int) {
-        activeSetBuilder.add(this, depth)
+    fun addTo(activePatchSetBuilder: ActivePatchSetBuilder, depth: Int) {
+        activePatchSetBuilder.add(this, depth)
 
         controlLayout.forEach { (panelId, openControls) ->
-            openControls.forEach { openControl -> openControl.addTo(activeSetBuilder, panelId, depth + 1) }
+            openControls.forEach { openControl -> openControl.addTo(activePatchSetBuilder, panelId, depth + 1) }
         }
     }
 }

--- a/src/commonMain/kotlin/baaahs/show/live/ShowOpener.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/ShowOpener.kt
@@ -6,10 +6,11 @@ import baaahs.getBang
 import baaahs.gl.glsl.GlslAnalyzer
 import baaahs.gl.shader.OpenShader
 import baaahs.show.DataSource
+import baaahs.show.Shader
 import baaahs.show.Show
 import baaahs.util.CacheBuilder
 
-class ShowOpener(
+open class ShowOpener(
     private val glslAnalyzer: GlslAnalyzer,
     private val show: Show,
     private val showPlayer: ShowPlayer
@@ -21,7 +22,7 @@ class ShowOpener(
     override val allControls: List<OpenControl> get() = openControlCache.all.values.toList()
 
     private val openShaders = CacheBuilder<String, OpenShader> { shaderId ->
-        glslAnalyzer.openShader(show.shaders.getBang(shaderId, "shaders"))
+        openShader(show.shaders.getBang(shaderId, "shaders"))
     }
 
     private val resolver = ShaderInstanceResolver(
@@ -48,6 +49,9 @@ class ShowOpener(
             .also { if (showState != null) it.applyState(showState) }
             .also { it.applyConstraints() }
     }
+
+    open fun openShader(shader: Shader) =
+        glslAnalyzer.openShader(shader)
 
     override fun release() {
 //        allControls.forEach { it.release() }

--- a/src/commonMain/kotlin/baaahs/sim/FakeDmxUniverse.kt
+++ b/src/commonMain/kotlin/baaahs/sim/FakeDmxUniverse.kt
@@ -1,6 +1,6 @@
 package baaahs.sim
 
-import baaahs.Dmx
+import baaahs.dmx.Dmx
 
 class FakeDmxUniverse : Dmx.Universe() {
     private val channelsOut = ByteArray(512)

--- a/src/commonTest/kotlin/baaahs/DmxTest.kt
+++ b/src/commonTest/kotlin/baaahs/DmxTest.kt
@@ -1,5 +1,6 @@
 package baaahs;
 
+import baaahs.dmx.Dmx
 import baaahs.dmx.Shenzarpy
 import kotlin.math.abs
 import kotlin.test.Test

--- a/src/commonTest/kotlin/baaahs/MovingHeadTest.kt
+++ b/src/commonTest/kotlin/baaahs/MovingHeadTest.kt
@@ -1,5 +1,6 @@
 package baaahs
 
+import baaahs.dmx.Dmx
 import baaahs.dmx.Shenzarpy
 import baaahs.model.MovingHead
 import kotlin.test.Test
@@ -19,13 +20,17 @@ class MovingHeadTest {
     class TestMovingHead : MovingHead.Buffer {
         override val buffer: Dmx.Buffer = Dmx.Buffer(ByteArray(10), 0, 10)
         override val panChannel: Dmx.Channel get() = TestChannel(1)
-        override val panFineChannel: Dmx.Channel? get() = TestChannel(2)
+        override val panFineChannel: Dmx.Channel get() = TestChannel(2)
         override val tiltChannel: Dmx.Channel get() = TestChannel(3)
-        override val tiltFineChannel: Dmx.Channel? get() = TestChannel(4)
+        override val tiltFineChannel: Dmx.Channel get() = TestChannel(4)
         override val dimmerChannel: Dmx.Channel get() = TestChannel(5)
         override var color: Color
             get() = Color.BLACK
-            set(value) {}
+            set(_) {}
+        override val panRange: ClosedRange<Float> =
+            toRadians(0f)..toRadians(540f)
+        override val tiltRange: ClosedRange<Float> =
+            toRadians(-110f)..toRadians(110f)
         override val colorMode: MovingHead.ColorMode get() = MovingHead.ColorMode.ColorWheel
         override val colorWheelColors: List<Shenzarpy.WheelColor> get() = emptyList()
     }

--- a/src/commonTest/kotlin/baaahs/PinkySpec.kt
+++ b/src/commonTest/kotlin/baaahs/PinkySpec.kt
@@ -34,7 +34,7 @@ object PinkySpec : Spek({
         val clientPort = 1234
 
         val panel17 = SheepModel.Panel("17")
-        val model = SheepModel().apply { surfaces = listOf(panel17) } as Model
+        val model = ModelForTest(listOf(panel17))
 
         val fakeFs by value { FakeFs() }
         val pinky by value {
@@ -47,7 +47,7 @@ object PinkySpec : Spek({
                 fakeFs,
                 PermissiveFirmwareDaddy(),
                 StubSoundAnalyzer(),
-                renderManager = fakeGlslContext.runInContext { RenderManager(TestModel) { fakeGlslContext } },
+                renderManager = fakeGlslContext.runInContext { RenderManager(model) { fakeGlslContext } },
                 plugins = Plugins.safe(),
                 pinkyMainDispatcher = object : CoroutineDispatcher() {
                     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -53,10 +53,10 @@ class ShowRunnerTest {
         dmxUniverse.reader(1, 1) { dmxEvents.add("dmx frame sent") }
         val renderManager = RenderManager(TestModel) { fakeGlslContext }
         fixtureManager = FixtureManager(renderManager)
-        val movingHeadManager = MovingHeadManager(fs, server, emptyList())
+        MovingHeadManager(fixtureManager, dmxUniverse, emptyList(), FakeFs())
         stageManager = StageManager(
             Plugins.safe(), renderManager, server, Storage(fs, Plugins.safe()), fixtureManager,
-            dmxUniverse, movingHeadManager, FakeClock(), sheepModel, testCoroutineContext
+            FakeClock(), sheepModel, testCoroutineContext
         )
         stageManager.switchTo(SampleData.sampleShow)
         renderTargets = fixtureManager.getRenderTargets_ForTestOnly()

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -51,7 +51,8 @@ class ShowRunnerTest {
         fakeGlslContext = FakeGlContext()
         dmxUniverse = FakeDmxUniverse()
         dmxUniverse.reader(1, 1) { dmxEvents.add("dmx frame sent") }
-        val renderManager = RenderManager(TestModel) { fakeGlslContext }
+        val model = TestModel
+        val renderManager = RenderManager(model) { fakeGlslContext }
         fixtureManager = FixtureManager(renderManager)
         MovingHeadManager(fixtureManager, dmxUniverse, emptyList(), FakeFs())
         stageManager = StageManager(

--- a/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/StageManagerSpec.kt
@@ -11,7 +11,6 @@ import baaahs.plugin.Plugins
 import baaahs.show.SampleData
 import baaahs.show.mutable.MutableShow
 import baaahs.shows.FakeGlContext
-import baaahs.sim.FakeDmxUniverse
 import baaahs.sim.FakeFs
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -40,8 +39,6 @@ object StageManagerSpec : Spek({
                 pubSub.server,
                 Storage(fakeFs, plugins),
                 FixtureManager(renderManager),
-                FakeDmxUniverse(),
-                MovingHeadManager(fakeFs, pubSub.server, emptyList()),
                 FakeClock(),
                 model,
                 object : CoroutineDispatcher() {

--- a/src/commonTest/kotlin/baaahs/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/TestUtil.kt
@@ -1,5 +1,6 @@
 package baaahs
 
+import baaahs.fixtures.DeviceType
 import baaahs.fixtures.PixelArrayDevice
 import baaahs.geom.Vector3F
 import baaahs.model.Model
@@ -40,6 +41,12 @@ class FakeClock(var time: Time = 0.0) : Clock {
     override fun now(): Time = time
 }
 
+class FakeModelEntity(
+    override val name: String,
+    override val deviceType: DeviceType = PixelArrayDevice,
+    override val description: String = name
+) : Model.Entity
+
 class TestModelSurface(
     name: String,
     expectedPixelCount: Int? = 1,
@@ -48,12 +55,15 @@ class TestModelSurface(
     override fun allVertices(): Collection<Vector3F> = vertices
 }
 
+fun fakeModel(entities: List<Model.Entity>) = ModelForTest(entities)
+
 object TestModel : ModelForTest(listOf(TestModelSurface("Panel")))
 
 open class ModelForTest(private val entities: List<Entity>) : Model() {
     override val name: String = "Test Model"
     override val movingHeads: List<MovingHead> get() = entities.filterIsInstance<MovingHead>()
     override val allSurfaces: List<Surface> get() = entities.filterIsInstance<Surface>()
+    override val allEntities: List<Entity> get() = entities
     override val geomVertices: List<Vector3F> = emptyList()
 
     override val center: Vector3F

--- a/src/commonTest/kotlin/baaahs/gl/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/gl/TestUtil.kt
@@ -1,6 +1,10 @@
 package baaahs.gl
 
+import baaahs.fixtures.DeviceTypeRenderPlan
+import baaahs.fixtures.ProgramRenderPlan
 import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.render.RenderTarget
 import org.spekframework.spek2.dsl.LifecycleAware
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.meta.*
@@ -23,6 +27,11 @@ fun GlslCode.GlslStatement.esc(lineNumbers: Boolean): String {
         buf.append(" # $lineNumber")
     return buf.toString()
 }
+
+fun renderPlanFor(
+    glslProgram: GlslProgram,
+    vararg renderTargets: RenderTarget
+) = DeviceTypeRenderPlan(listOf(ProgramRenderPlan(glslProgram, renderTargets.toList())))
 
 fun expectStatements(
     expected: List<GlslCode.GlslStatement>,

--- a/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
@@ -11,6 +11,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslAnalyzer
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.override
+import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.shader.PaintShader
 import baaahs.only
@@ -256,6 +257,7 @@ class DeviceTypeForTest(vararg fixtureDataSources: DataSource) : DeviceType {
     override val title: String get() = error("not implemented")
     override val dataSources: List<DataSource> = fixtureDataSources.toList()
     override val resultParams: List<ResultParam> get() = emptyList()
+    override val resultContentType: ContentType get() = error("not implemented")
 }
 
 fun Boolean.truify(): Boolean {

--- a/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
@@ -2,6 +2,7 @@ package baaahs.gl.render
 
 import baaahs.TestModel
 import baaahs.describe
+import baaahs.englishize
 import baaahs.fixtures.DeviceType
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.NullTransport
@@ -13,11 +14,13 @@ import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.override
 import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
+import baaahs.gl.renderPlanFor
 import baaahs.gl.shader.PaintShader
 import baaahs.only
 import baaahs.plugin.Plugins
 import baaahs.show.DataSource
-import baaahs.show.Surfaces
+import baaahs.show.Shader
+import baaahs.show.ShaderType
 import baaahs.show.UpdateMode
 import baaahs.show.live.LiveShaderInstance
 import baaahs.show.live.link
@@ -88,7 +91,7 @@ object ModelRenderEngineSpec : Spek({
             val incomingLinks by value { mapOf("gl_FragCoord" to dataSource.link("coord")) }
             val linkedPatch by value {
                 val liveShaderInstance = LiveShaderInstance(openShader, incomingLinks, null, 0f)
-                LinkedPatch(liveShaderInstance, Surfaces.AllSurfaces)
+                LinkedPatch(liveShaderInstance)
             }
             val program by value {
                 renderEngine.compile(linkedPatch) { _, dataSource -> dataSource.createFixtureFeed() }
@@ -146,13 +149,20 @@ object ModelRenderEngineSpec : Spek({
 
             context("when a fixtures are added") {
                 val fixture1Target by value {
-                    renderEngine.addFixture(testFixture(deviceType, 1, 0f)).also { it.program = initialProgram[0] }
+                    renderEngine.addFixture(testFixture(deviceType, 1, 0f))
                 }
                 val fixture2Target by value {
-                    renderEngine.addFixture(testFixture(deviceType, 2, 0.1f)).also { it.program = initialProgram[0] }
+                    renderEngine.addFixture(testFixture(deviceType, 2, 0.1f))
                 }
                 val addTwoFixtures by value { { fixture1Target.run { }; fixture2Target.run { } } }
-                val drawTwoFrames by value { { renderEngine.draw(); renderEngine.draw() } }
+                val renderPlan by value { renderPlanFor(initialProgram[0]!!, fixture1Target, fixture2Target) }
+                val drawTwoFrames by value {
+                    {
+                        renderEngine.setRenderPlan(renderPlan)
+                        renderEngine.draw()
+                        renderEngine.draw()
+                    }
+                }
 
                 beforeEachTest { addTwoFixtures() }
 
@@ -220,9 +230,7 @@ object ModelRenderEngineSpec : Spek({
 
                             beforeEachTest {
                                 // This causes program to be compiled finally.
-                                fixture1Target.program = program
-                                fixture2Target.program = program
-
+                                renderEngine.setRenderPlan(renderPlanFor(program, fixture1Target, fixture2Target))
                                 renderEngine.draw()
                                 renderEngine.draw()
                             }
@@ -252,12 +260,17 @@ private fun testFixture(deviceType: DeviceTypeForTest, pixelCount: Int, initial:
 private fun someVectors(count: Int, initial: Float = 0f): List<Vector3F> =
     (0 until count).map { Vector3F(initial + count / 10f, 0f, 0f) }
 
-class DeviceTypeForTest(vararg fixtureDataSources: DataSource) : DeviceType {
-    override val id: String get() = error("not implemented")
-    override val title: String get() = error("not implemented")
+class DeviceTypeForTest(
+    vararg fixtureDataSources: DataSource,
+    override val resultContentType: ContentType = ContentType.ColorStream,
+    override val id: String = "testDevice",
+    override val title: String = id.englishize()
+) : DeviceType {
     override val dataSources: List<DataSource> = fixtureDataSources.toList()
     override val resultParams: List<ResultParam> get() = emptyList()
-    override val resultContentType: ContentType get() = error("not implemented")
+    override val errorIndicatorShader: Shader
+        get() = Shader("Ω Guru Meditation Error Ω", ShaderType.Paint, "")
+    override fun toString(): String = id
 }
 
 fun Boolean.truify(): Boolean {

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
@@ -14,6 +14,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslAnalyzer
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
+import baaahs.gl.renderPlanFor
 import baaahs.plugin.CorePlugin
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
@@ -74,7 +75,8 @@ class RenderEngineTest {
             """.trimIndent()
 
         val glslProgram = compileAndBind(program)
-        val renderTarget = renderEngine.addFixture(fakeSurface()).apply { this.program = glslProgram }
+        val renderTarget = renderEngine.addFixture(fakeSurface())
+        renderEngine.setRenderPlan(renderPlanFor(glslProgram, renderTarget))
 
         renderEngine.draw()
 
@@ -101,7 +103,8 @@ class RenderEngineTest {
             """.trimIndent()
 
         val glslProgram = compileAndBind(program)
-        val renderTarget = renderEngine.addFixture(fakeSurface()).apply { this.program = glslProgram }
+        val renderTarget = renderEngine.addFixture(fakeSurface())
+        renderEngine.setRenderPlan(renderPlanFor(glslProgram, renderTarget))
 
         fakeShowPlayer.getGadget<Slider>("blueSlider").value = .1f
         renderEngine.draw()
@@ -137,9 +140,10 @@ class RenderEngineTest {
 
         val glslProgram = compileAndBind(program)
 
-        val renderTarget1 = renderEngine.addFixture(fakeSurface("s1")).apply { this.program = glslProgram }
-        val renderTarget2 = renderEngine.addFixture(fakeSurface("s2", 2)).apply { this.program = glslProgram }
-        val renderTarget3 = renderEngine.addFixture(fakeSurface("s3")).apply { this.program = glslProgram }
+        val renderTarget1 = renderEngine.addFixture(fakeSurface("s1"))
+        val renderTarget2 = renderEngine.addFixture(fakeSurface("s2", 2))
+        val renderTarget3 = renderEngine.addFixture(fakeSurface("s3"))
+        renderEngine.setRenderPlan(renderPlanFor(glslProgram, renderTarget1, renderTarget2, renderTarget3))
 
         renderEngine.draw()
 
@@ -179,8 +183,9 @@ class RenderEngineTest {
 
         val glslProgram = compileAndBind(program)
 
-        val renderTarget1 = renderEngine.addFixture(fakeSurface("s1")).apply { this.program = glslProgram }
-        val renderTarget2 = renderEngine.addFixture(fakeSurface("s2")).apply { this.program = glslProgram }
+        val renderTarget1 = renderEngine.addFixture(fakeSurface("s1"))
+        val renderTarget2 = renderEngine.addFixture(fakeSurface("s2"))
+        renderEngine.setRenderPlan(renderPlanFor(glslProgram, renderTarget1, renderTarget2))
 
         // TODO: yuck, let's not do this [first part]
 //        renderTarget1.uniforms.updateFrom(arrayOf(1f, 1f, 1f, 1f, 1f, 1f, .2f))

--- a/src/commonTest/kotlin/baaahs/glsl/GuruMeditationErrorSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glsl/GuruMeditationErrorSpec.kt
@@ -1,21 +1,21 @@
 package baaahs.glsl
 
-import baaahs.TestModel
 import baaahs.describe
-import baaahs.gl.render.RenderManager
+import baaahs.fixtures.PixelArrayDevice
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeKgl
 import org.spekframework.spek2.Spek
-import kotlin.test.assertNotNull
+import kotlin.test.expect
 
 object GuruMeditationErrorSpec : Spek({
     describe<GuruMeditationError> {
         val gl by value { FakeGlContext(FakeKgl()) }
-        val renderManager by value { RenderManager(TestModel) { gl } }
-        val renderPlan by value { GuruMeditationError.createRenderPlan(renderManager) }
+        val guruMeditationError by value { GuruMeditationError(PixelArrayDevice) }
 
         it("should create a RenderPlan") {
-            assertNotNull(renderPlan)
+            expect(PixelArrayDevice.errorIndicatorShader) {
+                guruMeditationError.linkedPatch.shaderInstance.shader.shader
+            }
         }
     }
 })

--- a/src/commonTest/kotlin/baaahs/shaders/util.kt
+++ b/src/commonTest/kotlin/baaahs/shaders/util.kt
@@ -3,11 +3,13 @@ package baaahs.shaders
 import baaahs.BrainShader
 import baaahs.Color
 import baaahs.Pixels
+import baaahs.fixtures.DeviceType
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.NullTransport
 import baaahs.fixtures.PixelArrayDevice
 import baaahs.io.ByteArrayReader
 import baaahs.io.ByteArrayWriter
+import baaahs.model.Model
 import kotlin.test.expect
 
 private fun <T : BrainShader.Buffer> send(srcBrainShader: BrainShader<T>, srcBuf: T, fixture: Fixture): Pair<BrainShader<T>, T> {
@@ -48,8 +50,12 @@ internal fun <T : BrainShader.Buffer> render(srcBuf: T, fixture: Fixture): Pixel
 internal fun <T : BrainShader.Buffer> render(srcBrainShaderAndBuffer: Pair<BrainShader<T>, T>, fixture: Fixture): Pixels =
     render(srcBrainShaderAndBuffer.second, fixture)
 
-fun fakeFixture(pixelCount: Int) =
-    Fixture(null, pixelCount, emptyList(), PixelArrayDevice, "fake fixture", transport = NullTransport)
+fun fakeFixture(
+    pixelCount: Int,
+    modelEntity: Model.Entity? = null,
+    deviceType: DeviceType = modelEntity?.deviceType ?: PixelArrayDevice
+) =
+    Fixture(modelEntity, pixelCount, emptyList(), deviceType, "Fake ${deviceType.title}", transport = NullTransport)
 
 class FakePixels(override val size: Int) : Pixels {
     private val buf = Array(size) { Color.BLACK }

--- a/src/commonTest/kotlin/baaahs/show/live/ControlDisplaySpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/ControlDisplaySpec.kt
@@ -83,7 +83,7 @@ object ControlDisplaySpec : Spek({
                 expect(
                     (openShow.patches + scene1Button.patches + backdrop11Button.patches).prettyPrint()
                 ) {
-                    openShow.activeSet().getActivePatches().prettyPrint()
+                    openShow.activePatchSet().activePatches.prettyPrint()
                 }
             }
         }

--- a/src/commonTest/kotlin/baaahs/show/live/OpenShowSpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/OpenShowSpec.kt
@@ -39,7 +39,7 @@ object OpenShowSpec : Spek({
             it("creates an empty OpenShow") {
                 expect("Show") { openShow.title }
 
-                expect(emptyList()) { openShow.activeSet().getActivePatches() }
+                expect(emptyList()) { openShow.activePatchSet().activePatches }
             }
         }
 
@@ -70,7 +70,7 @@ object OpenShowSpec : Spek({
                 expect(listOf(true, false)) { scenesButtonGroup.buttons.map { it.isPressed } }
 
                 expect(openShow.patches + scenesButtonGroup.buttons[0].patches) {
-                    openShow.activeSet().getActivePatches()
+                    openShow.activePatchSet().activePatches
                 }
             }
         }

--- a/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
@@ -15,7 +15,6 @@ import baaahs.show.ShaderType
 import baaahs.show.mutable.MutableShow
 import baaahs.show.mutable.ShowBuilder
 import baaahs.shows.FakeGlContext
-import baaahs.sim.FakeDmxUniverse
 import baaahs.sim.FakeFs
 import baaahs.sim.FakeNetwork
 import com.danielgergely.kgl.*
@@ -80,9 +79,8 @@ object ShowRunnerSpec : Spek({
         val stageManager by value {
             val fs = FakeFs()
             StageManager(
-                Plugins.safe(), renderManager, pubSub, Storage(fs, Plugins.safe()), fixtureManager, FakeDmxUniverse(),
-                MovingHeadManager(fs, pubSub, emptyList()), FakeClock(), model, testCoroutineContext
-            )
+                Plugins.safe(), renderManager, pubSub, Storage(fs, Plugins.safe()), fixtureManager,
+                FakeClock(), model, testCoroutineContext)
         }
 
         val fakeProgram by value { fakeGlslContext.programs.only("program") }

--- a/src/jsMain/js/simulator/windows/SheepVisualizerWindow/SheepVisualizerWindow.scss
+++ b/src/jsMain/js/simulator/windows/SheepVisualizerWindow/SheepVisualizerWindow.scss
@@ -12,6 +12,8 @@
 .toolbar {
   flex: 0 0 auto;
   padding: 0 16px;
+  justify-content: space-between;
+  display: flex;
 }
 
 .sheepView {

--- a/src/jsMain/js/simulator/windows/SimulatorSettingsWindow/SimulatorSettingsWindow.jsx
+++ b/src/jsMain/js/simulator/windows/SimulatorSettingsWindow/SimulatorSettingsWindow.jsx
@@ -7,7 +7,9 @@ import styles from "../SheepVisualizerWindow/SheepVisualizerWindow.scss";
 const SimulatorSettingsWindow = (props) => {
   const {state} = React.useContext(store);
   const Console = baaahs.sim.ui.Console;
-  const [isOpen, setIsOpen] = React.useState(false);
+  const GeneratedGlslPalette = baaahs.sim.ui.GeneratedGlslPalette;
+  const [isConsoleOpen, setIsConsoleOpen] = React.useState(false);
+  const [isGlslPaletteOpen, setIsGlslPaletteOpen] = React.useState(false);
   const simulator = state.simulator.facade;
 
   return (
@@ -17,15 +19,27 @@ const SimulatorSettingsWindow = (props) => {
           control={
             <Switch
               size="small"
-              checked={isOpen}
-              onChange={() => setIsOpen(!isOpen)}
+              checked={isConsoleOpen}
+              onChange={() => setIsConsoleOpen(!isConsoleOpen)}
             />
           }
           label="Open"
         />
+
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={isGlslPaletteOpen}
+              onChange={() => setIsGlslPaletteOpen(!isGlslPaletteOpen)}
+            />
+          }
+          label="Show GLSL"
+        />
       </div>
 
-      {isOpen ? <Console simulator={simulator}/> : <div/>}
+      {isConsoleOpen ? <Console simulator={simulator}/> : <div/>}
+      {isGlslPaletteOpen ? <GeneratedGlslPalette pinky={simulator.pinky}/> : <div/>}
     </div>
   );
 };

--- a/src/jsMain/kotlin/baaahs/DeadCodeEliminationDefeater.kt
+++ b/src/jsMain/kotlin/baaahs/DeadCodeEliminationDefeater.kt
@@ -5,6 +5,7 @@ object DeadCodeEliminationDefeater {
     fun noDCE() {
         // Entry points to Kotlin code that are only called by JS:
         baaahs.sim.ui.Console(nuffin())
+        baaahs.sim.ui.GeneratedGlslPalette(nuffin())
         baaahs.visualizer.ui.VisualizerPanel(nuffin())
     }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/CommonIcons.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/CommonIcons.kt
@@ -17,6 +17,7 @@ actual fun getCommonIcons() = object : PlatformIcons {
     override val DistortionShader get() = icon(Icons.Map)
     override val PaintShader get() = icon(Icons.Image)
     override val FilterShader get() = icon(Icons.FilterBAndW)
+    override val MoverShader get() = icon(Icons.OpenWith)
 
     override val BeatLinkControl get() = icon(Icons.AvTimer)
     override val Button get() = icon(Icons.CropLandscape)

--- a/src/jsMain/kotlin/baaahs/gl/render/ProjectionPreview.kt
+++ b/src/jsMain/kotlin/baaahs/gl/render/ProjectionPreview.kt
@@ -1,7 +1,9 @@
 package baaahs.gl.render
 
+import baaahs.fixtures.DeviceTypeRenderPlan
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.NullTransport
+import baaahs.fixtures.ProgramRenderPlan
 import baaahs.gl.GlBase
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.preview.ProjectionPreviewDevice
@@ -45,9 +47,11 @@ class ProjectionPreview(
     }
 
     override fun setProgram(program: GlslProgram) {
-        renderTargets.forEach { (_, renderTarget) ->
-            renderTarget.program = program
-        }
+        renderEngine.setRenderPlan(
+            DeviceTypeRenderPlan(
+                listOf(ProgramRenderPlan(program, renderTargets.values.toList()))
+            )
+        )
         projectionProgram = program
     }
 

--- a/src/jsMain/kotlin/baaahs/sim/ui/GeneratedGlslPalette.kt
+++ b/src/jsMain/kotlin/baaahs/sim/ui/GeneratedGlslPalette.kt
@@ -1,0 +1,69 @@
+package baaahs.sim.ui
+
+import baaahs.Pinky
+import baaahs.ui.and
+import baaahs.ui.on
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
+import external.react_draggable.Draggable
+import materialui.components.paper.enums.PaperStyle
+import materialui.components.paper.paper
+import materialui.components.portal.portal
+import materialui.components.typography.typographyH6
+import materialui.icon
+import materialui.icons.Icons
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+import react.dom.div
+import react.dom.header
+import react.dom.i
+import react.dom.pre
+
+val GeneratedGlslPalette = xComponent<GeneratedGlslPaletteProps>("GeneratedGlslPalette") { props ->
+    portal {
+        Draggable {
+            val randomStyleForHandle = "PinkyPanelHandle"
+            attrs.handle = ".$randomStyleForHandle"
+
+            div(+Styles.glslCodeSheet) {
+                div(+Styles.dragHandle and randomStyleForHandle) {
+                    icon(Icons.DragIndicator)
+                }
+
+                paper(Styles.glslCodePaper on PaperStyle.root) {
+                    attrs.elevation = 3
+
+                    typographyH6 { +"Generated GLSL" }
+
+                    div(+Styles.glslCodeDiv) {
+                        val renderPlan = props.pinky.stageManager.currentRenderPlan
+                        if (renderPlan == null) {
+                            i { +"No plans!" }
+                        } else {
+                            renderPlan.forEach { (deviceType, deviceTypeRenderPlans) ->
+                                deviceTypeRenderPlans.forEach { programRenderPlan ->
+                                    header {
+                                        +"${deviceType.title}: ${programRenderPlan.renderTargets.size} fixtures"
+                                    }
+
+                                    programRenderPlan.program?.fragShader?.source
+                                        ?.let { glsl -> pre { +glsl } }
+                                        ?: i { +"No program!" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+external interface GeneratedGlslPaletteProps : RProps {
+    var pinky: Pinky.Facade
+}
+
+fun RBuilder.generatedGlslPalette(handler: RHandler<GeneratedGlslPaletteProps>) =
+    child(GeneratedGlslPalette, handler = handler)

--- a/src/jsMain/kotlin/baaahs/sim/ui/PinkyPanel.kt
+++ b/src/jsMain/kotlin/baaahs/sim/ui/PinkyPanel.kt
@@ -49,8 +49,8 @@ class PinkyPanel(props: PinkyPanelProps) : BComponent<PinkyPanelProps, PinkyPane
                             typographyH6 { +"Generated GLSL" }
 
                             div(+Styles.glslCodeDiv) {
-                                props.pinky.stageManager.currentGlsl?.forEach { (surfaces, glsl) ->
-                                    header { +surfaces.name }
+                                props.pinky.stageManager.currentGlsl?.forEach { (surfaceName, glsl) ->
+                                    header { +surfaceName }
                                     pre { +glsl }
                                 }
                             }

--- a/src/jsMain/kotlin/baaahs/sim/ui/PinkyPanel.kt
+++ b/src/jsMain/kotlin/baaahs/sim/ui/PinkyPanel.kt
@@ -4,18 +4,7 @@ import baaahs.Pinky
 import baaahs.ui.*
 import baaahs.ui.SimulatorStyles.beatsDiv
 import baaahs.util.percent
-import external.react_draggable.Draggable
 import kotlinx.css.*
-import kotlinx.html.id
-import kotlinx.html.js.onChangeFunction
-import materialui.components.formcontrollabel.formControlLabel
-import materialui.components.paper.enums.PaperStyle
-import materialui.components.paper.paper
-import materialui.components.portal.portal
-import materialui.components.switches.switch
-import materialui.components.typography.typographyH6
-import materialui.icon
-import materialui.icons.Icons
 import react.*
 import react.dom.*
 import styled.StyleSheet
@@ -33,31 +22,6 @@ class PinkyPanel(props: PinkyPanelProps) : BComponent<PinkyPanelProps, PinkyPane
         val pinky = props.pinky
 
         if (state.showGlsl) {
-            portal {
-                Draggable {
-                    val randomStyleForHandle = "PinkyPanelHandle"
-                    attrs.handle = ".$randomStyleForHandle"
-
-                    div(+Styles.glslCodeSheet) {
-                        div(+Styles.dragHandle and randomStyleForHandle) {
-                            icon(Icons.DragIndicator)
-                        }
-
-                        paper(Styles.glslCodePaper on PaperStyle.root) {
-                            attrs.elevation = 3
-
-                            typographyH6 { +"Generated GLSL" }
-
-                            div(+Styles.glslCodeDiv) {
-                                props.pinky.stageManager.currentGlsl?.forEach { (surfaceName, glsl) ->
-                                    header { +surfaceName }
-                                    pre { +glsl }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         val currentShowTitle = pinky.stageManager.currentShow?.title
@@ -65,7 +29,6 @@ class PinkyPanel(props: PinkyPanelProps) : BComponent<PinkyPanelProps, PinkyPane
             css { +SimulatorStyles.section }
             b { +"Pinky:" }
             div {
-                attrs.id = "pinkyView" // TODO: kill
                 +"Current Show: "
                 b {
                     if (currentShowTitle == null) {
@@ -74,17 +37,6 @@ class PinkyPanel(props: PinkyPanelProps) : BComponent<PinkyPanelProps, PinkyPane
                         +currentShowTitle
                     }
                 }
-            }
-
-            formControlLabel {
-                attrs.control {
-                    switch {
-                        attrs["size"] = "small"
-                        attrs.checked = state.showGlsl
-                        attrs.onChangeFunction = { state.showGlsl = !state.showGlsl}
-                    }
-                }
-                attrs.label { +"Show GLSL" }
             }
 
             br { }

--- a/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
@@ -12,7 +12,6 @@ import info.laht.threekt.cameras.PerspectiveCamera
 import info.laht.threekt.core.Geometry
 import info.laht.threekt.core.Object3D
 import info.laht.threekt.geometries.ConeBufferGeometry
-import info.laht.threekt.geometries.CylinderBufferGeometry
 import info.laht.threekt.geometries.SphereBufferGeometry
 import info.laht.threekt.materials.MeshBasicMaterial
 import info.laht.threekt.materials.PointsMaterial
@@ -160,6 +159,8 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
         return VizMovingHead(movingHead, dmxUniverse)
     }
 
+    val coneLength = 1000.0
+
     inner class VizMovingHead(private val movingHead: MovingHead, dmxUniverse: FakeDmxUniverse) {
         private val dmxChannelMapping = Config.findDmxChannelMapping(movingHead)
         private val adapter = run {
@@ -176,8 +177,8 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
             opacity = .75
             depthTest = false
         }
-        private val innerConeGeometry = ConeBufferGeometry(20, 1000)
-            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -500.0, 0.0)) }
+        private val innerConeGeometry = ConeBufferGeometry(20, coneLength, openEnded = true)
+            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -coneLength / 2, 0.0)) }
         private val innerCone = Mesh(innerConeGeometry, innerConeMaterial)
 
         private val outerConeMaterial = MeshBasicMaterial().apply {
@@ -188,8 +189,8 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
             blending = THREE.AdditiveBlending
             depthTest = false
         }
-        private val outerConeGeometry = ConeBufferGeometry(50, 1000)
-            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -500.0, 0.0)) }
+        private val outerConeGeometry = ConeBufferGeometry(50, coneLength, openEnded = true)
+            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -coneLength / 2, 0.0)) }
         private val outerCone = Mesh(outerConeGeometry, outerConeMaterial)
 
         private val materials = listOf(innerConeMaterial, outerConeMaterial)

--- a/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
@@ -12,9 +12,11 @@ import info.laht.threekt.cameras.PerspectiveCamera
 import info.laht.threekt.core.Geometry
 import info.laht.threekt.core.Object3D
 import info.laht.threekt.geometries.ConeBufferGeometry
+import info.laht.threekt.geometries.CylinderBufferGeometry
 import info.laht.threekt.geometries.SphereBufferGeometry
 import info.laht.threekt.materials.MeshBasicMaterial
 import info.laht.threekt.materials.PointsMaterial
+import info.laht.threekt.math.Matrix4
 import info.laht.threekt.math.Vector2
 import info.laht.threekt.math.Vector3
 import info.laht.threekt.objects.Mesh
@@ -175,6 +177,7 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
             depthTest = false
         }
         private val innerConeGeometry = ConeBufferGeometry(20, 1000)
+            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -500.0, 0.0)) }
         private val innerCone = Mesh(innerConeGeometry, innerConeMaterial)
 
         private val outerConeMaterial = MeshBasicMaterial().apply {
@@ -186,6 +189,7 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
             depthTest = false
         }
         private val outerConeGeometry = ConeBufferGeometry(50, 1000)
+            .also { it.applyMatrix(Matrix4().makeTranslation(0.0, -500.0, 0.0)) }
         private val outerCone = Mesh(outerConeGeometry, outerConeMaterial)
 
         private val materials = listOf(innerConeMaterial, outerConeMaterial)
@@ -193,18 +197,13 @@ class Visualizer(model: Model) : JsMapperUi.StatusListener {
 
         init {
             cones.forEach { cone ->
-                cone.position.set(movingHead.origin.x, movingHead.origin.y, movingHead.origin.z)
+                cone.position.set(movingHead.origin.x - 500, movingHead.origin.y, movingHead.origin.z)
                 cone.rotation.set(movingHead.heading.x, movingHead.heading.y, movingHead.heading.z)
                 scene.add(cone)
             }
         }
 
         private fun receivedDmxFrame() {
-            logger.info {
-                "Received DMX frame for ${movingHead.name}:" +
-                        " color=${adapter.color} pan=${adapter.pan} tilt=${adapter.tilt}"
-            }
-
             materials.forEach { material ->
                 material.color.set(adapter.color.rgb)
                 material.visible = adapter.dimmer > .1

--- a/src/jsMain/kotlin/materialui/icons/Icons.kt
+++ b/src/jsMain/kotlin/materialui/icons/Icons.kt
@@ -41,6 +41,7 @@ external object Icons {
     val NotInterested: Icon
     val NotificationImportant: Icon
     val OpenInBrowser: Icon
+    val OpenWith: Icon
     val Palette: Icon
     val PowerInput: Icon
     val Redo: Icon

--- a/src/jvmMain/kotlin/baaahs/PinkyMain.kt
+++ b/src/jvmMain/kotlin/baaahs/PinkyMain.kt
@@ -1,5 +1,6 @@
 package baaahs
 
+import baaahs.dmx.Dmx
 import baaahs.dmx.DmxDevice
 import baaahs.gl.GlBase
 import baaahs.gl.render.RenderManager

--- a/src/jvmMain/kotlin/baaahs/app/ui/PlatformIconsJvm.kt
+++ b/src/jvmMain/kotlin/baaahs/app/ui/PlatformIconsJvm.kt
@@ -13,6 +13,7 @@ actual fun getCommonIcons(): PlatformIcons = object : PlatformIcons {
     override val DistortionShader: Icon = FakeIcon
     override val FilterShader: Icon = FakeIcon
     override val PaintShader: Icon = FakeIcon
+    override val MoverShader: Icon = FakeIcon
     override val ProjectionShader: Icon = FakeIcon
     override val BeatLinkControl: Icon = FakeIcon
     override val Button: Icon = FakeIcon

--- a/src/jvmMain/kotlin/baaahs/dmx/DmxDevice.kt
+++ b/src/jvmMain/kotlin/baaahs/dmx/DmxDevice.kt
@@ -1,6 +1,5 @@
 package baaahs.dmx
 
-import baaahs.Dmx
 import com.ftdichip.ftd2xx.*
 
 class DmxDevice(usbDevice: Device) : Dmx.Universe() {

--- a/src/jvmTest/kotlin/baaahs/fixtures/FixtureManagerSpec.kt
+++ b/src/jvmTest/kotlin/baaahs/fixtures/FixtureManagerSpec.kt
@@ -1,0 +1,167 @@
+package baaahs.fixtures
+
+import baaahs.*
+import baaahs.gl.glsl.GlslAnalyzer
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.override
+import baaahs.gl.patch.ContentType
+import baaahs.gl.render.DeviceTypeForTest
+import baaahs.gl.render.RenderManager
+import baaahs.gl.render.RenderTarget
+import baaahs.gl.shader.InputPort
+import baaahs.gl.shader.OpenShader
+import baaahs.gl.shader.OutputPort
+import baaahs.model.Model
+import baaahs.plugin.Plugins
+import baaahs.shaders.fakeFixture
+import baaahs.show.Shader
+import baaahs.show.ShaderChannel
+import baaahs.show.ShaderType
+import baaahs.show.live.ShowOpener
+import baaahs.show.mutable.MutableShow
+import baaahs.shows.FakeGlContext
+import baaahs.shows.FakeShowPlayer
+import org.spekframework.spek2.Spek
+import kotlin.test.expect
+
+object FixtureManagerSpec : Spek({
+    describe<FixtureManager> {
+        val modelEntities by value { emptyList<Model.Entity>() }
+        val model by value { fakeModel(modelEntities) }
+        val renderManager by value { RenderManager(model) { FakeGlContext() } }
+        val renderTargets by value { linkedMapOf<Fixture, RenderTarget>() }
+        val fixtureManager by value { FixtureManager(renderManager, renderTargets) } // Maintain stable fixture order for test.
+
+        context("when fixtures of multiple types have been added") {
+            val fogginess by value { ContentType("Fogginess", GlslType.Float) }
+            val fogMachineDevice by value { DeviceTypeForTest(id = "fogMachine", resultContentType = fogginess) }
+
+            val deafeningness by value { ContentType("Deafeningness", GlslType.Float) }
+            val vuzuvelaDevice by value { DeviceTypeForTest(id = "vuzuvela", resultContentType = deafeningness) }
+
+            val fogMachine1 by value { fakeFixture(1, FakeModelEntity("fog1", fogMachineDevice)) }
+            val fogMachine2 by value { fakeFixture(1, FakeModelEntity("fog2", fogMachineDevice)) }
+            val vuzuvela1 by value { fakeFixture(1, FakeModelEntity("vuzuvela1", vuzuvelaDevice)) }
+            val vuzuvela2 by value { fakeFixture(1, FakeModelEntity("vuzuvela2", vuzuvelaDevice)) }
+            val fixtures by value { listOf(fogMachine1, fogMachine2, vuzuvela1, vuzuvela2) }
+            override(modelEntities) { fixtures.map { it.modelEntity } }
+            val initialFixtures by value { fixtures }
+
+            beforeEachTest {
+                fixtureManager.fixturesChanged(initialFixtures, emptyList())
+            }
+
+            context("generating programs to cover every fixture") {
+                val show by value {
+                    MutableShow("Test Show") {
+                        addPatch {
+                            addShaderInstance(
+                                Shader(
+                                    "Pea Soup", ShaderType.Paint, """
+                                    vec4 main() { return vec4(0.); }
+                                """.trimIndent()
+                                )
+                            )
+                            addShaderInstance(
+                                Shader(
+                                    "Din", ShaderType.Paint, """
+                                    vec4 main() { return vec4(0.); }
+                                """.trimIndent()
+                                )
+                            )
+                        }
+                    }.getShow()
+                }
+
+                val openShow by value {
+                    val glslAnalyzer = GlslAnalyzer(Plugins.safe())
+                    object : ShowOpener(glslAnalyzer, show, FakeShowPlayer(model)) {
+                        override fun openShader(shader: Shader): OpenShader {
+                            val contentType = when (shader.title) {
+                                "Pea Soup" -> fogginess
+                                "Din" -> deafeningness
+                                else -> error("unknown shader")
+                            }
+                            return FakeOpenShader(OutputPort(contentType), shader.title)
+                        }
+                    }.openShow()
+                }
+
+                val activePatchSet by value { openShow.activePatchSet() }
+
+                beforeEachTest {
+                    fixtureManager.activePatchSetChanged(activePatchSet)
+                    val updated = fixtureManager.maybeUpdateRenderPlans { _, _ -> null }
+                    expect(true) { updated }
+                }
+
+                val renderPlan by value { fixtureManager.currentRenderPlan!! }
+                val fogMachinePrograms by value { renderPlan[fogMachineDevice]!!.programs }
+                val vuzuvelaPrograms by value { renderPlan[vuzuvelaDevice]!!.programs }
+
+                it("creates a RenderPlan to cover all device types") {
+                    val fogMachineProgram = fogMachinePrograms.only("program")
+                    val vuzuvelaProgram = vuzuvelaPrograms.only("program")
+
+                    expect(listOf(fogMachine1, fogMachine2)) { fogMachineProgram.renderTargets.map { it.fixture } }
+                    expect(listOf(vuzuvela1, vuzuvela2)) { vuzuvelaProgram.renderTargets.map { it.fixture } }
+
+                    expect("Pea Soup") { fogMachineProgram.program!!.title }
+                    expect("Din") { vuzuvelaProgram.program!!.title }
+                }
+
+                context("when more fixtures are added") {
+                    override(initialFixtures) { listOf(fogMachine1) }
+
+                    beforeEachTest {
+                        expect(setOf(fogMachineDevice)) { renderPlan.keys }
+
+                        fixtureManager.fixturesChanged(listOf(vuzuvela1), emptyList())
+                        val updated = fixtureManager.maybeUpdateRenderPlans { _, _ -> null }
+                        expect(true) { updated }
+                    }
+
+                    it("updates the RenderPlan to include the new fixture") {
+                        val newRenderPlan = fixtureManager.currentRenderPlan!!
+                        expect(setOf(fogMachineDevice, vuzuvelaDevice)) { newRenderPlan.keys }
+                    }
+                }
+            }
+        }
+    }
+})
+
+class FakeOpenShader(
+    override val outputPort: OutputPort,
+    override val title: String
+) : OpenShader, RefCounted by RefCounter() {
+    override val shader: Shader
+        get() = Shader(title, ShaderType.Paint /* not necessarily true */, "fake src for $title")
+    override val glslCode: GlslCode
+        get() = GlslCode(shader.src, emptyList())
+    override val entryPointName: String
+        get() = "entryPoint"
+    override val inputPorts: List<InputPort>
+        get() = emptyList()
+    override val defaultPriority: Int
+        get() = TODO("not implemented")
+    override val defaultUpstreams: Map<ContentType, ShaderChannel>
+        get() = TODO("not implemented")
+
+    override fun findInputPort(portId: String): InputPort {
+        TODO("not implemented")
+    }
+
+    override fun toGlsl(namespace: GlslCode.Namespace, portMap: Map<String, String>): String {
+        return "glslFor($title);\n"
+    }
+
+    override fun invocationGlsl(
+        namespace: GlslCode.Namespace,
+        resultVar: String,
+        portMap: Map<String, String>
+    ): String {
+        return "invocationGlslFor($title);\n"
+    }
+}


### PR DESCRIPTION
- Moving head visualization is back up.
- * Values from render are sent out over DMX.
- * Move BAAAHS' eyes to the right spots.
- * Double cones in visualizer.
- Hacky but working control of moving heads from shaders.
- Fairly working support for moving head control.
- * Less naive handling mapping of shaders to device types.
- * Surfaces matchers are now inclusive/additive.
- * MoverShaders can currently control pan and tilt.
- * DeviceTypes declare their own guru meditation error shaders.
- * Beginning to tease apart ShaderType from wiring decisions.
- * Show GLSL for all device types in floating palette in simulator.