### PR TITLE
Datasources have channels

### DIFF
--- a/src/commonMain/kotlin/baaahs/ShowRunner.kt
+++ b/src/commonMain/kotlin/baaahs/ShowRunner.kt
@@ -71,9 +71,7 @@ class ShowRunner(
             fixtureManager.activePatchSetChanged(openShow.activePatchSet())
         }
 
-        return fixtureManager.maybeUpdateRenderPlans { _, dataSource ->
-            openShow.feeds.getBang(dataSource, "data feed")
-        }
+        return fixtureManager.maybeUpdateRenderPlans(openShow)
     }
 
     fun shutDown() {

--- a/src/commonMain/kotlin/baaahs/SparkleMotion.kt
+++ b/src/commonMain/kotlin/baaahs/SparkleMotion.kt
@@ -4,4 +4,6 @@ object SparkleMotion {
     const val MAX_PIXEL_COUNT = 2048
     const val DEFAULT_PIXEL_COUNT = 1024
     const val PIXEL_COUNT_UNKNOWN = -1
+
+    const val EXTRA_ASSERTIONS = true
 }

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -1,11 +1,11 @@
 package baaahs.fixtures
 
-import baaahs.gl.glsl.FeedResolver
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.PatchResolver
 import baaahs.gl.render.RenderManager
 import baaahs.gl.render.RenderTarget
 import baaahs.show.live.ActivePatchSet
+import baaahs.show.live.OpenShow
 import baaahs.timeSync
 import baaahs.util.Logger
 
@@ -87,7 +87,7 @@ class FixtureManager(
         }
     }
 
-    fun maybeUpdateRenderPlans(feedResolver: FeedResolver): Boolean {
+    fun maybeUpdateRenderPlans(openShow: OpenShow): Boolean {
         var remapFixtures = incorporateFixtureChanges()
 
         // Maybe build new shaders.
@@ -96,8 +96,8 @@ class FixtureManager(
             val activePatchSet = currentActivePatchSet
 
             val elapsedMs = timeSync {
-                val patchResolution = PatchResolver(renderManager, renderTargets.values, activePatchSet)
-                currentRenderPlan = patchResolution.createRenderPlan(feedResolver)
+                val patchResolution = PatchResolver(openShow, renderManager, renderTargets.values, activePatchSet)
+                currentRenderPlan = patchResolution.createRenderPlan()
             }
 
             logger.info {

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -1,5 +1,6 @@
 package baaahs.fixtures
 
+import baaahs.getBang
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.PatchResolver
 import baaahs.gl.render.RenderManager
@@ -96,8 +97,11 @@ class FixtureManager(
             val activePatchSet = currentActivePatchSet
 
             val elapsedMs = timeSync {
-                val patchResolution = PatchResolver(openShow, renderManager, renderTargets.values, activePatchSet)
-                currentRenderPlan = patchResolution.createRenderPlan()
+                val patchResolution = PatchResolver(
+                    openShow.allDataSources, renderManager, renderTargets.values, activePatchSet)
+                currentRenderPlan = patchResolution.createRenderPlan { _, dataSource ->
+                    openShow.feeds.getBang(dataSource, "data feed")
+                }
             }
 
             logger.info {

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslProgram.kt
@@ -17,7 +17,7 @@ class GlslProgram(
     private val linkedPatch: LinkedPatch,
     engineFeedResolver: EngineFeedResolver
 ) {
-    val title: String get() = linkedPatch.shaderInstance.shader.title
+    val title: String get() = linkedPatch.rootNode.title
 
     private val vertexShader =
         gl.createVertexShader(

--- a/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
@@ -35,12 +35,6 @@ class AutoWirer(
         parentMutableShow: MutableShow? = null,
         defaultPorts: Map<ContentType, MutablePort> = emptyMap()
     ): UnresolvedPatch {
-        val locallyAvailable: MutableMap<ContentType, MutableSet<MutablePort>> = mutableMapOf()
-
-        defaultPorts.forEach { (contentType, port) ->
-            locallyAvailable[contentType] = hashSetOf(port)
-        }
-
         val siblingsPatch = MutablePatch {
             shaders.forEach { addShaderInstance(it.shader) }
         }
@@ -50,6 +44,7 @@ class AutoWirer(
             shaders.associateWith { openShader ->
                 val shaderInstanceOptions = ShaderInstanceOptions(
                     openShader,
+// TODO                   parentMutableShow = parentMutableShow,
                     parentMutablePatch = siblingsPatch,
                     defaultPorts = defaultPorts,
                     currentLinks = emptyMap(),

--- a/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/AutoWirer.kt
@@ -16,17 +16,19 @@ class AutoWirer(
 ) {
     fun autoWire(
         vararg shaders: Shader,
-        defaultPorts: Map<ContentType, MutablePort> = emptyMap()
+        defaultPorts: Map<ContentType, MutablePort> = emptyMap(),
+        shaderChannel: ShaderChannel = ShaderChannel.Main
     ): UnresolvedPatch {
         val openShaders = shaders.associate { it to glslAnalyzer.openShader(it) }
-        return autoWire(openShaders.values, defaultPorts = defaultPorts)
+        return autoWire(openShaders.values, defaultPorts = defaultPorts, shaderChannel = shaderChannel)
     }
 
     fun autoWire(
         vararg shaders: OpenShader,
-        defaultPorts: Map<ContentType, MutablePort> = emptyMap()
-    ): UnresolvedPatch {
-        return autoWire(shaders.toList(), defaultPorts = defaultPorts)
+        defaultPorts: Map<ContentType, MutablePort> = emptyMap(),
+        shaderChannel: ShaderChannel = ShaderChannel.Main
+        ): UnresolvedPatch {
+        return autoWire(shaders.toList(), defaultPorts = defaultPorts, shaderChannel = shaderChannel)
     }
 
     fun autoWire(

--- a/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
@@ -1,14 +1,14 @@
 package baaahs.gl.patch
 
 import baaahs.gl.glsl.GlslCode
-import baaahs.show.live.LiveShaderInstance
 import baaahs.show.live.LiveShaderInstance.DataSourceLink
 
 class LinkedPatch(
-    val shaderInstance: LiveShaderInstance,
+    val rootNode: ProgramNode,
     private val components: List<Component>,
     val dataSourceLinks: Set<DataSourceLink>,
-    private var structs: Set<GlslCode.GlslStruct>
+    private var structs: Set<GlslCode.GlslStruct>,
+    val warnings: List<String>
 ) {
     fun toGlsl(): String {
         val buf = StringBuilder()
@@ -18,7 +18,7 @@ class LinkedPatch(
         buf.append("\n")
         buf.append("// SparkleMotion-generated GLSL\n")
         buf.append("\n")
-        with(shaderInstance.shader.outputPort) {
+        with(rootNode.outputPort) {
             buf.append("layout(location = 0) out ${dataType.glslLiteral} sm_result;\n")
         }
         buf.append("\n")

--- a/src/commonMain/kotlin/baaahs/gl/patch/PortDiagram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/PortDiagram.kt
@@ -14,29 +14,27 @@ class PortDiagram(
     private val dataSourceChannelLinks = dataSources.map { (id, dataSource) ->
         (id to dataSource.contentType) to LiveShaderInstance.DataSourceLink(dataSource, id)
     }.associate { it }
-    private val candidates: Map<Lookup, List<ChannelEntry>>
-    private val resolved = hashMapOf<Lookup, LiveShaderInstance>()
+    private val candidates: Map<Track, Candidates>
+    private val resolvedNodes = hashMapOf<LiveShaderInstance, ProgramNode>()
 
     init {
-        val candidates = hashMapOf<Lookup, MutableList<ChannelEntry>>()
+        val candidates = hashMapOf<Track, MutableList<ChannelEntry>>()
         var level = 0
 
-        fun addToChannel(shaderChannel: ShaderChannel, contentType: ContentType, shaderInstance: LiveShaderInstance, level: Int) {
-            candidates.getOrPut(shaderChannel to contentType) { arrayListOf() }
-                .add(
-                    ChannelEntry(
-                        shaderInstance,
-                        shaderInstance.priority,
-                        level
-                    )
-                )
+        fun addToChannel(track: Track, shaderInstance: LiveShaderInstance, level: Int) {
+            val channelTypeCandidates = candidates.getOrPut(track) { arrayListOf() }
+            if (channelTypeCandidates.any { it.shaderInstance == shaderInstance }) {
+                throw error("candidates for $track already include ${shaderInstance.shader.title}")
+            }
+            channelTypeCandidates.add(ChannelEntry(shaderInstance, shaderInstance.priority, level))
         }
 
         fun add(patch: OpenPatch) {
             patch.shaderInstances.forEach { liveShaderInstance ->
                 if (liveShaderInstance.shaderChannel != null) {
                     val outputPort = liveShaderInstance.shader.outputPort
-                    addToChannel(liveShaderInstance.shaderChannel, outputPort.contentType, liveShaderInstance, level)
+                    val track = Track(liveShaderInstance.shaderChannel, outputPort.contentType)
+                    addToChannel(track, liveShaderInstance, level)
                 }
             }
 
@@ -45,80 +43,156 @@ class PortDiagram(
 
         patches.forEach { add(it) }
 
-        this.candidates = candidates
+        this.candidates = candidates.mapValues { (_, entries) -> Candidates(entries) }
     }
 
     fun resolvePatch(shaderChannel: ShaderChannel, contentType: ContentType): LinkedPatch? {
-        return Resolver().resolve(shaderChannel, contentType)
-            ?.let { ProgramLinker(it).buildLinkedPatch() }
+        val track = Track(shaderChannel, contentType)
+        val resolver = Resolver()
+        val rootProgramNode = resolver.resolve(track)
+
+        return if (rootProgramNode != null) {
+            logger.debug { "Resolved $track to $rootProgramNode." }
+            ProgramLinker(rootProgramNode, resolver.warnings).buildLinkedPatch()
+        } else {
+            logger.warn { "Failed to resolve $track." }
+            null
+        }
+    }
+
+    data class Track(val shaderChannel: ShaderChannel, val contentType: ContentType) {
+        override fun toString(): String {
+            return "Track[${shaderChannel.id}/${contentType.id}]"
+        }
+    }
+
+    private class Candidates(entries: List<ChannelEntry>) {
+        val sortedEntries = entries.sortedWith(
+            compareByDescending<ChannelEntry> { it.typePriority }
+                .thenByDescending { it.priority }
+                .thenByDescending { it.level }
+                .thenByDescending { it.shaderInstance.shader.title }
+        )
+
+        fun iterator(): Iterator<LiveShaderInstance> {
+            return sortedEntries
+                .map { it.shaderInstance }
+                .iterator()
+        }
+    }
+
+    class Breadcrumb(
+        val track: Track
+    ) {
+        var instance: LiveShaderInstance? = null
+        var resolvingInputPort: InputPort? = null
+        override fun toString(): String {
+            return "Resolving $track" +
+                    (instance?.let { " -> [${it.shader.title}]"} ?: "") +
+                    (resolvingInputPort?.let { ".${it.id} (${it.contentType?.id ?: "unknown content type"})"} ?: "")
+        }
     }
 
     inner class Resolver {
-        private val channelIterators =
-            hashMapOf<Lookup, Iterator<LiveShaderInstance>>()
+        private val trackResolvers = mutableMapOf<Track, TrackResolver>()
+        private val breadcrumbs = mutableListOf<Breadcrumb>()
+        private val currentBreadcrumb get() = breadcrumbs.last()
+        internal val warnings = mutableListOf<String>()
 
-        fun resolve(shaderChannel: ShaderChannel, contentType: ContentType): LiveShaderInstance? {
-            return resolveNext(shaderChannel, contentType).also {
-                logger.debug { "Resolved $shaderChannel/$contentType to $it"}
-                if (it != null) resolved[shaderChannel to contentType] = it
-            }
+        fun resolve(track: Track): ProgramNode? {
+            return trackResolvers.getOrPut(track) { TrackResolver(track) }
+                .resolve()
         }
 
-        private fun nextOf(shaderChannel: ShaderChannel, contentType: ContentType): LiveShaderInstance? {
-            resolved[shaderChannel to contentType]?.let { return it }
-
-            val iterator = channelIterators.getOrPut(shaderChannel to contentType) {
-                candidates[shaderChannel to contentType]
-                    ?.sortedWith(
-                        compareByDescending<ChannelEntry> { it.typePriority }
-                            .thenByDescending { it.priority }
-                            .thenByDescending { it.level }
-                            .thenByDescending { it.shaderInstance.shader.title }
-                    )
-                    ?.map { it.shaderInstance }?.iterator()
-                    ?: emptyList<LiveShaderInstance>().iterator()
-            }
-            return if (iterator.hasNext()) iterator.next() else null
-        }
-
-        private fun resolveNext(shaderChannel: ShaderChannel, contentType: ContentType): LiveShaderInstance? {
-            val nextInstance = nextOf(shaderChannel, contentType)
-            return nextInstance?.let { shaderInstance ->
-                LiveShaderInstance(
-                    shaderInstance.shader,
-                    shaderInstance.incomingLinks.mapValues { (portId, link) ->
-                        link.finalResolve(shaderInstance.shader.findInputPort(portId), this)
-                    },
-                    shaderChannel,
-                    shaderInstance.priority
+        fun resolveChannel(inputPort: InputPort, shaderChannel: ShaderChannel): ProgramNode {
+            val contentType = inputPort.contentType
+                ?: throw ResolveException(
+                    "attempt to resolve a channel for a port with no content type",
+                    message = "resolveChannel(inputPort=${inputPort.id}, channel=${shaderChannel.id}))"
                 )
-            }
+
+            val track = Track(shaderChannel, contentType)
+            return resolve(track)
+                ?: tryDataSource(shaderChannel, contentType)
+                ?: run {
+                    addWarning("No upstream shader found, using default for ${contentType.id}.")
+                    DefaultValueNode(contentType)
+                }
         }
 
-        fun tryDataSource(shaderChannel: ShaderChannel, contentType: ContentType): LiveShaderInstance.DataSourceLink? {
+        private fun addWarning(message: String) {
+            warnings.add("$message\n" +
+                    "Stack:" +
+                    breadcrumbs.asReversed().joinToString { "\n    $it" }
+            )
+        }
+
+        fun resolveLink(inputPort: InputPort, link: LiveShaderInstance.Link): ProgramNode {
+            currentBreadcrumb.resolvingInputPort = inputPort
+            return link.finalResolve(inputPort, this@Resolver)
+        }
+
+        private fun tryDataSource(
+            shaderChannel: ShaderChannel,
+            contentType: ContentType
+        ): LiveShaderInstance.DataSourceLink? {
             return dataSourceChannelLinks[shaderChannel.id to contentType]
         }
 
-        fun resolveChannel(inputPort: InputPort, shaderChannel: ShaderChannel): LiveShaderInstance.Link? {
-            val contentType = inputPort.contentType
-                ?: return null.also {
-                    // TODO: This should probably show a user-visible error.
-                    logger.error {
-                        "No content type specified for port ${inputPort.id};" +
-                                " it's required to resolve on channel ${shaderChannel.id}" }
-                }
-            val resolved = resolve(shaderChannel, contentType)
-            return if (resolved != null)
-                LiveShaderInstance.ShaderOutLink(resolved)
-            else {
-                tryDataSource(shaderChannel, contentType)
-                    ?: run {
-                        // TODO: This should probably show a user-visible error.
-                        logger.error {
-                            "No upstream shader found for port ${inputPort.id}" +
-                                    " (${inputPort.contentType}) on channel ${shaderChannel.id}" }
-                        null
+
+        inner class TrackResolver(private val track: Track) {
+            private val channelIterators = hashMapOf<Track, Iterator<LiveShaderInstance>>()
+            private val dagAncestors = hashSetOf<LiveShaderInstance>()
+
+            private var resolved = false
+            private var resolution: ProgramNode? = null
+
+            fun resolve(): ProgramNode? {
+                if (resolved) return resolution
+
+                breadcrumbs.add(Breadcrumb(track))
+
+                try {
+                    val nextInstance = try {
+                        val iterator = channelIterators.getOrPut(track) {
+                            candidates[track]?.iterator()
+                                ?: emptyList<LiveShaderInstance>().iterator()
+                        }
+                        if (iterator.hasNext())
+                            iterator.next()
+                        else null
+                    } catch (e: ResolveException) {
+                        throw e.chain("Resolver.resolve($track)")
                     }
+
+                    currentBreadcrumb.instance = nextInstance
+
+                    return nextInstance?.let { shaderInstance ->
+                        if (!dagAncestors.add(shaderInstance)) {
+                            throw ResolveException(
+                                "circular reference",
+                                message = "resolve($track) already saw [${shaderInstance.shader.title}]"
+                            )
+                        }
+
+                        try {
+                            resolvedNodes.getOrPut(shaderInstance) {
+                                shaderInstance.finalResolve(this@Resolver)
+                            }
+                        } finally {
+                            dagAncestors.remove(shaderInstance)
+                        }
+                    }.also {
+                        resolved = true
+                        resolution = it
+                    }
+                } finally {
+                    breadcrumbs.removeLast()
+
+                    if (breadcrumbs.isEmpty() && warnings.isNotEmpty()) {
+                        logger.error { warnings.joinToString("\n\n") }
+                    }
+                }
             }
         }
     }
@@ -131,9 +205,22 @@ class PortDiagram(
         }
     }
 
+    class ResolveException(
+        private val initialComplaint: String,
+        private val stack: List<String>,
+        cause: Exception? = null
+    ) : Exception("$initialComplaint: ${stack.joinToString(" -> ")}", cause) {
+        constructor(
+            initialComplaint: String,
+            message: String
+        ) : this(initialComplaint, listOf(message))
+
+        fun chain(message: String): Throwable {
+            return ResolveException(initialComplaint, listOf(message) + stack, this)
+        }
+    }
+
     companion object {
         private val logger = Logger("PortDiagram")
     }
 }
-
-private typealias Lookup = Pair<ShaderChannel, ContentType>

--- a/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
@@ -12,9 +12,14 @@ class UnresolvedPatch(private val unresolvedShaderInstances: List<UnresolvedShad
             ?: error("Couldn't find shader \"${shader.title}\"")
     }
 
+    fun editAll(callback: UnresolvedShaderInstance.() -> Unit): UnresolvedPatch {
+        unresolvedShaderInstances.forEach { it.callback() }
+        return this
+    }
+
     fun isAmbiguous() = unresolvedShaderInstances.any { it.isAmbiguous() }
 
-    fun resolve(): MutablePatch {
+    fun confirm(): MutablePatch {
         if (isAmbiguous()) {
             error("ambiguous! " +
                     unresolvedShaderInstances
@@ -30,7 +35,7 @@ class UnresolvedPatch(private val unresolvedShaderInstances: List<UnresolvedShad
                 it.incomingLinksOptions.entries.associate { (port, fromPortOptions) ->
                     port.id to
                             (fromPortOptions.firstOrNull()?.getMutablePort()
-                                ?: MutableConstPort(port.type.defaultInitializer()))
+                                ?: MutableConstPort(port.type.defaultInitializer(), port.type))
                 }.toMutableMap(),
                 MutableShaderChannel(it.shaderChannel.id),
                 it.priority

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -4,10 +4,7 @@ import baaahs.BaseShowPlayer
 import baaahs.Gadget
 import baaahs.fixtures.*
 import baaahs.gl.data.Feed
-import baaahs.gl.glsl.FeedResolver
-import baaahs.gl.glsl.GlslError
-import baaahs.gl.glsl.GlslException
-import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.*
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.ContentType
 import baaahs.gl.patch.LinkedPatch
@@ -112,13 +109,13 @@ class PreviewShaderBuilder(
 
             val defaultPorts = when (shader.type) {
                 ShaderType.Projection -> emptyMap()
-                else -> mapOf(ContentType.UvCoordinateStream to MutableConstPort("gl_FragCoord"))
+                else -> mapOf(ContentType.UvCoordinateStream to MutableConstPort("gl_FragCoord", GlslType.Vec2))
             }
 
             previewPatch = autoWirer.autoWire(*shaders, defaultPorts = defaultPorts)
 //                .dumpOptions()
                 .acceptSuggestedLinkOptions()
-                .resolve()
+                .confirm()
             linkedPatch = previewPatch?.openForPreview(autoWirer)
             state = ShaderBuilder.State.Linked
         } catch (e: GlslException) {

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -102,6 +102,7 @@ class PreviewShaderBuilder(
             val openShader = analyze(shader)
             this.openShader = openShader
             val shaders: Array<OpenShader> = when (shader.type) {
+                ShaderType.Unknown -> arrayOf(openShader)
                 ShaderType.Projection -> arrayOf(openShader, pixelUvIdentity)
                 ShaderType.Distortion -> arrayOf(screenCoordsProjection, openShader, smpteColorBars)
                 ShaderType.Paint -> arrayOf(screenCoordsProjection, openShader)

--- a/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
@@ -73,7 +73,7 @@ class ModelRenderEngine(
     }
 
     override fun compile(linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
-        logger.info { "Compiling ${linkedPatch.shaderInstance.shader.title} on ${deviceType::class.simpleName}"}
+        logger.info { "Compiling ${linkedPatch.rootNode.title} on ${deviceType::class.simpleName}"}
         return super.compile(linkedPatch, feedResolver)
     }
 

--- a/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
@@ -25,7 +25,7 @@ class GuruMeditationError(deviceType: DeviceType) {
         val showBuilder = ShowBuilder()
         val mutablePatch = autoWirer.autoWire(shader)
             .acceptSuggestedLinkOptions()
-            .resolve()
+            .confirm()
         val show = MutableShow("error").apply {
             addPatch(mutablePatch)
         }.build(showBuilder)

--- a/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/GuruMeditationError.kt
@@ -3,7 +3,6 @@ package baaahs.glsl
 import baaahs.BaseShowPlayer
 import baaahs.Gadget
 import baaahs.fixtures.DeviceType
-import baaahs.gl.data.Feed
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.patch.LinkedPatch
 import baaahs.gl.patch.PatchResolver
@@ -18,7 +17,6 @@ import baaahs.show.mutable.ShowBuilder
 
 class GuruMeditationError(deviceType: DeviceType) {
     private val shader = deviceType.errorIndicatorShader
-    private val feeds: Map<DataSource, Feed>
     val linkedPatch: LinkedPatch
 
     init {
@@ -34,9 +32,8 @@ class GuruMeditationError(deviceType: DeviceType) {
 
         val showPlayer = FakeShowPlayer(plugins)
         val openShow = ShowOpener(autoWirer.glslAnalyzer, show, showPlayer).openShow()
-        feeds = openShow.feeds
         val openPatch = openShow.patches.only("patch")
-        linkedPatch = PatchResolver.buildPortDiagram(openPatch)
+        linkedPatch = PatchResolver.buildPortDiagram(openShow.allDataSources, openPatch)
             .resolvePatch(ShaderChannel.Main, deviceType.resultContentType)
             ?: error("Couldn't build guru meditation error patch.")
     }

--- a/src/commonMain/kotlin/baaahs/show/PortRef.kt
+++ b/src/commonMain/kotlin/baaahs/show/PortRef.kt
@@ -1,6 +1,7 @@
 package baaahs.show
 
 import baaahs.getBang
+import baaahs.gl.glsl.GlslType
 import baaahs.show.mutable.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -44,7 +45,7 @@ data class OutputPortRef(val portId: String) : PortRef() {
 }
 
 @Serializable @SerialName("const")
-data class ConstPortRef(val glsl: String) : PortRef() {
+data class ConstPortRef(val glsl: String, val type: String) : PortRef() {
     override fun dereference(mutableShow: MutableShow): MutablePort =
-        MutableConstPort(glsl)
+        MutableConstPort(glsl, GlslType.from(type))
 }

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -52,7 +52,7 @@ object SampleData {
 
     private val autoWirer = AutoWirer(plugins)
 
-    private val uvShader = wireUp(Shaders.cylindricalProjection)
+    private val uvShader get() = wireUp(Shaders.cylindricalProjection)
 
     private val showDefaultPaint = autoWirer.autoWire(
         Shader(
@@ -67,7 +67,7 @@ object SampleData {
         )
     )
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     private val brightnessFilter = autoWirer.autoWire(
         Shader(
@@ -85,7 +85,7 @@ object SampleData {
         )
     )
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     private val saturationFilter = autoWirer.autoWire(
         Shader(
@@ -128,7 +128,7 @@ object SampleData {
         )
     )
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     private val redYellowGreenPatch = autoWirer.autoWire(
         Shader(
@@ -144,7 +144,7 @@ object SampleData {
         )
     )
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     private val blueAquaGreenPatch = autoWirer.autoWire(
         Shader(
@@ -161,11 +161,11 @@ object SampleData {
         )
     )
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     private val fireBallPatch = autoWirer.autoWire(FixtureShaders.fireBallGlsl)
         .acceptSuggestedLinkOptions()
-        .resolve()
+        .confirm()
 
     val defaultLayout = Layout(stdLayout)
     val layouts = Layouts(
@@ -187,7 +187,8 @@ object SampleData {
         "Checkerboard Size", .1f, .001f, 1f, null
     )
 
-    val sampleShow: Show get() = MutableShow("Sample Show").apply {
+    val sampleShow: Show get() = MutableShow("Sample Show") {
+        println("Initialize sampleShow!")
         editLayouts {
             copyFrom(layouts)
         }
@@ -265,6 +266,6 @@ object SampleData {
         }
         return unresolvedPatch
             .acceptSuggestedLinkOptions()
-            .resolve()
+            .confirm()
     }
 }

--- a/src/commonMain/kotlin/baaahs/show/ShaderType.kt
+++ b/src/commonMain/kotlin/baaahs/show/ShaderType.kt
@@ -16,6 +16,44 @@ enum class ShaderType(
     val icon: Icon,
     val template: String
 ) {
+    Unknown(
+        0, emptyMap(),
+        ContentType.Unknown, CommonIcons.None,
+        """
+            ---
+        """.trimIndent()
+    ) {
+        override fun matches(glslCode: GlslCode): Boolean {
+            return glslCode.functionNames.contains("mainMain")
+        }
+
+        override fun open(shader: Shader, glslCode: GlslCode, plugins: Plugins): OpenShader {
+            return object : OpenShader.Base(shader, glslCode, plugins) {
+                override val proFormaInputPorts: List<InputPort>
+                    get() = emptyList()
+                override val wellKnownInputPorts: Map<String, InputPort>
+                    get() = emptyMap()
+                override val shaderType: ShaderType
+                    get() = Unknown
+                override val entryPointName: String
+                    get() = "mainMain"
+                override val outputPort: OutputPort =
+                    OutputPort(
+                        entryPoint.hint?.contentType(plugins)
+                            ?: ContentType.Unknown
+                    )
+
+                override fun invocationGlsl(
+                    namespace: GlslCode.Namespace,
+                    resultVar: String,
+                    portMap: Map<String, String>
+                ): String {
+                    return resultVar + " = " + namespace.qualify(entryPoint.name) + "()"
+                }
+            }
+        }
+    },
+
     Projection(
         0, emptyMap(),
         ContentType.UvCoordinateStream, CommonIcons.ProjectionShader,

--- a/src/commonMain/kotlin/baaahs/show/Show.kt
+++ b/src/commonMain/kotlin/baaahs/show/Show.kt
@@ -1,5 +1,6 @@
 package baaahs.show
 
+import baaahs.SparkleMotion
 import baaahs.app.ui.Editable
 import baaahs.camelize
 import baaahs.fixtures.DeviceType
@@ -65,7 +66,16 @@ data class Show(
 data class Patch(
     val shaderInstanceIds: List<String>,
     val surfaces: Surfaces
-)
+) {
+    init { if (SparkleMotion.EXTRA_ASSERTIONS) shaderInstanceIds.assertNoDuplicates() }
+}
+
+fun <T> List<T>.assertNoDuplicates(items: String = "items") {
+    val duplicates = groupBy { it }.mapValues { (_, v) -> v.size }.filterValues { it > 1 }
+    if (duplicates.isNotEmpty()) {
+        throw error("duplicate $items: $duplicates")
+    }
+}
 
 @Serializable
 data class EventBinding(

--- a/src/commonMain/kotlin/baaahs/show/live/LinkedShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/LinkedShaderInstance.kt
@@ -1,0 +1,30 @@
+package baaahs.show.live
+
+import baaahs.gl.patch.Component
+import baaahs.gl.patch.ProgramLinker
+import baaahs.gl.patch.ProgramNode
+import baaahs.gl.patch.ShaderComponent
+import baaahs.gl.shader.OpenShader
+import baaahs.gl.shader.OutputPort
+import baaahs.show.ShaderChannel
+
+class LinkedShaderInstance(
+    val shader: OpenShader,
+    val incomingLinks: Map<String, ProgramNode>,
+    val shaderChannel: ShaderChannel?,
+    val priority: Float
+) : ProgramNode {
+    override val title: String get() = shader.title
+    override val outputPort: OutputPort get() = shader.outputPort
+
+    override fun getNodeId(programLinker: ProgramLinker): String = programLinker.idFor(shader.shader)
+
+    override fun traverse(programLinker: ProgramLinker, depth: Int) {
+        programLinker.visit(shader)
+        incomingLinks.forEach { (_, link) -> programLinker.visit(link) }
+    }
+
+    override fun buildComponent(id: String, index: Int, findUpstreamComponent: (ProgramNode) -> Component): Component {
+        return ShaderComponent(id, index, this, findUpstreamComponent)
+    }
+}

--- a/src/commonMain/kotlin/baaahs/show/mutable/EditingShader.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/EditingShader.kt
@@ -86,8 +86,6 @@ class EditingShader(
     }
 
     fun getShaderInstanceOptions(): ShaderInstanceOptions? {
-        if (state == State.Errors) return null
-
         val currentOpenShader = openShader
         if (shaderInstanceOptions == null && currentOpenShader != null) {
             val showBuilder = ShowBuilder()

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutablePort.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutablePort.kt
@@ -2,6 +2,7 @@ package baaahs.show.mutable
 
 import baaahs.app.ui.CommonIcons
 import baaahs.englishize
+import baaahs.gl.glsl.GlslType
 import baaahs.show.*
 import baaahs.ui.Icon
 
@@ -90,13 +91,13 @@ data class MutableOutputPort(private val portId: String) : MutablePort {
     override fun accept(visitor: MutableShowVisitor, log: VisitationLog) {}
 }
 
-data class MutableConstPort(private val glsl: String) : MutablePort {
+data class MutableConstPort(private val glsl: String, private val type: GlslType) : MutablePort {
     override val title: String get() = "const($glsl)"
     override val icon: Icon get() = error("not implemented")
     override val groupName: String get() = error("not implemented")
 
     override fun toRef(showBuilder: ShowBuilder): PortRef =
-        ConstPortRef(glsl)
+        ConstPortRef(glsl, type.glslLiteral)
 
     override fun accept(visitor: MutableShowVisitor, log: VisitationLog) {}
 }

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
@@ -1,6 +1,7 @@
 package baaahs.show.mutable
 
 import baaahs.ShowState
+import baaahs.SparkleMotion
 import baaahs.app.ui.EditorPanel
 import baaahs.app.ui.MutableEditable
 import baaahs.app.ui.editor.*
@@ -71,6 +72,7 @@ abstract class MutablePatchHolder(
         val existingPatch = patches.find { it.surfaces == mutablePatch.surfaces }
         if (existingPatch != null) {
             existingPatch.mutableShaderInstances.addAll(mutablePatch.mutableShaderInstances)
+            if (SparkleMotion.EXTRA_ASSERTIONS) existingPatch.mutableShaderInstances.assertNoDuplicates()
         } else {
             patches.add(mutablePatch)
         }
@@ -276,14 +278,16 @@ class MutablePatch {
         mutableShaderInstances: List<MutableShaderInstance> = emptyList(),
         surfaces: Surfaces = Surfaces.AllSurfaces
     ) {
+        if (SparkleMotion.EXTRA_ASSERTIONS) mutableShaderInstances.assertNoDuplicates()
         this.mutableShaderInstances = mutableShaderInstances.toMutableList()
         this.surfaces = surfaces
     }
 
     constructor(basePatch: Patch, show: MutableShow) {
-        this.mutableShaderInstances = basePatch.shaderInstanceIds.map { shaderInstanceId ->
+        mutableShaderInstances = basePatch.shaderInstanceIds.map { shaderInstanceId ->
             show.findShaderInstance(shaderInstanceId)
         }.toMutableList()
+        if (SparkleMotion.EXTRA_ASSERTIONS) mutableShaderInstances.assertNoDuplicates()
 
         this.surfaces = basePatch.surfaces
     }
@@ -328,6 +332,7 @@ class MutablePatch {
 
     fun addShaderInstance(mutableShaderInstance: MutableShaderInstance): MutablePatch {
         mutableShaderInstances.add(mutableShaderInstance)
+        if (SparkleMotion.EXTRA_ASSERTIONS) mutableShaderInstances.assertNoDuplicates()
         return this
     }
 
@@ -339,6 +344,7 @@ class MutablePatch {
         val mutableShaderInstance = MutableShaderInstance(shader)
         mutableShaderInstance.block()
         mutableShaderInstances.add(mutableShaderInstance)
+        if (SparkleMotion.EXTRA_ASSERTIONS) mutableShaderInstances.assertNoDuplicates()
         return mutableShaderInstance
     }
 

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
@@ -322,7 +322,7 @@ class MutablePatch {
                 .getResolvedShaderInstances()
         val openPatch = OpenPatch(resolvedShaderInstances.values.toList(), surfaces)
 
-        val portDiagram = PatchResolver.buildPortDiagram(openPatch)
+        val portDiagram = PatchResolver.buildPortDiagram(showBuilder.getDataSources(), openPatch)
         return portDiagram.resolvePatch(ShaderChannel.Main, resultContentType)
     }
 

--- a/src/commonMain/kotlin/baaahs/util.kt
+++ b/src/commonMain/kotlin/baaahs/util.kt
@@ -75,8 +75,7 @@ internal fun Clock.timeSync(function: () -> Unit): Int {
 fun String.camelize(): String =
     replace(Regex("([A-Z]+)"), " $1")
         .split(Regex("[^A-Za-z0-9]+"))
-        .map { it.toLowerCase().capitalize() }
-        .joinToString("")
+        .joinToString("") { it.toLowerCase().capitalize() }
         .decapitalize()
 
 fun String.englishize(): String {

--- a/src/commonTest/kotlin/baaahs/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/TestUtil.kt
@@ -5,12 +5,13 @@ import baaahs.geom.Vector3F
 import baaahs.gl.glsl.GlslAnalyzer
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.ProgramLinker
+import baaahs.gl.patch.ProgramNode
 import baaahs.gl.render.ModelRenderEngine
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.testPlugins
 import baaahs.model.Model
 import baaahs.model.MovingHead
-import baaahs.show.live.LiveShaderInstance
+import baaahs.show.live.LinkedShaderInstance
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeShowPlayer
 import baaahs.util.Clock
@@ -101,9 +102,9 @@ class TestRenderContext(
     val showPlayer = FakeShowPlayer()
     val renderTargets = mutableListOf<RenderTarget>()
 
-    fun createProgram(shaderSrc: String, incomingLinks: Map<String, LiveShaderInstance.DataSourceLink>): GlslProgram {
+    fun createProgram(shaderSrc: String, incomingLinks: Map<String, ProgramNode>): GlslProgram {
         val openShader = glslAnalyzer.openShader(shaderSrc)
-        val liveShaderInstance = LiveShaderInstance(openShader, incomingLinks, null, 0f)
+        val liveShaderInstance = LinkedShaderInstance(openShader, incomingLinks, null, 0f)
         val linkedPatch = ProgramLinker(liveShaderInstance).buildLinkedPatch()
         return renderEngine.compile(linkedPatch) { id, dataSource -> dataSource.createFeed(showPlayer, id) }
     }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -271,6 +271,38 @@ object GlslAnalyzerSpec : Spek({
                             )
                     }
                 }
+
+                context("with a comment before a function") {
+                    override(shaderText) {
+                        """
+                            uniform float time; // @type time1
+                            // @type time2
+                            float mainMain() { return time + sin(time); }
+                        """.trimIndent()
+                    }
+
+                    it("attaches the comment to that function") {
+                        expectStatements(
+                            listOf(
+                                GlslVar(
+                                    GlslType.Float,
+                                    "time",
+                                    "uniform float time;", lineNumber = 1,
+                                    comments = listOf(" @type time1"),
+                                    isUniform = true
+                                ),
+                                GlslFunction(
+                                    GlslType.Void,
+                                    "mainMain",
+                                    lineNumber = 1, // TODO: 1 seems wrong here, shouldn't it be 3?
+                                    fullText = "float mainMain() { return time + sin(time); }\n",
+                                    comments = listOf(" @type time2"),
+                                    params = emptyList()
+                                ),
+                            ), { glslAnalyzer.findStatements(shaderText) }, true
+                        )
+                    }
+                }
             }
 
             context("#asShader") {

--- a/src/commonTest/kotlin/baaahs/gl/patch/PatchLayeringSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/PatchLayeringSpec.kt
@@ -13,8 +13,10 @@ import baaahs.show.Shader
 import baaahs.show.ShaderChannel
 import baaahs.show.ShaderType
 import baaahs.show.live.OpenButtonControl
+import baaahs.show.live.OpenShow
 import baaahs.show.live.ShowOpener
 import baaahs.show.mutable.MutablePatch
+import baaahs.show.mutable.MutableShaderChannel
 import baaahs.show.mutable.MutableShow
 import baaahs.show.mutable.ShowBuilder
 import baaahs.shows.FakeGlContext
@@ -40,19 +42,27 @@ object PatchLayeringSpec : Spek({
         val orangeShader by value {
             Shader(
                 "Orange Shader", ShaderType.Paint,
-                "void main() {\n  gl_FragColor = vec4(1., .5, 0., gl_FragCoord.x);\n}"
+                "uniform float time;\n" +
+                        "void main() {\n" +
+                        "  gl_FragColor = vec4(1., .5, time, gl_FragCoord.x);\n" +
+                        "}"
             )
         }
         val brightnessFilter by value {
             Shader(
                 "Brightness Filter", ShaderType.Filter,
-                "uniform float brightness; // @@Slider min=0 max=1 default=1\nvec4 mainFilter(vec4 colorIn) {\n  return colorIn * brightness;\n}"
+                "uniform float brightness; // @@Slider min=0 max=1 default=1\n" +
+                        "vec4 mainFilter(vec4 colorIn) {\n" +
+                        "  return colorIn * brightness;\n" +
+                        "}"
             )
         }
-        val saturationFilter by value {
+        val wobblyTimeFilter by value {
             Shader(
-                "Saturation Filter", ShaderType.Filter,
-                "vec4 mainFilter(vec4 colorIn) { return colorIn; }"
+                "Wobbly Time Filter", ShaderType.Unknown,
+                "uniform float time; // @type time\n" +
+                        "// @type time\n" +
+                        "float mainMain() { return time + sin(time); }"
             )
         }
         val mutableShow by value {
@@ -65,7 +75,14 @@ object PatchLayeringSpec : Spek({
             ShowOpener(autoWirer.glslAnalyzer, show, FakeShowPlayer()).openShow()
         }
 
+        fun clickButton(id: String) {
+            (show.allControls.associateBy { it.id }.getBang(id, "control") as OpenButtonControl)
+                .click()
+        }
+
         context("for a show with a couple buttons") {
+            val linkedPatch by value { generateLinkedPatch(show) }
+
             beforeEachTest {
                 mutableShow.apply {
                     addPatch(autoWire(uvShader, blackShader))
@@ -78,22 +95,12 @@ object PatchLayeringSpec : Spek({
                         addPatch(autoWire(orangeShader))
                     }
                 }
-
-                (show.allControls.find { it.id == "brightnessButton" } as OpenButtonControl).click()
-                (show.allControls.find { it.id == "orangeButton" } as OpenButtonControl).click()
             }
 
             it("merges layered patches into a single patch") {
-                val model = TestModel
-                val renderManager = RenderManager(model) { FakeGlContext() }
-                val fixture = model.allEntities.first()
-                val renderTarget = renderManager.addFixture(fakeFixture(1, fixture))
-                val patchResolution = PatchResolver(renderManager, listOf(renderTarget), show.activePatchSet())
-                val portDiagram = patchResolution.portDiagrams
-                    .getBang(PixelArrayDevice, "device type")
-                    .only("port diagram to render targets")
-                    .first
-                val linkedPatch = portDiagram.resolvePatch(ShaderChannel.Main, ContentType.ColorStream)!!
+                clickButton("brightnessButton")
+                clickButton("orangeButton")
+
                 kexpect(linkedPatch.toGlsl()).toBe(
                     /**language=glsl*/
                     """
@@ -118,6 +125,9 @@ object PatchLayeringSpec : Spek({
 
                         // Data source: Pixel Coordinates Texture
                         uniform sampler2D in_pixelCoordsTexture;
+
+                        // Data source: Time
+                        uniform float in_time;
 
                         // Shader: Cylindrical Projection; namespace: p0
                         // Cylindrical Projection
@@ -152,9 +162,9 @@ object PatchLayeringSpec : Spek({
 
                         vec4 p1_orangeShader_gl_FragColor = vec4(0., 0., 0., 1.);
 
-                        #line 1
+                        #line 2
                         void p1_orangeShader_main() {
-                          p1_orangeShader_gl_FragColor = vec4(1., .5, 0., p0_cylindricalProjectioni_result.x);
+                          p1_orangeShader_gl_FragColor = vec4(1., .5, in_time, p0_cylindricalProjectioni_result.x);
                         }
 
                         // Shader: Brightness Filter; namespace: p2
@@ -184,6 +194,145 @@ object PatchLayeringSpec : Spek({
                         
                     """.trimIndent())
             }
+
+            context("with a data source filter") {
+                beforeEachTest {
+                    mutableShow.apply {
+                        addButton("Main", "Time Wobble") {
+                            addPatch(
+                                autoWire(wobblyTimeFilter).apply {
+                                    mutableShaderInstances.only("shader instance")
+                                        .shaderChannel = MutableShaderChannel("time")
+                                }
+                            )
+                        }
+                    }
+                }
+
+                it("merges layered patches into a single patch") {
+                    clickButton("brightnessButton")
+                    clickButton("orangeButton")
+                    clickButton("timeWobbleButton")
+
+                    kexpect(linkedPatch.toGlsl()).toBe(
+                        /**language=glsl*/
+                        """
+                        #ifdef GL_ES
+                        precision mediump float;
+                        #endif
+
+                        // SparkleMotion-generated GLSL
+
+                        layout(location = 0) out vec4 sm_result;
+
+                        struct ModelInfo {
+                            vec3 center;
+                            vec3 extents;
+                        };
+                        
+                        // Data source: Brightness Slider
+                        uniform float in_brightnessSlider;
+
+                        // Data source: Model Info
+                        uniform ModelInfo in_modelInfo;
+
+                        // Data source: Pixel Coordinates Texture
+                        uniform sampler2D in_pixelCoordsTexture;
+
+                        // Data source: Time
+                        uniform float in_time;
+
+                        // Shader: Cylindrical Projection; namespace: p0
+                        // Cylindrical Projection
+
+                        vec2 p0_cylindricalProjectioni_result = vec2(0.);
+
+                        #line 12
+                        const float p0_cylindricalProjection_PI = 3.141592654;
+
+                        #line 14
+                        vec2 p0_cylindricalProjection_project(vec3 pixelLocation) {
+                            vec3 pixelOffset = pixelLocation - in_modelInfo.center;
+                            vec3 normalDelta = normalize(pixelOffset);
+                            float theta = atan(abs(normalDelta.z), normalDelta.x); // theta in range [-π,π]
+                            if (theta < 0.0) theta += (2.0f * p0_cylindricalProjection_PI);                 // theta in range [0,2π)
+                            float u = theta / (2.0f * p0_cylindricalProjection_PI);                         // u in range [0,1)
+                            float v = (pixelOffset.y + in_modelInfo.extents.y / 2.0f) / in_modelInfo.extents.y;
+                            return vec2(u, v);
+                        }
+
+                        #line 24
+                        vec2 p0_cylindricalProjection_mainProjection(vec2 rasterCoord) {
+                            int rasterX = int(rasterCoord.x);
+                            int rasterY = int(rasterCoord.y);
+                            
+                            vec3 pixelCoord = texelFetch(in_pixelCoordsTexture, ivec2(rasterX, rasterY), 0).xyz;
+                            return p0_cylindricalProjection_project(pixelCoord);
+                        }
+
+                        // Shader: Wobbly Time Filter; namespace: p1
+                        // Wobbly Time Filter
+
+                        float p1_wobblyTimeFilteri_result = float(0.);
+
+                        #line 1
+                         
+                        float p1_wobblyTimeFilter_mainMain() { return in_time + sin(in_time); }
+
+                        // Shader: Orange Shader; namespace: p2
+                        // Orange Shader
+
+                        vec4 p2_orangeShader_gl_FragColor = vec4(0., 0., 0., 1.);
+
+                        #line 2
+                        void p2_orangeShader_main() {
+                          p2_orangeShader_gl_FragColor = vec4(1., .5, p1_wobblyTimeFilteri_result, p0_cylindricalProjectioni_result.x);
+                        }
+
+                        // Shader: Brightness Filter; namespace: p3
+                        // Brightness Filter
+
+                        vec4 p3_brightnessFilteri_result = vec4(0., 0., 0., 1.);
+
+                        #line 1
+                         vec4 p3_brightnessFilter_mainFilter(vec4 colorIn) {
+                          return colorIn * in_brightnessSlider;
+                        }
+
+
+                        #line 10001
+                        void main() {
+                          // Invoke Cylindrical Projection
+                          p0_cylindricalProjectioni_result = p0_cylindricalProjection_mainProjection(gl_FragCoord.xy);
+
+                          // Invoke Wobbly Time Filter
+                          p1_wobblyTimeFilteri_result = p1_wobblyTimeFilter_mainMain();
+
+                          // Invoke Orange Shader
+                          p2_orangeShader_main();
+
+                          // Invoke Brightness Filter
+                          p3_brightnessFilteri_result = p3_brightnessFilter_mainFilter(p2_orangeShader_gl_FragColor);
+
+                          sm_result = p3_brightnessFilteri_result;
+                        }
+                        
+                    """.trimIndent())
+                }
+            }
         }
     }
 })
+
+private fun generateLinkedPatch(show: OpenShow): LinkedPatch {
+    val model = TestModel
+    val renderManager = RenderManager(model) { FakeGlContext() }
+    val fixture = model.allEntities.first()
+    val renderTarget = renderManager.addFixture(fakeFixture(1, fixture))
+    val patchResolution = PatchResolver(show, renderManager, listOf(renderTarget), show.activePatchSet())
+    val portDiagram = patchResolution.portDiagrams
+        .getBang(PixelArrayDevice, "device type")
+        .only("port diagram to render targets")
+        .first
+    return portDiagram.resolvePatch(ShaderChannel.Main, ContentType.ColorStream)!!
+}

--- a/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
@@ -1,6 +1,7 @@
 package baaahs.gl.patch
 
 import baaahs.TestModel
+import baaahs.app.ui.editor.PortLinkOption
 import baaahs.fixtures.PixelArrayDevice
 import baaahs.getBang
 import baaahs.gl.kexpect
@@ -9,11 +10,12 @@ import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders
 import baaahs.only
 import baaahs.shaders.fakeFixture
+import baaahs.show.DataSource
 import baaahs.show.Shader
 import baaahs.show.ShaderChannel
 import baaahs.show.ShaderType
+import baaahs.show.live.ActivePatchSet
 import baaahs.show.live.OpenButtonControl
-import baaahs.show.live.OpenShow
 import baaahs.show.live.ShowOpener
 import baaahs.show.mutable.MutablePatch
 import baaahs.show.mutable.MutableShaderChannel
@@ -29,8 +31,9 @@ object PatchResolverSpec : Spek({
     describe("Layering of patch links") {
         val autoWirer by value { AutoWirer(testPlugins()) }
 
-        fun autoWire(vararg shaders: Shader): MutablePatch {
-            return autoWirer.autoWire(*shaders).acceptSuggestedLinkOptions().resolve()
+        fun autoWire(vararg shaders: Shader, shaderChannel: ShaderChannel = ShaderChannel.Main): MutablePatch {
+            return autoWirer.autoWire(*shaders, shaderChannel = shaderChannel)
+                .acceptSuggestedLinkOptions().confirm()
         }
 
         val uvShader = Shaders.cylindricalProjection
@@ -75,6 +78,7 @@ object PatchResolverSpec : Spek({
             val show = mutableShow.build(ShowBuilder())
             ShowOpener(autoWirer.glslAnalyzer, show, FakeShowPlayer()).openShow()
         }
+        val linkedPatch by value { generateLinkedPatch(show.allDataSources, show.activePatchSet()) }
 
         fun clickButton(id: String) {
             (show.allControls.associateBy { it.id }.getBang(id, "control") as OpenButtonControl)
@@ -82,8 +86,6 @@ object PatchResolverSpec : Spek({
         }
 
         context("for a show with a couple buttons") {
-            val linkedPatch by value { generateLinkedPatch(show) }
-
             beforeEachTest {
                 mutableShow.apply {
                     addPatch(autoWire(uvShader, blackShader))
@@ -193,7 +195,8 @@ object PatchResolverSpec : Spek({
                           sm_result = p2_brightnessFilteri_result;
                         }
                         
-                    """.trimIndent())
+                    """.trimIndent()
+                )
             }
 
             context("with a data source filter") {
@@ -318,19 +321,182 @@ object PatchResolverSpec : Spek({
                           sm_result = p3_brightnessFilteri_result;
                         }
                         
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                 }
+            }
+        }
+
+        context("with a color mixer") {
+            beforeEachTest {
+                mutableShow.apply {
+                    addPatch(autoWire(uvShader, blackShader))
+                    addPatch(
+                        autoWire(
+                            Shader(
+                                "Main Shader", ShaderType.Paint,
+                                "uniform float time;\n" +
+                                        "void main() {\n" +
+                                        "  gl_FragColor = vec4(time, time, time, gl_FragCoord.x);\n" +
+                                        "}"
+                            ), shaderChannel = ShaderChannel("main")
+                        )
+                    )
+                    addPatch(
+                        autoWirer.autoWire(
+                            Shader(
+                                "Fade", ShaderType.Filter, """
+                                    uniform float fade;
+                                    varying vec4 otherColorStream; // @type color-stream
+                
+                                    vec4 mainFilter(vec4 colorIn) {
+                                        return mix(colorIn, otherColorStream, fade);
+                                    }
+                                """.trimIndent()
+                            )
+                        ).editAll {
+                            linkOptionsFor("otherColorStream").apply {
+                                clear()
+                                add(PortLinkOption(MutableShaderChannel("other")))
+                            }
+                        }.acceptSuggestedLinkOptions().confirm()
+                    )
+                    addPatch(autoWire(orangeShader, shaderChannel = ShaderChannel("other")))
+                    addPatch(autoWire(wobblyTimeFilter, shaderChannel = ShaderChannel("time")))
+                }
+            }
+
+            it("merges layered patches into a single patch") {
+                kexpect(linkedPatch.toGlsl()).toBe(
+                    /**language=glsl*/
+                    """
+                        #ifdef GL_ES
+                        precision mediump float;
+                        #endif
+
+                        // SparkleMotion-generated GLSL
+
+                        layout(location = 0) out vec4 sm_result;
+
+                        struct ModelInfo {
+                            vec3 center;
+                            vec3 extents;
+                        };
+
+                        // Data source: Fade Slider
+                        uniform float in_fadeSlider;
+
+                        // Data source: Model Info
+                        uniform ModelInfo in_modelInfo;
+
+                        // Data source: Pixel Coordinates Texture
+                        uniform sampler2D in_pixelCoordsTexture;
+
+                        // Data source: Time
+                        uniform float in_time;
+
+                        // Shader: Cylindrical Projection; namespace: p0
+                        // Cylindrical Projection
+
+                        vec2 p0_cylindricalProjectioni_result = vec2(0.);
+
+                        #line 12
+                        const float p0_cylindricalProjection_PI = 3.141592654;
+
+                        #line 14
+                        vec2 p0_cylindricalProjection_project(vec3 pixelLocation) {
+                            vec3 pixelOffset = pixelLocation - in_modelInfo.center;
+                            vec3 normalDelta = normalize(pixelOffset);
+                            float theta = atan(abs(normalDelta.z), normalDelta.x); // theta in range [-π,π]
+                            if (theta < 0.0) theta += (2.0f * p0_cylindricalProjection_PI);                 // theta in range [0,2π)
+                            float u = theta / (2.0f * p0_cylindricalProjection_PI);                         // u in range [0,1)
+                            float v = (pixelOffset.y + in_modelInfo.extents.y / 2.0f) / in_modelInfo.extents.y;
+                            return vec2(u, v);
+                        }
+
+                        #line 24
+                        vec2 p0_cylindricalProjection_mainProjection(vec2 rasterCoord) {
+                            int rasterX = int(rasterCoord.x);
+                            int rasterY = int(rasterCoord.y);
+                            
+                            vec3 pixelCoord = texelFetch(in_pixelCoordsTexture, ivec2(rasterX, rasterY), 0).xyz;
+                            return p0_cylindricalProjection_project(pixelCoord);
+                        }
+
+                        // Shader: Wobbly Time Filter; namespace: p1
+                        // Wobbly Time Filter
+
+                        float p1_wobblyTimeFilteri_result = float(0.);
+
+                        #line 1
+                         
+                        float p1_wobblyTimeFilter_mainMain() { return in_time + sin(in_time); }
+
+                        // Shader: Main Shader; namespace: p2
+                        // Main Shader
+
+                        vec4 p2_mainShader_gl_FragColor = vec4(0., 0., 0., 1.);
+
+                        #line 2
+                        void p2_mainShader_main() {
+                          p2_mainShader_gl_FragColor = vec4(p1_wobblyTimeFilteri_result, p1_wobblyTimeFilteri_result, p1_wobblyTimeFilteri_result, p0_cylindricalProjectioni_result.x);
+                        }
+
+                        // Shader: Orange Shader; namespace: p3
+                        // Orange Shader
+
+                        vec4 p3_orangeShader_gl_FragColor = vec4(0., 0., 0., 1.);
+
+                        #line 2
+                        void p3_orangeShader_main() {
+                          p3_orangeShader_gl_FragColor = vec4(1., .5, p1_wobblyTimeFilteri_result, p0_cylindricalProjectioni_result.x);
+                        }
+
+                        // Shader: Fade; namespace: p4
+                        // Fade
+
+                        vec4 p4_fadei_result = vec4(0., 0., 0., 1.);
+
+                        #line 2
+                         
+                        vec4 p4_fade_mainFilter(vec4 colorIn) {
+                            return mix(colorIn, p3_orangeShader_gl_FragColor, in_fadeSlider);
+                        }
+
+
+                        #line 10001
+                        void main() {
+                          // Invoke Cylindrical Projection
+                          p0_cylindricalProjectioni_result = p0_cylindricalProjection_mainProjection(gl_FragCoord.xy);
+
+                          // Invoke Wobbly Time Filter
+                          p1_wobblyTimeFilteri_result = p1_wobblyTimeFilter_mainMain();
+
+                          // Invoke Main Shader
+                          p2_mainShader_main();
+
+                          // Invoke Orange Shader
+                          p3_orangeShader_main();
+
+                          // Invoke Fade
+                          p4_fadei_result = p4_fade_mainFilter(p2_mainShader_gl_FragColor);
+
+                          sm_result = p4_fadei_result;
+                        }
+
+                    """.trimIndent()
+                )
             }
         }
     }
 })
 
-private fun generateLinkedPatch(show: OpenShow): LinkedPatch {
+private fun generateLinkedPatch(dataSources: Map<String, DataSource>, activePatchSet: ActivePatchSet): LinkedPatch {
     val model = TestModel
     val renderManager = RenderManager(model) { FakeGlContext() }
     val fixture = model.allEntities.first()
     val renderTarget = renderManager.addFixture(fakeFixture(1, fixture))
-    val patchResolution = PatchResolver(show, renderManager, listOf(renderTarget), show.activePatchSet())
+    val patchResolution = PatchResolver(dataSources, renderManager, listOf(renderTarget), activePatchSet)
     val portDiagram = patchResolution.portDiagrams
         .getBang(PixelArrayDevice, "device type")
         .only("port diagram to render targets")

--- a/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
@@ -24,7 +24,8 @@ import baaahs.shows.FakeShowPlayer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-object PatchLayeringSpec : Spek({
+@Suppress("unused")
+object PatchResolverSpec : Spek({
     describe("Layering of patch links") {
         val autoWirer by value { AutoWirer(testPlugins()) }
 

--- a/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
@@ -22,7 +22,7 @@ import baaahs.show.DataSource
 import baaahs.show.Shader
 import baaahs.show.ShaderType
 import baaahs.show.UpdateMode
-import baaahs.show.live.LiveShaderInstance
+import baaahs.show.live.LinkedShaderInstance
 import baaahs.show.live.link
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeShowPlayer
@@ -75,8 +75,8 @@ object ModelRenderEngineSpec : Spek({
             val openShader by value { GlslAnalyzer(testPlugins()).openShader(shaderText) as PaintShader }
             val incomingLinks by value { mapOf("gl_FragCoord" to dataSource.link("coord")) }
             val linkedPatch by value {
-                val liveShaderInstance = LiveShaderInstance(openShader, incomingLinks, null, 0f)
-                ProgramLinker(liveShaderInstance).buildLinkedPatch()
+                val rootNode = LinkedShaderInstance(openShader, incomingLinks, null, 0f)
+                ProgramLinker(rootNode).buildLinkedPatch()
             }
             val program by value {
                 renderEngine.compile(linkedPatch) { id, dataSource -> dataSource.createFeed(FakeShowPlayer(), id) }

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
@@ -260,7 +260,7 @@ class RenderEngineTest {
         val linkedPatch = autoWirer
             .autoWire(directXyProjection, shader)
             .acceptSuggestedLinkOptions()
-            .resolve()
+            .confirm()
             .openForPreview(autoWirer)!!
         return renderEngine.compile(linkedPatch) { id, dataSource ->
             if (dataSource is CorePlugin.GadgetDataSource<*>) {

--- a/src/commonTest/kotlin/baaahs/gl/shader/FilterShaderSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/FilterShaderSpec.kt
@@ -83,7 +83,7 @@ object FilterShaderSpec : Spek({
                         addShaderInstance(shader.shader) {
                             link("gl_FragColor", MutableShaderOutPort(redInstance))
                             link("otherColorStream", MutableShaderChannel(otherChannel.id))
-                            link("fade", MutableConstPort(".5"))
+                            link("fade", MutableConstPort(".5", GlslType.Float))
                         }
                     }.openForPreview(autoWirer)
                 }

--- a/src/commonTest/kotlin/baaahs/glsl/GuruMeditationErrorSpec.kt
+++ b/src/commonTest/kotlin/baaahs/glsl/GuruMeditationErrorSpec.kt
@@ -2,6 +2,7 @@ package baaahs.glsl
 
 import baaahs.describe
 import baaahs.fixtures.PixelArrayDevice
+import baaahs.show.live.LinkedShaderInstance
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeKgl
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
@@ -14,7 +15,8 @@ object GuruMeditationErrorSpec : Spek({
         val guruMeditationError by value { GuruMeditationError(PixelArrayDevice) }
 
         it("should create a RenderPlan") {
-            expect(guruMeditationError.linkedPatch.shaderInstance.shader.shader)
+            val rootNode = guruMeditationError.linkedPatch.rootNode as LinkedShaderInstance
+            expect(rootNode.shader.shader)
                 .toBe(PixelArrayDevice.errorIndicatorShader)
         }
     }

--- a/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
@@ -24,7 +24,7 @@ object CorePluginSpec : Spek({
         val program by value {
             val autoWirer = AutoWirer(plugins)
             val linkedPatch = autoWirer.autoWire(Shaders.red).acceptSuggestedLinkOptions()
-                .resolve().openForPreview(autoWirer)!!
+                .confirm().openForPreview(autoWirer)!!
             GlslProgram(gl, linkedPatch) { _, _ -> null }
         }
         val programFeed by value { glFeed.bind(program) }

--- a/src/commonTest/kotlin/baaahs/show/MutableShowSpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/MutableShowSpec.kt
@@ -1,5 +1,6 @@
 package baaahs.show
 
+import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.testPlugins
 import baaahs.only
@@ -11,13 +12,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import kotlin.collections.associate
-import kotlin.collections.listOf
-import kotlin.collections.map
-import kotlin.collections.mapOf
 import kotlin.collections.set
-import kotlin.collections.setOf
-import kotlin.collections.toSet
 
 object MutableShowSpec : Spek({
     describe("MutableShow") {
@@ -76,7 +71,7 @@ object MutableShowSpec : Spek({
 
             context("when weird port mappings are added") {
                 beforeEachTest {
-                    editor.incomingLinks["nonsense"] = MutableConstPort("invalid")
+                    editor.incomingLinks["nonsense"] = MutableConstPort("invalid", GlslType.from("?unknown?"))
                 }
 
                 it("should retain them, I guess?") {
@@ -255,7 +250,7 @@ private fun AutoWirer.testPatch(title: String): MutablePatch {
         """.trimIndent()
     )
 
-    return autoWire(shader).acceptSuggestedLinkOptions().resolve()
+    return autoWire(shader).acceptSuggestedLinkOptions().confirm()
 }
 
 //private fun Show.desc(): List<String> =

--- a/src/commonTest/kotlin/baaahs/show/live/OpenShowSpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/OpenShowSpec.kt
@@ -1,6 +1,7 @@
 package baaahs.show.live
 
 import baaahs.describe
+import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.AutoWirer
 import baaahs.gl.testPlugins
 import baaahs.only
@@ -16,14 +17,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import kotlinx.serialization.json.buildJsonObject
 import org.spekframework.spek2.Spek
-import kotlin.collections.emptyList
-import kotlin.collections.first
-import kotlin.collections.listOf
-import kotlin.collections.map
-import kotlin.collections.mapOf
-import kotlin.collections.plus
 import kotlin.collections.set
-import kotlin.collections.setOf
 
 object OpenShowSpec : Spek({
     describe<OpenShow> {
@@ -92,7 +86,8 @@ object OpenShowSpec : Spek({
             beforeEachTest {
                 mutableShow.addPatch(
                     autoWirer.wireUp(fakeShader("Weird Shader")).apply {
-                        mutableShaderInstances.only().incomingLinks["nonsense"] = MutableConstPort("invalid")
+                        mutableShaderInstances.only().incomingLinks["nonsense"] =
+                            MutableConstPort("invalid", GlslType.Companion.from("?huh?"))
                     }
                 )
             }

--- a/src/commonTest/kotlin/baaahs/show/live/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/TestUtil.kt
@@ -24,7 +24,7 @@ fun AutoWirer.wireUp(shader: Shader, ports: Map<String, MutablePort> = emptyMap(
             }
         }
     }
-    return unresolvedPatch.acceptSuggestedLinkOptions().resolve()
+    return unresolvedPatch.acceptSuggestedLinkOptions().confirm()
 }
 
 fun fakeShader(title: String, type: ShaderType = ShaderType.Paint) =

--- a/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowRunnerSpec.kt
@@ -43,7 +43,7 @@ object ShowRunnerSpec : Spek({
                 addPatch(
                     autoWirer.autoWire(Shaders.cylindricalProjection, Shaders.blue)
                         .acceptSuggestedLinkOptions()
-                        .resolve()
+                        .confirm()
                 )
                 addButtonGroup(
                     "Panel", "Scenes"
@@ -56,7 +56,7 @@ object ShowRunnerSpec : Spek({
                                 addPatch(
                                     autoWirer.autoWire(Shader("Untitled", ShaderType.Paint, shaderSrc))
                                         .acceptSuggestedLinkOptions()
-                                        .resolve()
+                                        .confirm()
                                 )
                             }
                         }

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -1,5 +1,6 @@
 package baaahs.app.ui
 
+import baaahs.app.ui.editor.ShaderEditorStyles
 import baaahs.ui.*
 import kotlinx.css.*
 import kotlinx.css.properties.*
@@ -13,6 +14,7 @@ import styled.StyleSheet
 
 class AllStyles(val theme: MuiTheme) {
     val appUi by lazy { ThemeStyles(theme) }
+    val shaderEditor by lazy { ShaderEditorStyles(theme) }
 }
 
 private fun linearRepeating(

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -31,7 +31,6 @@ import materialui.components.tabs.tabs
 import materialui.components.textfield.textField
 import materialui.components.typography.typographyH6
 import materialui.icon
-import materialui.useTheme
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
 import react.*
@@ -43,8 +42,7 @@ private enum class PageTabs {
 
 val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstanceEditor") { props ->
     val appContext = useContext(appContext)
-    val theme = useTheme()
-    val shaderEditorStyles = memo(theme) { ShaderEditorStyles(theme) }
+    val shaderEditorStyles = appContext.allStyles.shaderEditor
 
     var selectedTab by state { PageTabs.Properties }
     @Suppress("UNCHECKED_CAST")

--- a/src/jvmTest/kotlin/baaahs/fixtures/FixtureManagerSpec.kt
+++ b/src/jvmTest/kotlin/baaahs/fixtures/FixtureManagerSpec.kt
@@ -94,7 +94,7 @@ object FixtureManagerSpec : Spek({
 
                 beforeEachTest {
                     fixtureManager.activePatchSetChanged(activePatchSet)
-                    val updated = fixtureManager.maybeUpdateRenderPlans { _, _ -> null }
+                    val updated = fixtureManager.maybeUpdateRenderPlans(openShow)
                     expect(updated).toBe(true)
                 }
 
@@ -122,7 +122,7 @@ object FixtureManagerSpec : Spek({
                         expect(renderPlan.keys).toBe(setOf(fogMachineDevice))
 
                         fixtureManager.fixturesChanged(listOf(vuzuvela1), emptyList())
-                        val updated = fixtureManager.maybeUpdateRenderPlans { _, _ -> null }
+                        val updated = fixtureManager.maybeUpdateRenderPlans(openShow)
                         expect(updated).toBe(true)
                     }
 

--- a/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
+++ b/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
@@ -21,6 +21,7 @@ import baaahs.ui.Observer
 import baaahs.ui.addObserver
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
 import ch.tutteli.atrium.api.fluent.en_GB.isEmpty
+import ch.tutteli.atrium.api.fluent.en_GB.notToBeNull
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import com.danielgergely.kgl.GL_FRAGMENT_SHADER
@@ -146,8 +147,8 @@ object EditingShaderSpec : Spek({
                         expect(notifiedStates).containsExactly(State.Errors)
                     }
 
-                    it("should return null for ShaderInstanceOptions") {
-                        expect(editingShader.getShaderInstanceOptions()).toBe(null)
+                    it("should still return ShaderInstanceOptions") {
+                        expect(editingShader.getShaderInstanceOptions()).notToBeNull()
                     }
                 }
             }


### PR DESCRIPTION
Patch data source wiring is via shader channels. …
* Data sources implicitly create and publish to a shader channel named after them.
* Links from shaders to data sources are via such channels.
* Filters may be applied to such channels.
* New `Unknown` shader type permits arbitrary return content types.
* `Unknown` should be short-lived as a reified `ShaderType`.

Comments on lines preceding a GLSL function are associated with that function.