### PR TITLE
Shader refactor cleanup

### DIFF
--- a/src/commonMain/kotlin/baaahs/app/ui/editor/Editable.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/Editable.kt
@@ -1,5 +1,6 @@
 package baaahs.app.ui
 
+import baaahs.Severity
 import baaahs.app.ui.editor.EditableManager
 import baaahs.show.ButtonControl
 import baaahs.show.live.ControlDisplay
@@ -109,6 +110,8 @@ interface EditorPanel {
     val title: String
     val listSubhead: String?
     val icon: Icon?
+    val problemLevel: Severity? get() = null
+
     fun getNestedEditorPanels(): List<EditorPanel> = emptyList()
     fun getRenderer(editableManager: EditableManager): Renderer
 }

--- a/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/EditorPanels.kt
@@ -1,5 +1,6 @@
 package baaahs.app.ui.editor
 
+import baaahs.Severity
 import baaahs.app.ui.CommonIcons
 import baaahs.app.ui.EditorPanel
 import baaahs.show.mutable.*
@@ -15,7 +16,7 @@ data class GenericPropertiesEditorPanel(
         get() = "Properties"
     override val listSubhead: String?
         get() = null
-    override val icon: Icon?
+    override val icon: Icon
         get() = CommonIcons.Settings
 
     override fun getRenderer(editableManager: EditableManager): Renderer =
@@ -29,7 +30,7 @@ data class PatchHolderEditorPanel(
         get() = "Patches"
     override val listSubhead: String?
         get() = null
-    override val icon: Icon?
+    override val icon: Icon
         get() = CommonIcons.Patch
 
     override fun getNestedEditorPanels(): List<EditorPanel> {
@@ -45,9 +46,9 @@ data class PatchEditorPanel(
 ) : EditorPanel {
     override val title: String
         get() = mutablePatch.surfaces.name
-    override val listSubhead: String?
+    override val listSubhead: String
         get() = "Fixtures"
-    override val icon: Icon?
+    override val icon: Icon
         get() = CommonIcons.Fixture
 
     override fun getNestedEditorPanels(): List<EditorPanel> {
@@ -68,6 +69,8 @@ data class PatchEditorPanel(
             get() = "Shaders"
         override val icon: Icon
             get() = CommonIcons.UnknownShader // TODO: Derive this via ShaderType.
+        override val problemLevel: Severity?
+            get() = super.problemLevel
 
         override fun getRenderer(editableManager: EditableManager): Renderer =
             editorPanelViews.forShaderInstance(editableManager, mutablePatch, mutableShaderInstance)

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
@@ -32,14 +32,14 @@ class GlslAnalyzer(private val plugins: Plugins) {
 
     fun import(src: String): Shader {
         val glslCode = parse(src)
-        return validate(glslCode).shader
+        return analyze(glslCode).shader
     }
 
-    fun validate(src: String): ShaderAnalysis {
-        return validate(parse(src))
+    fun analyze(src: String): ShaderAnalysis {
+        return analyze(parse(src))
     }
 
-    fun validate(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
+    fun analyze(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
         val dialect = detectDialect(glslCode)
         return dialect.analyze(glslCode, plugins, shader)
     }
@@ -53,7 +53,7 @@ class GlslAnalyzer(private val plugins: Plugins) {
     }
 
     private fun openShader(glslCode: GlslCode, shader: Shader? = null): OpenShader {
-        val shaderAnalysis = validate(glslCode, shader)
+        val shaderAnalysis = analyze(glslCode, shader)
         return openShader(shaderAnalysis)
     }
 

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
@@ -40,6 +40,10 @@ class GlslAnalyzer(private val plugins: Plugins) {
         return analyze(parse(src))
     }
 
+    fun analyze(shader: Shader): ShaderAnalysis {
+        return analyze(parse(shader.src), shader)
+    }
+
     fun analyze(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
         val dialect = detectDialect(glslCode)
         return dialect.analyze(glslCode, plugins, shader)

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
@@ -8,16 +8,16 @@ import baaahs.show.Shader
 import baaahs.show.ShaderType
 
 class GlslAnalyzer(private val plugins: Plugins) {
-    fun pickPrototype(src: String): ShaderPrototype {
-        return pickPrototype(parse(src))
+    fun detectDialect(src: String): ShaderDialect {
+        return detectDialect(parse(src))
     }
 
-    fun pickPrototype(glslCode: GlslCode): ShaderPrototype {
-        return plugins.shaderPrototypes.all
+    fun detectDialect(glslCode: GlslCode): ShaderDialect {
+        return plugins.shaderDialects.all
             .map { it to it.matches(glslCode) }
             .filter { (_, match) -> match != MatchLevel.NoMatch }
             .maxByOrNull { (_, match) -> match }?.first
-            ?: GenericShaderPrototype
+            ?: GenericShaderDialect
     }
 
     fun parse(src: String): GlslCode {
@@ -40,8 +40,8 @@ class GlslAnalyzer(private val plugins: Plugins) {
     }
 
     fun validate(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
-        val prototype = pickPrototype(glslCode)
-        return prototype.analyze(glslCode, plugins, shader)
+        val dialect = detectDialect(glslCode)
+        return dialect.analyze(glslCode, plugins, shader)
     }
 
     fun openShader(src: String): OpenShader {
@@ -73,7 +73,7 @@ class GlslAnalyzer(private val plugins: Plugins) {
         return with(shaderAnalysis) {
             OpenShader.Base(this.shader, shaderAnalysis.glslCode,
                 entryPoint!!, inputPorts, outputPorts.only(),
-                shaderType, shaderPrototype)
+                shaderType, shaderDialect)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslCode.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslCode.kt
@@ -99,23 +99,8 @@ class GlslCode(
             symbolsToNamespace: Set<String>,
             symbolMap: Map<String, String>
         ): String {
-            // Chomp leading whitespace.
-            var newlineCount = 0
-            var i = 0
-            loop@ while (i < fullText.length) {
-                when (fullText[i]) {
-                    '\n' -> newlineCount++
-                    ' ', '\t' -> {}
-                    else -> break@loop
-                }
-                i++
-            }
-
-            val trimmedText = fullText.substring(i)
-            val trimmedLineNumber = lineNumber?.plus(newlineCount)
-
-            return "${trimmedLineNumber?.let { "\n#line $trimmedLineNumber\n" }}" +
-                    replaceCodeWords(trimmedText) {
+            return "${lineNumber?.let { "\n#line $lineNumber\n" }}" +
+                    replaceCodeWords(fullText) {
                         symbolMap[it]
                             ?: if (it == name || symbolsToNamespace.contains(it)) {
                                 namespace.qualify(it)

--- a/src/commonMain/kotlin/baaahs/gl/glsl/README.md
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/README.md
@@ -45,7 +45,7 @@ Shader stages:
 | _edit_                       | `MutableShader` |
 | `mutableShader.build()`      | `Shader` |
 | `glslAnalyzer.parse()`       | `GlslCode` |
-| `glslAnalyzer.pickPrototype` | `ShaderPrototype` |
+| `glslAnalyzer.detectDialect` | `ShaderDialect` |
 | `glslAnalyzer.validate()`    | `ShaderAnalyzsis` |
 | `glslAnalyzer.openShader()`  | `OpenShader` |
 | `autoWirer.autoWire()`       | `UnresolvedPatch` |

--- a/src/commonMain/kotlin/baaahs/gl/glsl/ShaderAnalysis.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/ShaderAnalysis.kt
@@ -2,13 +2,13 @@ package baaahs.gl.glsl
 
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OutputPort
-import baaahs.gl.shader.ShaderPrototype
+import baaahs.gl.shader.ShaderDialect
 import baaahs.show.Shader
 
 interface ShaderAnalysis {
     val glslCode: GlslCode
 
-    val shaderPrototype: ShaderPrototype
+    val shaderDialect: ShaderDialect
 
     val entryPoint: GlslCode.GlslFunction?
 

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
@@ -3,6 +3,7 @@ package baaahs.gl.patch
 import baaahs.app.ui.editor.LinkOption
 import baaahs.app.ui.editor.PortLinkOption
 import baaahs.fixtures.DeviceType
+import baaahs.gl.glsl.LinkException
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OpenShader
 import baaahs.plugin.Plugins
@@ -145,7 +146,7 @@ class ShaderInstanceOptions(
                 try {
                     val dataSource = plugins.resolveDataSource(inputPort)
                     options.add(PortLinkOption(MutableDataSourcePort(dataSource), isPluginRef = true))
-                } catch (e: IllegalStateException) {
+                } catch (e: LinkException) {
                     logger.warn(e) { "Incorrect plugin reference." }
                 }
             }

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -99,7 +99,7 @@ class PreviewShaderBuilder(
     }
 
     fun analyze() {
-        val shaderAnalysis = autoWirer.glslAnalyzer.analyze(shader.src)
+        val shaderAnalysis = autoWirer.glslAnalyzer.analyze(shader)
         this.shaderAnalysis = shaderAnalysis
         openShader = autoWirer.glslAnalyzer.openShader(shaderAnalysis)
         state = ShaderBuilder.State.Linking

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -29,6 +29,7 @@ interface ShaderBuilder : IObservable {
     val shader: Shader
     val state: State
     val gadgets: List<GadgetPreview>
+    val shaderAnalysis: ShaderAnalysis?
     val openShader: OpenShader?
     val linkedPatch: LinkedPatch?
     val glslProgram: GlslProgram?
@@ -65,6 +66,8 @@ class PreviewShaderBuilder(
         ShaderBuilder.State.Unbuilt
         private set
 
+    override var shaderAnalysis: ShaderAnalysis? = null
+        private set
     override var openShader: OpenShader? = null
         private set
     var previewPatch: MutablePatch? = null
@@ -77,12 +80,12 @@ class PreviewShaderBuilder(
     override val gadgets: List<ShaderBuilder.GadgetPreview> get() = mutableGadgets
     private val mutableGadgets: MutableList<ShaderBuilder.GadgetPreview> = arrayListOf()
 
-    override var glslErrors: List<GlslError> = emptyList()
-        private set
+    override val glslErrors: List<GlslError> get() =
+        (shaderAnalysis?.errors ?: emptyList()) + compileErrors
+
+    private var compileErrors: List<GlslError> = emptyList()
 
     val feeds = mutableListOf<Feed>()
-
-    private fun analyze(shader: Shader) = autoWirer.glslAnalyzer.openShader(shader)
 
     private val previewShaders = PreviewShaders(autoWirer)
 
@@ -96,7 +99,9 @@ class PreviewShaderBuilder(
     }
 
     fun analyze() {
-        openShader = analyze(shader)
+        val shaderAnalysis = autoWirer.glslAnalyzer.analyze(shader.src)
+        this.shaderAnalysis = shaderAnalysis
+        openShader = autoWirer.glslAnalyzer.openShader(shaderAnalysis)
         state = ShaderBuilder.State.Linking
         notifyChanged()
 
@@ -110,6 +115,7 @@ class PreviewShaderBuilder(
             val openShader = openShader!!
             val shaderType = openShader.shaderType
             val shaders = shaderType.pickPreviewShaders(openShader, previewShaders)
+            val resultContentType = shaderType.previewResultContentType()
             val defaultPorts = if (shaderType.injectUvCoordinateForPreview) {
                 mapOf(ContentType.UvCoordinate to MutableConstPort("gl_FragCoord", GlslType.Vec2))
             } else emptyMap()
@@ -118,14 +124,14 @@ class PreviewShaderBuilder(
 //                .dumpOptions()
                 .acceptSuggestedLinkOptions()
                 .confirm()
-            linkedPatch = previewPatch?.openForPreview(autoWirer)
+            linkedPatch = previewPatch?.openForPreview(autoWirer, resultContentType)
             state = ShaderBuilder.State.Linked
         } catch (e: GlslException) {
-            glslErrors = e.errors
+            compileErrors = e.errors
             state = ShaderBuilder.State.Errors
         } catch (e: Exception) {
             logger.warn(e) { "Failed to analyze shader." }
-            glslErrors = listOf(GlslError(e.message ?: e.toString()))
+            compileErrors = listOf(GlslError(e.message ?: e.toString()))
             state = ShaderBuilder.State.Errors
         }
         notifyChanged()
@@ -159,11 +165,11 @@ class PreviewShaderBuilder(
             glslProgram = linkedPatch?.let { renderEngine.compile(it, feedResolver) }
             state = ShaderBuilder.State.Success
         } catch (e: GlslException) {
-            glslErrors = e.errors
+            compileErrors = e.errors
             state = ShaderBuilder.State.Errors
         } catch (e: Exception) {
             logger.warn(e) { "Failed to compile patch." }
-            glslErrors = listOf(GlslError(e.message ?: e.toString()))
+            compileErrors = listOf(GlslError(e.message ?: e.toString()))
             state = ShaderBuilder.State.Errors
         }
         notifyChanged()

--- a/src/commonMain/kotlin/baaahs/gl/shader/DistortionShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/DistortionShader.kt
@@ -1,14 +1,11 @@
 package baaahs.gl.shader
 
 import baaahs.app.ui.CommonIcons
-import baaahs.gl.glsl.GlslType
 import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.patch.ContentType
 import baaahs.gl.preview.PreviewShaders
-import baaahs.plugin.objectSerializer
 import baaahs.show.ShaderType
 import baaahs.ui.Icon
-import kotlinx.serialization.SerialName
 
 object DistortionShader : ShaderType {
     override val title: String = "Distortion"
@@ -24,9 +21,9 @@ object DistortionShader : ShaderType {
     """.trimIndent()
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputPorts.firstOrNull()?.contentType == ContentType.UvCoordinate
-            && shaderAnalysis.inputPorts.any { it.contentType == ContentType.UvCoordinate })
-            ShaderType.MatchLevel.MatchAndFilter else ShaderType.MatchLevel.NoMatch
+        return if (shaderAnalysis.signatureMatches(ContentType.UvCoordinate, ContentType.UvCoordinate))
+            ShaderType.MatchLevel.MatchAndFilter
+        else ShaderType.MatchLevel.NoMatch
     }
 
     override fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader> {

--- a/src/commonMain/kotlin/baaahs/gl/shader/FilterShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/FilterShader.kt
@@ -21,9 +21,9 @@ object FilterShader : ShaderType {
     """.trimIndent()
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputPorts.firstOrNull()?.contentType == ContentType.Color
-            && shaderAnalysis.inputPorts.any { it.contentType == ContentType.Color })
-            ShaderType.MatchLevel.MatchAndFilter else ShaderType.MatchLevel.NoMatch
+        return if (shaderAnalysis.signatureMatches(ContentType.Color, ContentType.Color))
+            ShaderType.MatchLevel.MatchAndFilter
+        else ShaderType.MatchLevel.NoMatch
     }
 
     override fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader> {

--- a/src/commonMain/kotlin/baaahs/gl/shader/GenericShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/GenericShaderDialect.kt
@@ -6,7 +6,7 @@ import baaahs.gl.patch.ContentType
 import baaahs.listOf
 import baaahs.plugin.Plugins
 
-object GenericShaderPrototype : HintedShaderPrototype("baaahs.Core:Generic") {
+object GenericShaderDialect : HintedShaderDialect("baaahs.Core:Generic") {
     override val title: String = "Generic"
     override val entryPointName: String = "main"
 

--- a/src/commonMain/kotlin/baaahs/gl/shader/HintedShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/HintedShaderDialect.kt
@@ -5,7 +5,7 @@ import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
 
-abstract class HintedShaderPrototype(id: String) : ShaderPrototype(id) {
+abstract class HintedShaderDialect(id: String) : ShaderDialect(id) {
     open val implicitInputPorts: List<InputPort> = emptyList()
     open val wellKnownInputPorts: List<InputPort> = emptyList()
     open val defaultInputPortsByType: Map<GlslType, InputPort> = emptyMap()
@@ -26,8 +26,8 @@ abstract class HintedShaderPrototype(id: String) : ShaderPrototype(id) {
         val proFormaInputPorts: List<InputPort> =
             implicitInputPorts.mapNotNull { glslCode.ifRefersTo(it)?.copy(isImplicit = true) }
 
-        val wellKnownInputPorts = this@HintedShaderPrototype.wellKnownInputPorts.associateBy { it.id }
-        val defaultInputPortsByType = this@HintedShaderPrototype.defaultInputPortsByType
+        val wellKnownInputPorts = this@HintedShaderDialect.wellKnownInputPorts.associateBy { it.id }
+        val defaultInputPortsByType = this@HintedShaderDialect.defaultInputPortsByType
 
         val entryPoint = findEntryPointOrNull(glslCode)
 
@@ -60,7 +60,7 @@ abstract class HintedShaderPrototype(id: String) : ShaderPrototype(id) {
 
         return object : ShaderAnalysis {
             override val glslCode = glslCode
-            override val shaderPrototype = this@HintedShaderPrototype
+            override val shaderDialect = this@HintedShaderDialect
             override val entryPoint = entryPoint
             override val inputPorts = inputPorts
             override val outputPorts = outputPorts

--- a/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/MoverShader.kt
@@ -1,14 +1,11 @@
 package baaahs.gl.shader
 
 import baaahs.app.ui.CommonIcons
-import baaahs.gl.glsl.GlslType
 import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.patch.ContentType
 import baaahs.gl.preview.PreviewShaders
-import baaahs.plugin.objectSerializer
 import baaahs.show.ShaderType
 import baaahs.ui.Icon
-import kotlinx.serialization.SerialName
 
 object MoverShader : ShaderType {
     override val title: String = "Mover"
@@ -22,8 +19,9 @@ object MoverShader : ShaderType {
     """.trimIndent()
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputPorts.firstOrNull()?.contentType == ContentType.PanAndTilt)
-            ShaderType.MatchLevel.Match else ShaderType.MatchLevel.NoMatch
+        return if (shaderAnalysis.outputIs(ContentType.PanAndTilt))
+            ShaderType.MatchLevel.Match
+        else ShaderType.MatchLevel.NoMatch
     }
 
     override fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader> {

--- a/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
@@ -5,6 +5,7 @@ import baaahs.RefCounter
 import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslCode.GlslFunction
 import baaahs.gl.glsl.GlslCode.Namespace
+import baaahs.gl.glsl.GlslError
 import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.only
 import baaahs.show.Shader
@@ -24,6 +25,8 @@ interface OpenShader : RefCounted {
 
     val shaderType: ShaderType
     val shaderDialect: ShaderDialect
+
+    val errors: List<GlslError>
 
     fun findInputPortOrNull(portId: String): InputPort? =
         inputPorts.find { it.id == portId }
@@ -47,7 +50,8 @@ interface OpenShader : RefCounted {
         override val inputPorts: List<InputPort>,
         override val outputPort: OutputPort,
         override val shaderType: ShaderType,
-        override val shaderDialect: ShaderDialect
+        override val shaderDialect: ShaderDialect,
+        override val errors: List<GlslError> = emptyList()
     ) : OpenShader, RefCounted by RefCounter() {
 
         constructor(shaderAnalysis: ShaderAnalysis, shaderType: ShaderType) : this(

--- a/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
@@ -23,7 +23,7 @@ interface OpenShader : RefCounted {
     val outputPort: OutputPort
 
     val shaderType: ShaderType
-    val shaderPrototype: ShaderPrototype
+    val shaderDialect: ShaderDialect
 
     fun findInputPortOrNull(portId: String): InputPort? =
         inputPorts.find { it.id == portId }
@@ -47,13 +47,13 @@ interface OpenShader : RefCounted {
         override val inputPorts: List<InputPort>,
         override val outputPort: OutputPort,
         override val shaderType: ShaderType,
-        override val shaderPrototype: ShaderPrototype
+        override val shaderDialect: ShaderDialect
     ) : OpenShader, RefCounted by RefCounter() {
 
         constructor(shaderAnalysis: ShaderAnalysis, shaderType: ShaderType) : this(
             shaderAnalysis.shader, shaderAnalysis.glslCode, shaderAnalysis.entryPoint!!,
             shaderAnalysis.inputPorts, shaderAnalysis.outputPorts.only(), shaderType,
-            shaderAnalysis.shaderPrototype
+            shaderAnalysis.shaderDialect
         )
 
         override val title: String get() = shader.title

--- a/src/commonMain/kotlin/baaahs/gl/shader/PaintShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/PaintShader.kt
@@ -21,9 +21,9 @@ object PaintShader : ShaderType {
     """.trimIndent()
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputPorts.firstOrNull()?.contentType == ContentType.Color
-            && shaderAnalysis.inputPorts.any { it.contentType == ContentType.UvCoordinate })
-            ShaderType.MatchLevel.Match else ShaderType.MatchLevel.NoMatch
+        return if (shaderAnalysis.outputIs(ContentType.Color))
+            ShaderType.MatchLevel.Match
+        else ShaderType.MatchLevel.NoMatch
     }
 
     override fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader> {

--- a/src/commonMain/kotlin/baaahs/gl/shader/ProjectionShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/ProjectionShader.kt
@@ -1,14 +1,11 @@
 package baaahs.gl.shader
 
 import baaahs.app.ui.CommonIcons
-import baaahs.gl.glsl.GlslType
 import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.patch.ContentType
 import baaahs.gl.preview.PreviewShaders
-import baaahs.plugin.objectSerializer
 import baaahs.show.ShaderType
 import baaahs.ui.Icon
-import kotlinx.serialization.SerialName
 
 object ProjectionShader : ShaderType {
     override val title: String = "Projection"
@@ -34,9 +31,9 @@ object ProjectionShader : ShaderType {
     override val injectUvCoordinateForPreview: Boolean get() = false
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputPorts.firstOrNull()?.contentType == ContentType.UvCoordinate
-            && shaderAnalysis.inputPorts.any { it.contentType == ContentType.XyzCoordinate })
-            ShaderType.MatchLevel.Match else ShaderType.MatchLevel.NoMatch
+        return if (shaderAnalysis.signatureMatches(ContentType.XyzCoordinate, ContentType.UvCoordinate))
+            ShaderType.MatchLevel.Match
+        else ShaderType.MatchLevel.NoMatch
     }
 
     override fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader> {

--- a/src/commonMain/kotlin/baaahs/gl/shader/ShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/ShaderDialect.kt
@@ -5,7 +5,7 @@ import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
 
-abstract class ShaderPrototype(val id: String) {
+abstract class ShaderDialect(val id: String) {
 
     abstract val title: String
 

--- a/src/commonMain/kotlin/baaahs/gl/shader/ShaderToyShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/ShaderToyShaderDialect.kt
@@ -8,7 +8,7 @@ import baaahs.gl.patch.ContentType
 import baaahs.plugin.Plugins
 import baaahs.show.Shader
 
-object ShaderToyShaderPrototype : HintedShaderPrototype("baaahs.Core:ShaderToy") {
+object ShaderToyShaderDialect : HintedShaderDialect("baaahs.Core:ShaderToy") {
 
     override val entryPointName: String = "mainImage"
 

--- a/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
@@ -69,10 +69,10 @@ class CorePlugin(private val pluginContext: PluginContext) : Plugin {
             MovingHeadDevice
         )
 
-    override val shaderPrototypes
+    override val shaderDialects
         get() = listOf(
-            GenericShaderPrototype,
-            ShaderToyShaderPrototype
+            GenericShaderDialect,
+            ShaderToyShaderDialect
         )
 
     override val shaderTypes: List<ShaderType>

--- a/src/commonMain/kotlin/baaahs/plugin/Plugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/Plugin.kt
@@ -2,7 +2,7 @@ package baaahs.plugin
 
 import baaahs.fixtures.DeviceType
 import baaahs.gl.patch.ContentType
-import baaahs.gl.shader.ShaderPrototype
+import baaahs.gl.shader.ShaderDialect
 import baaahs.show.*
 import baaahs.util.Clock
 import kotlinx.serialization.InternalSerializationApi
@@ -34,7 +34,7 @@ interface Plugin {
     val deviceTypes: List<DeviceType>
         get() = emptyList()
 
-    val shaderPrototypes: List<ShaderPrototype>
+    val shaderDialects: List<ShaderDialect>
         get() = emptyList()
 
     val shaderTypes: List<ShaderType>

--- a/src/commonMain/kotlin/baaahs/plugin/Plugins.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/Plugins.kt
@@ -85,7 +85,7 @@ class Plugins private constructor(
 
     val deviceTypes = DeviceTypes()
 
-    val shaderPrototypes = ShaderPrototypes()
+    val shaderDialects = ShaderDialects()
     val shaderTypes = ShaderTypes()
 
     private inline fun <reified T : Any> SerializersModuleBuilder.registerSerializers(
@@ -276,8 +276,8 @@ class Plugins private constructor(
         }
     }
 
-    inner class ShaderPrototypes {
-        val all = plugins.flatMap { it.shaderPrototypes }
+    inner class ShaderDialects {
+        val all = plugins.flatMap { it.shaderDialects }
     }
 
     inner class ShaderTypes {

--- a/src/commonMain/kotlin/baaahs/show/ShaderType.kt
+++ b/src/commonMain/kotlin/baaahs/show/ShaderType.kt
@@ -2,6 +2,7 @@ package baaahs.show
 
 import baaahs.app.ui.CommonIcons
 import baaahs.gl.glsl.ShaderAnalysis
+import baaahs.gl.patch.ContentType
 import baaahs.gl.preview.PreviewShaders
 import baaahs.gl.shader.OpenShader
 import baaahs.show.mutable.MutableShader
@@ -20,6 +21,18 @@ interface ShaderType {
     fun matches(shaderAnalysis: ShaderAnalysis): MatchLevel
 
     fun pickPreviewShaders(openShader: OpenShader, previewShaders: PreviewShaders): List<OpenShader>
+
+    fun previewResultContentType(): ContentType = ContentType.Color
+
+
+    fun ShaderAnalysis.anyInputIs(contentType: ContentType) =
+        inputPorts.any { it.contentType == contentType }
+
+    fun ShaderAnalysis.outputIs(contentType: ContentType) =
+        outputPorts.firstOrNull()?.contentType == contentType
+
+    fun ShaderAnalysis.signatureMatches(inputContentType: ContentType, outputContentType: ContentType) =
+        outputIs(outputContentType) && anyInputIs(inputContentType)
 
     object Unknown : ShaderType {
         override val title: String get() = "Unknown"

--- a/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
@@ -54,7 +54,15 @@ class LiveShaderInstance(
                 add(
                     ShowProblem(
                     "Result content type is unknown for shader \"$title\".", severity = Severity.ERROR
-                ))
+                    )
+                )
+            }
+            if (shader.errors.isNotEmpty()) {
+                add(
+                    ShowProblem(
+                        "GLSL errors in shader \"$title\".", severity = Severity.ERROR
+                    )
+                )
             }
         }
 

--- a/src/commonMain/kotlin/baaahs/show/live/OpenPatchHolder.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenPatchHolder.kt
@@ -1,5 +1,7 @@
 package baaahs.show.live
 
+import baaahs.Severity
+import baaahs.getValue
 import baaahs.show.PatchHolder
 
 open class OpenPatchHolder(
@@ -9,6 +11,7 @@ open class OpenPatchHolder(
     val title = patchHolder.title
     val patches = patchHolder.patches.map { OpenPatch(it, openContext) }
     val problems get() = patches.flatMap { it.problems }
+    val problemLevel: Severity? by lazy { problems.maxOfOrNull { it.severity } }
 
     val controlLayout: Map<String, List<OpenControl>> =
         patchHolder.controlLayout.mapValues { (_, controlRefs) ->

--- a/src/commonMain/kotlin/baaahs/show/mutable/EditingShader.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/EditingShader.kt
@@ -36,6 +36,16 @@ class EditingShader(
     val openShader get() = shaderBuilder.openShader
     val inputPorts get() = openShader?.inputPorts?.sortedBy { it.title }
 
+    val extraLinks: Map<String, MutablePort>
+        get() {
+            return openShader?.let {
+                val inputPortIds = it.inputPorts.map { port -> port.id }.toSet()
+                mutableShaderInstance.incomingLinks.filter { (id, _) ->
+                    !inputPortIds.contains(id)
+                }
+            } ?: emptyMap()
+        }
+
     init {
         startBuilding()
     }

--- a/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/mutable/MutableShow.kt
@@ -305,7 +305,7 @@ class MutablePatch {
     }
 
     /** Build a [LinkedPatch] independent of an [baaahs.show.live.OpenShow]. */
-    fun openForPreview(autoWirer: AutoWirer, resultContentType: ContentType = ContentType.Color): LinkedPatch? {
+    fun openForPreview(autoWirer: AutoWirer, resultContentType: ContentType): LinkedPatch? {
         val showBuilder = ShowBuilder()
         build(showBuilder)
 

--- a/src/commonTest/kotlin/baaahs/gl/PreviewShaderBuilderSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/PreviewShaderBuilderSpec.kt
@@ -86,8 +86,9 @@ object PreviewShaderBuilderSpec : Spek({
                             )
                         }
 
-                        it("should report an error right away") {
-                            expect(previewShaderBuilder.state).toBe(ShaderBuilder.State.Errors)
+                        it("should not result in a build error") {
+                            expect(previewShaderBuilder.state).toBe(ShaderBuilder.State.Linked)
+                            expect(previewShaderBuilder.openShader!!.errors).isEmpty()
                         }
                     }
 

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -326,7 +326,7 @@ object GlslAnalyzerSpec : Spek({
             }
 
             context("#validate") {
-                val validationResult by value { glslAnalyzer.validate(shaderText) }
+                val validationResult by value { glslAnalyzer.analyze(shaderText) }
 
                 context("when there are problems in the shader") {
                     override(shaderText) {

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -6,9 +6,9 @@ import baaahs.gl.expects
 import baaahs.gl.glsl.GlslCode.*
 import baaahs.gl.override
 import baaahs.gl.patch.ContentType
-import baaahs.gl.shader.GenericShaderPrototype
+import baaahs.gl.shader.GenericShaderDialect
 import baaahs.gl.shader.InputPort
-import baaahs.gl.shader.ShaderToyShaderPrototype
+import baaahs.gl.shader.ShaderToyShaderDialect
 import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders
 import baaahs.only
@@ -306,20 +306,20 @@ object GlslAnalyzerSpec : Spek({
                 }
             }
 
-            context("#pickPrototype") {
+            context("#detectDialect") {
                 override(shaderText) { "void main() {}" }
 
-                val prototype by value { glslAnalyzer.pickPrototype(shaderText) }
+                val dialect by value { glslAnalyzer.detectDialect(shaderText) }
 
                 it("is generic") {
-                    expect(prototype).toBe(GenericShaderPrototype)
+                    expect(dialect).toBe(GenericShaderDialect)
                 }
 
                 context("for shaders having a mainImage function") {
                     override(shaderText) { "void mainImage() {}" }
 
                     it("is ShaderToy") {
-                        expect(prototype).toBe(ShaderToyShaderPrototype)
+                        expect(dialect).toBe(ShaderToyShaderDialect)
                     }
                 }
             }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -13,11 +13,11 @@ import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders
 import baaahs.only
 import baaahs.toBeSpecified
+import baaahs.toEqual
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
-import kotlin.test.fail
 
 object GlslAnalyzerSpec : Spek({
     describe<GlslAnalyzer> {
@@ -473,11 +473,8 @@ object GlslAnalyzerSpec : Spek({
                     override(shaderText) { "" }
 
                     it("provides a fake entry point function") {
-                        try {
-                            shader.let {}
-                            fail("should have failed")
-                        } catch (e: Exception) {
-                        }
+                        expect(shader.entryPoint.name)
+                            .toEqual("invalid")
                     }
                 }
             }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -65,7 +65,7 @@ object GlslAnalyzerSpec : Spek({
                             GlslOther(
                                 "unknown",
                                 "precision mediump float;",
-                                lineNumber = 1,
+                                lineNumber = 4,
                                 listOf("This Shader's Name", "Other stuff.")
                             ),
                             GlslVar(
@@ -79,9 +79,9 @@ object GlslAnalyzerSpec : Spek({
                             GlslVar(
                                 "resolution",
                                 GlslType.Vec2,
-                                "\n\n\n\nuniform vec2  resolution;",
+                                "uniform vec2  resolution;",
                                 isUniform = true,
-                                lineNumber = 5,
+                                lineNumber = 10,
                                 comments = listOf(" @@HintClass", "   key=value", "   key2=value2")
                             ),
                             GlslVar(
@@ -94,7 +94,7 @@ object GlslAnalyzerSpec : Spek({
                                         "    vec3 heading;\n" +
                                         "} leftEye;",
                                 isUniform = true,
-                                lineNumber = 12,
+                                lineNumber = 13,
                                 comments = listOf("@@AnotherClass key=value key2=value2")
                             ),
                             GlslFunction(
@@ -133,7 +133,7 @@ object GlslAnalyzerSpec : Spek({
                                 comments = listOf(" trailing comment")
                             ), GlslVar(
                                 "resolution", GlslType.Vec2,
-                                fullText = " \n\n\n\nuniform vec2  resolution;", isUniform = true, lineNumber = 5,
+                                fullText = "uniform vec2  resolution;", isUniform = true, lineNumber = 10,
                                 comments = listOf(" @@HintClass", "   key=value", "   key2=value2")
                             ), GlslVar(
                                 "leftEye",
@@ -141,7 +141,7 @@ object GlslAnalyzerSpec : Spek({
                                     "MovingHeadInfo",
                                     mapOf("origin" to GlslType.Vec3, "heading" to GlslType.Vec3)
                                 ),
-                                fullText = "uniform MovingHeadInfo leftEye;", lineNumber = 12,
+                                fullText = "uniform MovingHeadInfo leftEye;", lineNumber = 13,
                                 comments = listOf(" @@AnotherClass key=value key2=value2")
                             )
                         )
@@ -156,9 +156,9 @@ object GlslAnalyzerSpec : Spek({
                 }
 
                 it("finds the structs") {
-                    expect(glslCode.structs.map { it.fullText })
+                    expect(glslCode.structs.map { "${it.lineNumber}: ${it.fullText}" })
                         .containsExactly(
-                            "\nuniform struct MovingHeadInfo {\n    vec3 origin;\n    vec3 heading;\n} leftEye;"
+                            "13: uniform struct MovingHeadInfo {\n    vec3 origin;\n    vec3 heading;\n} leftEye;"
                         )
                 }
 
@@ -199,11 +199,12 @@ object GlslAnalyzerSpec : Spek({
                         expect(glslCode.globalVars.toList()).containsExactly(
                             GlslVar(
                                 "shouldBeDefined", GlslType.Float,
-                                fullText = "\n\n\nuniform float shouldBeDefined;", isUniform = true, lineNumber = 5
+                                fullText = "uniform float shouldBeDefined;", isUniform = true, lineNumber = 8
                             ),
                             GlslVar(
                                 "shouldBeThis", GlslType.Vec2,
-                                fullText = "\n\n\n\n\nuniform vec2 shouldBeThis;", isUniform = true, lineNumber = 9
+                                // TODO: 18 is wrong, should be 14!
+                                fullText = "uniform vec2 shouldBeThis;", isUniform = true, lineNumber = 18
                             )
                         )
                     }
@@ -297,7 +298,7 @@ object GlslAnalyzerSpec : Spek({
                                     GlslType.Void,
                                     params = emptyList(), // TODO: 1 seems wrong here, shouldn't it be 3?
                                     fullText = "float main() { return time + sin(time); }\n",
-                                    lineNumber = 1,
+                                    lineNumber = 3,
                                     comments = listOf(" @return time2")
                                 ),
                             ), { glslAnalyzer.findStatements(shaderText) }, true
@@ -341,7 +342,7 @@ object GlslAnalyzerSpec : Spek({
                         expect(validationResult.errors.toSet()).containsExactly(
                             GlslError("Input port \"foo\" content type is \"unknown/float\"", 1),
                             GlslError("Input port \"inColor\" content type is \"unknown/vec4\"", 2),
-                            GlslError("Output port \"[return value]\" content type is \"unknown/vec4\"", 1)
+                            GlslError("Output port \"[return value]\" content type is \"unknown/vec4\"", 2)
                         )
                     }
                 }

--- a/src/commonTest/kotlin/baaahs/gl/patch/AutoWirerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/AutoWirerSpec.kt
@@ -169,7 +169,7 @@ object AutoWirerSpec : Spek({
                 autoWirer.autoWire(*shaders, deviceTypes = listOf(deviceType))
                     .acceptSuggestedLinkOptions().confirm()
             }
-            val linkedPatch by value { patch.openForPreview(autoWirer)!! }
+            val linkedPatch by value { patch.openForPreview(autoWirer, ContentType.Color)!! }
             val rootProgramNode by value { linkedPatch.rootNode as LinkedShaderInstance }
             val mutableLinks by value { patch.mutableShaderInstances.only().incomingLinks }
             val links by value { rootProgramNode.incomingLinks }

--- a/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
@@ -182,7 +182,7 @@ object PatchResolverSpec : Spek({
 
                         vec4 p2_brightnessFilteri_result = vec4(0., 0., 0., 1.);
 
-                        #line 3
+                        #line 4
                         vec4 p2_brightnessFilter_main(vec4 colorIn) {
                           return colorIn * in_brightnessSlider;
                         }
@@ -282,7 +282,7 @@ object PatchResolverSpec : Spek({
 
                         float p1_wobblyTimeFilteri_result = float(0.);
 
-                        #line 2
+                        #line 3
                         float p1_wobblyTimeFilter_main() { return in_time + sin(in_time); }
 
                         // Shader: Orange Shader; namespace: p2
@@ -300,7 +300,7 @@ object PatchResolverSpec : Spek({
 
                         vec4 p3_brightnessFilteri_result = vec4(0., 0., 0., 1.);
 
-                        #line 3
+                        #line 4
                         vec4 p3_brightnessFilter_main(vec4 colorIn) {
                           return colorIn * in_brightnessSlider;
                         }
@@ -435,7 +435,7 @@ object PatchResolverSpec : Spek({
 
                         float p1_wobblyTimeFilteri_result = float(0.);
 
-                        #line 2
+                        #line 3
                         float p1_wobblyTimeFilter_main() { return in_time + sin(in_time); }
 
                         // Shader: A Main Shader; namespace: p2
@@ -463,7 +463,7 @@ object PatchResolverSpec : Spek({
 
                         vec4 p4_fadei_result = vec4(0., 0., 0., 1.);
 
-                        #line 5
+                        #line 6
                         vec4 p4_fade_main(vec4 colorIn) {
                             return mix(colorIn, p3_orangeShader_gl_FragColor, in_fadeSlider);
                         }

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
@@ -14,6 +14,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslAnalyzer
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
+import baaahs.gl.patch.ContentType
 import baaahs.gl.renderPlanFor
 import baaahs.gl.testPlugins
 import baaahs.plugin.CorePlugin
@@ -260,7 +261,7 @@ class RenderEngineTest {
             .autoWire(directXyProjection, shader)
             .acceptSuggestedLinkOptions()
             .confirm()
-            .openForPreview(autoWirer)!!
+            .openForPreview(autoWirer, ContentType.Color)!!
         return renderEngine.compile(linkedPatch) { id, dataSource ->
             if (dataSource is CorePlugin.GadgetDataSource<*>) {
                 fakeShowPlayer.registerGadget(id, dataSource.createGadget(), dataSource)

--- a/src/commonTest/kotlin/baaahs/gl/shader/FilterShaderSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/FilterShaderSpec.kt
@@ -15,7 +15,7 @@ object FilterShaderSpec : Spek({
     describe<FilterShader> {
         val shaderText by value { toBeSpecified<String>() }
         val analyzer by value { GlslAnalyzer(testPlugins()) }
-        val shaderAnalysis by value { analyzer.validate(shaderText) }
+        val shaderAnalysis by value { analyzer.analyze(shaderText) }
         val openShader by value { analyzer.openShader(shaderText) }
         val shaderType by value { FilterShader }
 

--- a/src/commonTest/kotlin/baaahs/gl/shader/GenericShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/GenericShaderDialectSpec.kt
@@ -28,7 +28,7 @@ object GenericShaderDialectSpec : Spek({
         val dialect by value { GenericShaderDialect }
         val plugins by value { testPlugins() }
         val analyzer by value { GlslAnalyzer(plugins) }
-        val shaderAnalysis by value { analyzer.validate(src) }
+        val shaderAnalysis by value { analyzer.analyze(src) }
         val glslCode by value { shaderAnalysis.glslCode }
         val openShader by value { analyzer.openShader(shaderAnalysis) }
 

--- a/src/commonTest/kotlin/baaahs/gl/shader/GenericShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/GenericShaderDialectSpec.kt
@@ -15,8 +15,8 @@ import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 
 @Suppress("unused")
-object GenericShaderPrototypeSpec : Spek({
-    describe<GenericShaderPrototypeSpec> {
+object GenericShaderDialectSpec : Spek({
+    describe<GenericShaderDialectSpec> {
         val src by value {
             """
                 // @return time
@@ -25,7 +25,7 @@ object GenericShaderPrototypeSpec : Spek({
                 ) { return time + sin(time); }
             """.trimIndent()
         }
-        val prototype by value { GenericShaderPrototype }
+        val dialect by value { GenericShaderDialect }
         val plugins by value { testPlugins() }
         val analyzer by value { GlslAnalyzer(plugins) }
         val shaderAnalysis by value { analyzer.validate(src) }
@@ -34,7 +34,7 @@ object GenericShaderPrototypeSpec : Spek({
 
         context("shaders having a main() function") {
             it("is a poor match (so this one acts as a fallback)") {
-                expect(prototype.matches(glslCode)).toEqual(MatchLevel.Poor)
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.Poor)
             }
 
             it("finds the input port") {
@@ -70,7 +70,7 @@ object GenericShaderPrototypeSpec : Spek({
                 override(src) { "void main(float intensity) { gl_FragColor = vec4(gl_FragCoord, 0., 1.); };" }
 
                 it("continues to be a match") {
-                    expect(prototype.matches(glslCode)).toEqual(MatchLevel.Poor)
+                    expect(dialect.matches(glslCode)).toEqual(MatchLevel.Poor)
                 }
 
                 it("finds the input port") {
@@ -99,7 +99,7 @@ object GenericShaderPrototypeSpec : Spek({
         context("shaders without a main() function") {
             override(src) { "void mainImage(void) { ... };" }
             it("is not a match") {
-                expect(prototype.matches(glslCode)).toEqual(MatchLevel.NoMatch)
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.NoMatch)
             }
         }
     }

--- a/src/commonTest/kotlin/baaahs/gl/shader/HintedShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/HintedShaderDialectSpec.kt
@@ -14,13 +14,13 @@ import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 
 @Suppress("unused")
-object HintedShaderPrototypeSpec : Spek({
-    describe<HintedShaderPrototype> {
+object HintedShaderDialectSpec : Spek({
+    describe<HintedShaderDialect> {
         val shaderText by value<String> { toBeSpecified() }
-        val prototype by value { HintedShaderPrototypeForTest() }
+        val dialect by value { HintedShaderDialectForTest() }
         val plugins by value { testPlugins() }
         val glslCode by value { GlslAnalyzer(plugins).parse(shaderText) }
-        val shaderAnalysis by value { prototype.analyze(glslCode, plugins, null) }
+        val shaderAnalysis by value { dialect.analyze(glslCode, plugins, null) }
 
         context("determining a method's output ports") {
             context("when there are none") {
@@ -86,7 +86,7 @@ object HintedShaderPrototypeSpec : Spek({
     }
 })
 
-class HintedShaderPrototypeForTest : HintedShaderPrototype("xxx") {
+class HintedShaderDialectForTest : HintedShaderDialect("xxx") {
     override val entryPointName: String = "main"
     override val title: String
         get() = TODO("not implemented")

--- a/src/commonTest/kotlin/baaahs/gl/shader/OpenShaderSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/OpenShaderSpec.kt
@@ -16,7 +16,7 @@ object OpenShaderSpec : Spek({
             "void main(float intensity) { gl_FragColor = vec4(gl_FragCoord, 0., 1.); };"
         }
         val plugins by value { testPlugins() }
-        val shaderAnalysis by value { GlslAnalyzer(plugins).validate(src) }
+        val shaderAnalysis by value { GlslAnalyzer(plugins).analyze(src) }
         val openShader by value { GlslAnalyzer(plugins).openShader(shaderAnalysis) }
         val invocationStatement by value {
             openShader.invocationGlsl(

--- a/src/commonTest/kotlin/baaahs/gl/shader/PaintShaderSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/PaintShaderSpec.kt
@@ -21,7 +21,7 @@ object PaintShaderSpec : Spek({
     describe<PaintShader> {
         val shaderText by value { toBeSpecified<String>() }
         val analyzer by value { GlslAnalyzer(testPlugins()) }
-        val shaderAnalysis by value { analyzer.validate(shaderText) }
+        val shaderAnalysis by value { analyzer.analyze(shaderText) }
         val openShader by value { analyzer.openShader(shaderText) }
         val shaderType by value { PaintShader }
 

--- a/src/commonTest/kotlin/baaahs/gl/shader/ShaderToyShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/ShaderToyShaderDialectSpec.kt
@@ -18,7 +18,7 @@ object ShaderToyShaderDialectSpec : Spek({
         val src by value { "void mainImage(out vec4 fragColor, in vec2 fragCoord) { ... };" }
         val dialect by value { ShaderToyShaderDialect }
         val plugins by value { testPlugins() }
-        val shaderAnalysis by value { GlslAnalyzer(plugins).validate(src) }
+        val shaderAnalysis by value { GlslAnalyzer(plugins).analyze(src) }
         val glslCode by value { shaderAnalysis.glslCode }
         val openShader by value { OpenShader.Base(shaderAnalysis, PaintShader) }
         val invocationStatement by value {

--- a/src/commonTest/kotlin/baaahs/gl/shader/ShaderToyShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/ShaderToyShaderDialectSpec.kt
@@ -13,10 +13,10 @@ import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 
 @Suppress("unused")
-object ShaderToyShaderPrototypeSpec : Spek({
-    describe<ShaderToyShaderPrototypeSpec> {
+object ShaderToyShaderDialectSpec : Spek({
+    describe<ShaderToyShaderDialectSpec> {
         val src by value { "void mainImage(out vec4 fragColor, in vec2 fragCoord) { ... };" }
-        val prototype by value { ShaderToyShaderPrototype }
+        val dialect by value { ShaderToyShaderDialect }
         val plugins by value { testPlugins() }
         val shaderAnalysis by value { GlslAnalyzer(plugins).validate(src) }
         val glslCode by value { shaderAnalysis.glslCode }
@@ -30,7 +30,7 @@ object ShaderToyShaderPrototypeSpec : Spek({
 
         context("shaders having a void mainImage(out vec4, in vec2) function") {
             it("is an good match") {
-                expect(prototype.matches(glslCode)).toEqual(MatchLevel.Good)
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.Good)
             }
 
             it("finds the input port") {
@@ -53,7 +53,7 @@ object ShaderToyShaderPrototypeSpec : Spek({
                 override(src) { "void mainImage(in vec2 fragCoord, out vec4 fragColor) { ... };" }
 
                 it("is an good match") {
-                    expect(prototype.matches(glslCode)).toEqual(MatchLevel.Good)
+                    expect(dialect.matches(glslCode)).toEqual(MatchLevel.Good)
                 }
 
                 it("generates an invocation statement") {
@@ -65,7 +65,7 @@ object ShaderToyShaderPrototypeSpec : Spek({
                 override(src) { "void mainImage(in vec2 fragCoord, out vec4 fragColor, in float intensity) { ... };" }
 
                 it("is an good match") {
-                    expect(prototype.matches(glslCode)).toEqual(MatchLevel.Good)
+                    expect(dialect.matches(glslCode)).toEqual(MatchLevel.Good)
                 }
 
                 it("finds the input port") {
@@ -128,7 +128,7 @@ object ShaderToyShaderPrototypeSpec : Spek({
                 override(src) { "void mainImage() { ... };" }
 
                 it("is still a match") {
-                    expect(prototype.matches(glslCode)).toEqual(MatchLevel.Good)
+                    expect(dialect.matches(glslCode)).toEqual(MatchLevel.Good)
                 }
 
                 it("fails validation") {
@@ -148,7 +148,7 @@ object ShaderToyShaderPrototypeSpec : Spek({
             override(src) { "void main(void) { ... };" }
 
             it("is not a match") {
-                expect(prototype.matches(glslCode)).toEqual(MatchLevel.NoMatch)
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.NoMatch)
             }
 
             it("fails to validate") {

--- a/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
@@ -4,6 +4,7 @@ import baaahs.FakeClock
 import baaahs.describe
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.patch.AutoWirer
+import baaahs.gl.patch.ContentType
 import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders
 import baaahs.only
@@ -24,7 +25,7 @@ object CorePluginSpec : Spek({
         val program by value {
             val autoWirer = AutoWirer(plugins)
             val linkedPatch = autoWirer.autoWire(Shaders.red).acceptSuggestedLinkOptions()
-                .confirm().openForPreview(autoWirer)!!
+                .confirm().openForPreview(autoWirer, ContentType.Color)!!
             GlslProgram(gl, linkedPatch) { _, _ -> null }
         }
         val programFeed by value { glFeed.bind(program) }

--- a/src/commonTest/kotlin/baaahs/show/live/FakeOpenShader.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/FakeOpenShader.kt
@@ -6,7 +6,7 @@ import baaahs.gl.glsl.GlslCode
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OpenShader
 import baaahs.gl.shader.OutputPort
-import baaahs.gl.shader.ShaderPrototype
+import baaahs.gl.shader.ShaderDialect
 import baaahs.show.Shader
 import baaahs.show.ShaderType
 
@@ -36,6 +36,6 @@ class FakeOpenShader(
     override val shaderType: ShaderType
         get() = TODO("not implemented")
 
-    override val shaderPrototype: ShaderPrototype
+    override val shaderDialect: ShaderDialect
         get() = TODO("not implemented")
 }

--- a/src/commonTest/kotlin/baaahs/show/live/FakeOpenShader.kt
+++ b/src/commonTest/kotlin/baaahs/show/live/FakeOpenShader.kt
@@ -3,6 +3,7 @@ package baaahs.show.live
 import baaahs.RefCounted
 import baaahs.RefCounter
 import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslError
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OpenShader
 import baaahs.gl.shader.OutputPort
@@ -38,4 +39,7 @@ class FakeOpenShader(
 
     override val shaderDialect: ShaderDialect
         get() = TODO("not implemented")
+
+    override val errors: List<GlslError>
+        get() = emptyList()
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/AppToolbar.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppToolbar.kt
@@ -2,7 +2,7 @@ package baaahs.app.ui
 
 import baaahs.Severity
 import baaahs.ShowEditorState
-import baaahs.app.ui.controls.editIconWithBadge
+import baaahs.app.ui.controls.problemBadge
 import baaahs.ui.*
 import baaahs.util.UndoStack
 import kotlinx.css.opacity
@@ -87,11 +87,12 @@ val AppToolbar = xComponent<AppToolbarProps>("AppToolbar") { props ->
                     if (webClient.showIsModified) i { +" (Unsaved)" }
                 }
 
+                show?.let { problemBadge(show, themeStyles.problemBadge) }
+
                 if (show != null && props.editMode) {
                     div(+themeStyles.editButton) {
+                        icon(Icons.Edit)
                         attrs.onClickFunction = handleShowEditButtonClick.withEvent()
-
-                        editIconWithBadge(show, props.editMode)
                     }
                 }
             }

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -108,6 +108,7 @@ class ThemeStyles(val theme: MuiTheme) : StyleSheet("app-ui-theme", isStatic = t
 
     val problemBadge by css {
         paddingLeft = 1.em
+        filter = "drop-shadow(0px 0px 2px white)"
     }
 
     val editButton by css {
@@ -123,6 +124,7 @@ class ThemeStyles(val theme: MuiTheme) : StyleSheet("app-ui-theme", isStatic = t
 
     val appToolbarProblemsIcon by css {
         transform.translateY(1.em)
+        filter = "drop-shadow(0px 0px 2px white)"
 
         ".infoSeverity" { color = Color.darkGray }
         ".warnSeverity" { color = Color.orange }

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -106,6 +106,10 @@ class ThemeStyles(val theme: MuiTheme) : StyleSheet("app-ui-theme", isStatic = t
         flexDirection = FlexDirection.row
     }
 
+    val problemBadge by css {
+        paddingLeft = 1.em
+    }
+
     val editButton by css {
         paddingLeft = 1.em
     }

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/ButtonGroup.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/ButtonGroup.kt
@@ -95,12 +95,14 @@ private val ButtonGroup = xComponent<ButtonGroupProps>("SceneList") { props ->
                             ref = sceneDragProvided.innerRef
                             copyFrom(sceneDragProvided.draggableProps)
 
+                            problemBadge(buttonControl as OpenControl)
+
                             div(+Styles.editButton) {
                                 if (editMode) {
                                     attrs.onClickFunction = { event -> handleEditButtonClick(event, index) }
                                 }
 
-                                editIconWithBadge(buttonControl as OpenControl, editMode)
+                                icon(Icons.Edit)
                             }
                             div(+Styles.dragHandle) {
                                 copyFrom(sceneDragProvided.dragHandleProps)

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/ControlWrapper.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/ControlWrapper.kt
@@ -34,11 +34,13 @@ val ControlWrapper = xComponent<ControlWrapperProps>("Control") { props ->
             copyFrom(draggableProvided.draggableProps)
         }
 
+        problemBadge(control)
+
         if (!props.disableEdit) {
             div(+Styles.editButton) {
                 attrs.onClickFunction = onEditButtonClick
 
-                editIconWithBadge(control, props.controlProps.editMode)
+                icon(Icons.Edit)
             }
         }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/EditIcon.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/EditIcon.kt
@@ -3,49 +3,29 @@ package baaahs.app.ui.controls
 import baaahs.Severity
 import baaahs.show.live.OpenControl
 import baaahs.show.live.OpenPatchHolder
-import baaahs.ui.on
-import kotlinext.js.jsObject
-import materialui.components.badge.badge
-import materialui.components.badge.enums.BadgeColor
-import materialui.components.badge.enums.BadgeStyle
-import materialui.components.badge.enums.BadgeVariant
+import baaahs.ui.and
+import baaahs.ui.unaryPlus
+import kotlinx.css.RuleSet
 import materialui.icon
 import materialui.icons.Icons
 import react.RBuilder
+import react.dom.div
 
-fun RBuilder.editIconWithBadge(
-    openControl: OpenControl,
-    editMode: Boolean
-) {
+fun RBuilder.problemBadge(openControl: OpenControl) {
     if (openControl is OpenPatchHolder) {
-        editIconWithBadge(openControl as OpenPatchHolder, editMode)
-    } else {
-        icon(Icons.Edit)
+        problemBadge(openControl as OpenPatchHolder)
     }
 }
 
-fun RBuilder.editIconWithBadge(
-    openPatchHolder: OpenPatchHolder,
-    editMode: Boolean
-) {
-    if (editMode && openPatchHolder.problems.isNotEmpty()) {
-        val isError = openPatchHolder.problems.any { it.severity >= Severity.ERROR }
-        val badgeStyle = if (isError) Styles.editButtonErrorBadge else Styles.editButtonWarningBadge
-        badge(badgeStyle on BadgeStyle.colorError) {
-            attrs.color = BadgeColor.error
-            attrs.variant = BadgeVariant.dot
-            attrs["anchorOrigin"] = jsObject<AnchorOrigin> {
-                horizontal = "right"
-                vertical = "bottom"
-            }
-            icon(Icons.Edit)
+fun RBuilder.problemBadge(openPatchHolder: OpenPatchHolder, cssClass: RuleSet = Styles.cardProblemBadge) {
+    openPatchHolder.problemLevel?.let { severity ->
+        val (severityClass, severityIcon) = when (severity) {
+            Severity.INFO -> Styles.cardProblemInfo to Icons.Info
+            Severity.WARN -> Styles.cardProblemWarning to Icons.Warning
+            Severity.ERROR -> Styles.cardProblemError to Icons.Error
         }
-    } else {
-        icon(Icons.Edit)
+        div(+cssClass and severityClass) {
+            icon(severityIcon)
+        }
     }
-}
-
-external interface AnchorOrigin {
-    var horizontal: String
-    var vertical: String
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/EditIcon.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/EditIcon.kt
@@ -18,7 +18,11 @@ fun RBuilder.problemBadge(openControl: OpenControl) {
 }
 
 fun RBuilder.problemBadge(openPatchHolder: OpenPatchHolder, cssClass: RuleSet = Styles.cardProblemBadge) {
-    openPatchHolder.problemLevel?.let { severity ->
+    problemBadge(openPatchHolder.problemLevel, cssClass)
+}
+
+fun RBuilder.problemBadge(problemLevel: Severity?, cssClass: RuleSet = Styles.cardProblemBadge) {
+    problemLevel?.let { severity ->
         val (severityClass, severityIcon) = when (severity) {
             Severity.INFO -> Styles.cardProblemInfo to Icons.Info
             Severity.WARN -> Styles.cardProblemWarning to Icons.Warning

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/Styles.kt
@@ -43,12 +43,24 @@ object Styles : StyleSheet("app-ui-controls", isStatic = true) {
         }
     }
 
-    val editButtonWarningBadge by css {
-        backgroundColor = Color.orange
+    val cardProblemBadge by css {
+        position = Position.absolute
+        right = .5.em
+        top = .5.em
+        zIndex = 1
+        opacity = .75
     }
 
-    val editButtonErrorBadge by css {
-        backgroundColor = Color.red
+    val cardProblemInfo by css {
+        color = Color.yellowGreen
+    }
+
+    val cardProblemWarning by css {
+        color = Color.orange
+    }
+
+    val cardProblemError by css {
+        color = Color.red
     }
 
     val visualizerCard by css {

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/EditableManagerUi.kt
@@ -2,6 +2,7 @@ package baaahs.app.ui.editor
 
 import baaahs.app.ui.EditorPanel
 import baaahs.app.ui.PatchHolderEditorHelpText
+import baaahs.app.ui.controls.problemBadge
 import baaahs.ui.*
 import external.ErrorBoundary
 import kotlinx.html.js.onClickFunction
@@ -97,6 +98,10 @@ val EditableManagerUi = xComponent<EditableManagerUiProps>("EditableManagerUi") 
 
                     listItemText {
                         +editorPanel.title
+                    }
+
+                    editorPanel.problemLevel?.let {
+                        problemBadge(it)
                     }
                 }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/LinkSourceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/LinkSourceEditor.kt
@@ -2,7 +2,6 @@ package baaahs.app.ui.editor
 
 import baaahs.gl.shader.InputPort
 import baaahs.show.mutable.EditingShader
-import baaahs.ui.asTextNode
 import baaahs.ui.xComponent
 import kotlinx.html.js.onChangeFunction
 import materialui.components.divider.divider
@@ -12,6 +11,7 @@ import materialui.components.listitemtext.listItemText
 import materialui.components.listsubheader.listSubheader
 import materialui.components.menuitem.menuItem
 import materialui.components.select.select
+import materialui.components.typography.typography
 import materialui.icon
 import react.RBuilder
 import react.RHandler
@@ -52,7 +52,9 @@ val LinkSourceEditor = xComponent<LinkSourceEditorProps>("LinkSourceEditor") { p
             if (selected == null) {
                 this@xComponent.logger.warn { "Huh? None of the LinkOptions are active for ${props.inputPort.id}?" }
             }
-            attrs.renderValue<LinkOption> { it.title.asTextNode() }
+            attrs.renderValue<LinkOption> {
+                typography { +it.title }
+            }
             attrs.onChangeFunction = handleChange
             attrs.disabled = props.editingShader.isBuilding()
 

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/LinksEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/LinksEditor.kt
@@ -2,18 +2,26 @@ package baaahs.app.ui.editor
 
 import baaahs.gl.shader.InputPort
 import baaahs.show.mutable.EditingShader
+import baaahs.ui.typographyBody1
+import baaahs.ui.typographyBody2
+import baaahs.ui.typographySubtitle2
 import baaahs.ui.xComponent
+import kotlinx.html.js.onClickFunction
 import materialui.components.circularprogress.circularProgress
+import materialui.components.iconbutton.iconButton
 import materialui.components.table.table
 import materialui.components.tablebody.tableBody
 import materialui.components.tablecell.tdCell
 import materialui.components.tablecell.thCell
 import materialui.components.tablehead.tableHead
 import materialui.components.tablerow.tableRow
+import materialui.components.typography.enums.TypographyColor
+import materialui.components.typography.typography
 import materialui.components.typography.typographyH6
+import materialui.icon
+import materialui.icons.Icons
 import react.*
 import react.dom.b
-import react.dom.br
 import react.dom.code
 
 val LinksEditor = xComponent<LinksEditorProps>("LinksEditor") { props ->
@@ -32,8 +40,8 @@ val LinksEditor = xComponent<LinksEditorProps>("LinksEditor") { props ->
 
         tableHead {
             tableRow {
-                thCell { +"Port" }
-                thCell { +"Source" }
+                thCell { typographySubtitle2 { +"Port" } }
+                thCell { typographySubtitle2 { +"Source" } }
             }
         }
 
@@ -41,9 +49,14 @@ val LinksEditor = xComponent<LinksEditorProps>("LinksEditor") { props ->
             shaderInputPorts.forEach { inputPort ->
                 tableRow {
                     tdCell {
-                        b { +inputPort.title }
-                        br {}
-                        code { +"(${inputPort.contentType?.title ?: inputPort.type.glslLiteral})" }
+                        typographyBody1 { b { +inputPort.title } }
+                        typographyBody2 {
+                            if (inputPort.contentType.isUnknown()) {
+                                attrs.color = TypographyColor.error
+                            }
+
+                            +"(${inputPort.contentType.title})"
+                        }
                     }
 
                     tdCell {
@@ -52,6 +65,38 @@ val LinksEditor = xComponent<LinksEditorProps>("LinksEditor") { props ->
                             attrs.editableManager = props.editableManager
                             attrs.editingShader = props.editingShader
                             attrs.inputPort = inputPort
+                        }
+                    }
+                }
+            }
+
+            val extraLinks = props.editingShader.extraLinks
+            if (extraLinks.isNotEmpty()) {
+                tableRow {
+                    thCell { typographySubtitle2 { +"Unknown Port" } }
+                    thCell { typographySubtitle2 { +"Old Source" } }
+                }
+
+                extraLinks.forEach { (portId, link) ->
+                    tableRow {
+                        tdCell {
+                            typography {
+                                attrs.color = TypographyColor.error
+
+                                code { +portId }
+                            }
+                        }
+
+                        tdCell {
+                            typography { +link.title }
+
+                            iconButton {
+                                attrs.onClickFunction = { _ ->
+                                    props.editingShader.changeInputPortLink(portId, null)
+                                    props.editableManager.onChange()
+                                }
+                                icon(Icons.Delete)
+                            }
                         }
                     }
                 }

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditor.kt
@@ -32,13 +32,12 @@ val ShaderEditor = xComponent<ShaderEditorProps>("ShaderEditor") { props ->
             }
             when (editingShader.state) {
                 EditingShader.State.Building,
-                EditingShader.State.Success -> setAnnotations(emptyList())
-
+                EditingShader.State.Success,
                 EditingShader.State.Errors -> {
                     val lineCount = editor.getSession().getLength().toInt()
                     setAnnotations(editingShader.shaderBuilder.glslErrors.map { error ->
                         jsObject {
-                            row = (error.row).boundedBy(0 until lineCount)
+                            row = (error.row).boundedBy(1 until lineCount) - 1
                             column = 0
                             text = error.message
                             type = "error"

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -29,6 +29,8 @@ import materialui.components.tab.tab
 import materialui.components.tabs.enums.TabsStyle
 import materialui.components.tabs.tabs
 import materialui.components.textfield.textField
+import materialui.components.typography.enums.TypographyColor
+import materialui.components.typography.typography
 import materialui.components.typography.typographyH6
 import materialui.icon
 import org.w3c.dom.HTMLInputElement
@@ -36,7 +38,6 @@ import org.w3c.dom.events.Event
 import react.*
 import react.dom.b
 import react.dom.br
-import react.dom.code
 import react.dom.div
 
 private enum class PageTabs {
@@ -189,22 +190,27 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
                         }
 
                         div(+shaderEditorStyles.shaderReturnType) {
-                            b { +"Return type: " }
                             val openShader = editingShader.openShader
-                            code { +(openShader?.outputPort?.contentType?.id ?: "") }
 
-                            val isFilter = openShader?.let {
-                                editingShader.mutableShaderInstance.isFilter(
-                                    it
-                                )
-                            } ?: false
-                            if (isFilter) {
-                                +" (Filter)"
-                            }
-                            br {}
                             if (openShader != null) {
-                                +"Type: ${openShader.shaderType.title} (${openShader.shaderDialect.title})"
+                                val outputPort = openShader.outputPort
+
+                                typography { b { +"Returns: " } }
+                                typography {
+                                    if (outputPort.contentType.isUnknown()) {
+                                        attrs.color = TypographyColor.error
+                                    }
+                                    +outputPort.contentType.title
+                                }
+
+                                br {}
+
+                                typography { b { +"Shader Type: " } }
+                                typography {
+                                    +"${openShader.shaderType.title} (${openShader.shaderDialect.title})"
+                                }
                             }
+
                         }
                     }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -6,7 +6,10 @@ import baaahs.app.ui.shaderPreview
 import baaahs.englishize
 import baaahs.gl.preview.PreviewShaderBuilder
 import baaahs.show.ShaderChannel
-import baaahs.show.mutable.*
+import baaahs.show.mutable.EditingShader
+import baaahs.show.mutable.MutablePatch
+import baaahs.show.mutable.MutableShaderChannel
+import baaahs.show.mutable.MutableShaderInstance
 import baaahs.ui.*
 import kotlinx.html.InputType
 import kotlinx.html.js.onChangeFunction
@@ -200,7 +203,7 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
                             }
                             br {}
                             if (openShader != null) {
-                                +"Type: ${openShader.shaderType.title} (${openShader.shaderPrototype.title})"
+                                +"Type: ${openShader.shaderType.title} (${openShader.shaderDialect.title})"
                             }
                         }
                     }

--- a/src/jsMain/kotlin/baaahs/ui/FileDialog.kt
+++ b/src/jsMain/kotlin/baaahs/ui/FileDialog.kt
@@ -183,8 +183,8 @@ private val FileDialog = xComponent<FileDialogProps>("FileDialog") { props ->
                     attrs.onClickFunction = handleCancel
                 }
                 button {
-                    +if (props.isSaveAs) "Save" else "Open"
-                    attrs.onClickFunction = handleConfirm
+                        +if (props.isSaveAs) "Save" else "Open"
+                        attrs.onClickFunction = handleConfirm
                     attrs.disabled = selectedFile == null
                 }
             }

--- a/src/jsMain/kotlin/baaahs/ui/util.kt
+++ b/src/jsMain/kotlin/baaahs/ui/util.kt
@@ -6,8 +6,15 @@ import external.copyFrom
 import kotlinx.css.CSSBuilder
 import kotlinx.css.RuleSet
 import kotlinx.css.StyledElement
+import kotlinx.html.DIV
+import materialui.components.typography.TypographyElementBuilder
+import materialui.components.typography.TypographyProps
+import materialui.components.typography.enums.TypographyStyle
+import materialui.components.typography.enums.TypographyVariant
+import materialui.components.typography.typography
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventTarget
+import react.RBuilder
 import react.RMutableRef
 import react.RProps
 import react.ReactElement
@@ -101,6 +108,30 @@ fun RDOMBuilder<*>.install(droppableProvided: DroppableProvided) {
 
 fun RDOMBuilder<*>.insertPlaceholder(droppableProvided: DroppableProvided) {
     this.childList.add(droppableProvided.placeholder)
+}
+
+inline fun RBuilder.typographySubtitle1(vararg classMap: Pair<TypographyStyle, String>, crossinline block: TypographyElementBuilder<DIV, TypographyProps>.() -> Unit)
+        = typography(*classMap, factory = { DIV(mapOf(), it) }) {
+    attrs.variant = TypographyVariant.subtitle1
+    block()
+}
+
+inline fun RBuilder.typographySubtitle2(vararg classMap: Pair<TypographyStyle, String>, crossinline block: TypographyElementBuilder<DIV, TypographyProps>.() -> Unit)
+        = typography(*classMap, factory = { DIV(mapOf(), it) }) {
+    attrs.variant = TypographyVariant.subtitle2
+    block()
+}
+
+inline fun RBuilder.typographyBody1(vararg classMap: Pair<TypographyStyle, String>, crossinline block: TypographyElementBuilder<DIV, TypographyProps>.() -> Unit)
+        = typography(*classMap, factory = { DIV(mapOf(), it) }) {
+    attrs.variant = TypographyVariant.body1
+    block()
+}
+
+inline fun RBuilder.typographyBody2(vararg classMap: Pair<TypographyStyle, String>, crossinline block: TypographyElementBuilder<DIV, TypographyProps>.() -> Unit)
+        = typography(*classMap, factory = { DIV(mapOf(), it) }) {
+    attrs.variant = TypographyVariant.body2
+    block()
 }
 
 private val logger = Logger("util.kt")

--- a/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
+++ b/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
@@ -386,7 +386,7 @@ object EditingShaderSpec : Spek({
 
                     vec2 p0_screenCoordsi_result = vec2(0.);
 
-                    #line 3
+                    #line 4
                     vec2 p0_screenCoords_main(
                         vec4 fragCoords 
                     ) {


### PR DESCRIPTION
- Improvements to error reporting.
  * Shaders whose ShaderAnalysis isn't valid can still be checked for compile errors.
  * List compile errors in shader problems.
  * Fix preview of distortion shaders.
  * Extra shader instance links can be deleted.
  * Style cleanup.
- Rename `ShaderPrototype` to `ShaderDialect`.
- Better line number calculation.