### PR TITLE
Moving head parameters use a struct in GLSL

### DIFF
--- a/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
+++ b/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
@@ -2,16 +2,13 @@ package baaahs
 
 import baaahs.dmx.Dmx
 import baaahs.fixtures.*
-import baaahs.io.Fs
 import baaahs.model.MovingHead
 import baaahs.util.Logger
-import kotlinx.serialization.json.Json
 
 class MovingHeadManager(
     private val fixtureManager: FixtureManager,
     private val dmxUniverse: Dmx.Universe,
-    movingHeads: List<MovingHead>,
-    private val fs: Fs
+    movingHeads: List<MovingHead>
 ) {
     init {
         fixtureManager.addFrameListener {
@@ -28,36 +25,16 @@ class MovingHeadManager(
 
             override fun send(fixture: Fixture, resultViews: List<ResultView>) {
                 val params = MovingHeadDevice.getResults(resultViews)[0]
-                movingHeadBuffer.pan = params.x
-                movingHeadBuffer.tilt = params.y
-                movingHeadBuffer.colorWheelPosition = params.z
-
-                movingHeadBuffer.dimmer = 1f
+                movingHeadBuffer.pan = params.pan
+                movingHeadBuffer.tilt = params.tilt
+                movingHeadBuffer.colorWheelPosition = params.colorWheel
+                movingHeadBuffer.dimmer = params.dimmer
             }
         })
     }
 
-    private val defaultPosition = MovingHead.MovingHeadPosition(127, 127)
-    private val currentPositions = mutableMapOf<MovingHead, MovingHead.MovingHeadPosition>()
-    private val listeners = mutableMapOf<MovingHead, (MovingHead.MovingHeadPosition) -> Unit>()
-
-    private val movingHeadPresets = mutableMapOf<String, MovingHead.MovingHeadPosition>()
-    private val json = Json
-
-    private val presetsFileName = fs.resolve("presets/moving-head-positions.json")
-
     suspend fun start() {
         fixtureManager.fixturesChanged(fixtures, emptyList())
-
-        val presetsJson = fs.loadFile(presetsFileName)
-        if (presetsJson != null) {
-            val map = json.decodeFromString(Topics.movingHeadPresets.serializer, presetsJson)
-            movingHeadPresets.putAll(map)
-        }
-    }
-
-    fun listen(movingHead: MovingHead, onUpdate: (MovingHead.MovingHeadPosition) -> Unit) {
-        listeners[movingHead] = onUpdate
     }
 
     companion object {

--- a/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
+++ b/src/commonMain/kotlin/baaahs/MovingHeadManager.kt
@@ -27,10 +27,10 @@ class MovingHeadManager(
                 get() = "DMX Transport"
 
             override fun send(fixture: Fixture, resultViews: List<ResultView>) {
-                val panAndTilt = MovingHeadDevice.getResults(resultViews)[0]
-                movingHeadBuffer.pan = panAndTilt.x
-                movingHeadBuffer.tilt = panAndTilt.y
-                movingHeadBuffer.colorWheelPosition = panAndTilt.z
+                val params = MovingHeadDevice.getResults(resultViews)[0]
+                movingHeadBuffer.pan = params.x
+                movingHeadBuffer.tilt = params.y
+                movingHeadBuffer.colorWheelPosition = params.z
 
                 movingHeadBuffer.dimmer = 1f
             }

--- a/src/commonMain/kotlin/baaahs/Pinky.kt
+++ b/src/commonMain/kotlin/baaahs/Pinky.kt
@@ -74,7 +74,7 @@ class Pinky(
     private val udpSocket = link.listenUdp(Ports.PINKY, this)
     private val brainManager =
         BrainManager(fixtureManager, firmwareDaddy, model, mappingResults, udpSocket, networkStats, clock)
-    private val movingHeadManager = MovingHeadManager(fixtureManager, dmxUniverse, model.movingHeads, fs)
+    private val movingHeadManager = MovingHeadManager(fixtureManager, dmxUniverse, model.movingHeads)
 
     private val serverNotices = arrayListOf<ServerNotice>()
     private val serverNoticesChannel = pubSub.publish(Topics.serverNotices, serverNotices) {

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -2,6 +2,7 @@ package baaahs.fixtures
 
 import baaahs.gl.patch.ContentType
 import baaahs.plugin.core.FixtureInfoDataSource
+import baaahs.plugin.core.MovingHeadParams
 import baaahs.show.DataSourceBuilder
 import baaahs.show.Shader
 
@@ -12,15 +13,16 @@ object MovingHeadDevice : DeviceType {
     override val dataSourceBuilders: List<DataSourceBuilder<*>>
         get() = listOf(FixtureInfoDataSource)
 
-    override val resultParams: List<ResultParam> get() = listOf(
-        ResultParam("Pan/Tilt", Vec4ResultType)
-    )
+    override val resultParams: List<ResultParam>
+        get() = listOf(
+            ResultParam("Pan/Tilt", Vec4ResultType)
+        )
     override val resultContentType: ContentType
-        get() = ContentType.PanAndTilt
+        get() = MovingHeadParams.contentType
 
     override val likelyPipelines: List<Pair<ContentType, ContentType>>
         get() = with(ContentType) {
-            listOf(XyzCoordinate to PanAndTilt)
+            listOf(XyzCoordinate to MovingHeadParams.contentType)
         }
 
     override val errorIndicatorShader: Shader

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -15,7 +15,7 @@ object MovingHeadDevice : DeviceType {
 
     override val resultParams: List<ResultParam>
         get() = listOf(
-            ResultParam("Pan/Tilt", Vec4ResultType)
+            ResultParam("Moving Head Params", MovingHeadParams.resultType)
         )
     override val resultContentType: ContentType
         get() = MovingHeadParams.contentType
@@ -40,7 +40,7 @@ object MovingHeadDevice : DeviceType {
         )
 
     fun getResults(resultViews: List<ResultView>) =
-        resultViews[0] as Vec4ResultType.Vec4ResultView
+        resultViews[0] as MovingHeadParams.ResultView
 
     override fun toString(): String = id
 }

--- a/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/MovingHeadDevice.kt
@@ -1,35 +1,16 @@
 package baaahs.fixtures
 
-import baaahs.RefCounted
-import baaahs.RefCounter
-import baaahs.ShowPlayer
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeed
-import baaahs.gl.data.Feed
-import baaahs.gl.data.ProgramFeed
-import baaahs.gl.glsl.GlslCode
-import baaahs.gl.glsl.GlslProgram
-import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
-import baaahs.gl.render.RenderTarget
-import baaahs.gl.shader.InputPort
-import baaahs.model.MovingHead
-import baaahs.plugin.CorePlugin
-import baaahs.plugin.classSerializer
-import baaahs.show.DataSource
+import baaahs.plugin.core.FixtureInfoDataSource
 import baaahs.show.DataSourceBuilder
 import baaahs.show.Shader
-import baaahs.show.UpdateMode
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 
 object MovingHeadDevice : DeviceType {
     override val id: String get() = "MovingHead"
     override val title: String get() = "Moving Head"
 
     override val dataSourceBuilders: List<DataSourceBuilder<*>>
-        get() = listOf(MovingHeadInfoDataSource)
+        get() = listOf(FixtureInfoDataSource)
 
     override val resultParams: List<ResultParam> get() = listOf(
         ResultParam("Pan/Tilt", Vec4ResultType)
@@ -60,73 +41,4 @@ object MovingHeadDevice : DeviceType {
         resultViews[0] as Vec4ResultType.Vec4ResultView
 
     override fun toString(): String = id
-}
-
-val movingHeadInfoStruct = GlslCode.GlslStruct(
-    "MovingHeadInfo",
-    mapOf(
-        "origin" to GlslType.Vec3,
-        "heading" to GlslType.Vec3
-    ),
-    fullText = """
-            struct MovingHeadInfo {
-                vec3 origin;            
-                vec3 heading; // in Euler angles
-            }
-        """.trimIndent(),
-    varName = null
-)
-
-val movingHeadInfoType = GlslType.Struct(movingHeadInfoStruct)
-val movingHeadInfoContentType = ContentType("moving-head-info", "Moving Head Info", movingHeadInfoType)
-
-@Serializable
-@SerialName("baaahs.Core.MovingHeadInfo")
-data class MovingHeadInfoDataSource(@Transient val `_`: Boolean = true) : DataSource {
-    override val pluginPackage: String get() = CorePlugin.id
-    override val title: String get() = "Moving Head Info"
-    override fun getType(): GlslType = movingHeadInfoType
-    override val contentType: ContentType
-        get() = movingHeadInfoContentType
-
-    override fun createFeed(showPlayer: ShowPlayer, id: String): Feed {
-        return MovingHeadInfoFeed(getVarName(id))
-    }
-
-    companion object : DataSourceBuilder<MovingHeadInfoDataSource> {
-        override val resourceName: String get() = "baaahs.Core.MovingHeadInfo"
-        override val contentType: ContentType get() = movingHeadInfoContentType
-        override val serializerRegistrar get() = classSerializer(serializer())
-
-        override fun build(inputPort: InputPort): MovingHeadInfoDataSource {
-            return MovingHeadInfoDataSource()
-        }
-    }
-}
-
-class MovingHeadInfoFeed(
-    private val id: String,
-    private val refCounter: RefCounter = RefCounter()
-) : Feed, RefCounted by refCounter {
-    override fun bind(gl: GlContext): EngineFeed = object : EngineFeed {
-        override fun bind(glslProgram: GlslProgram) = object : ProgramFeed {
-            override val updateMode: UpdateMode get() = UpdateMode.PER_FIXTURE
-
-            private val originUniform = glslProgram.getUniform("$id.origin")
-            private val headingUniform = glslProgram.getUniform("$id.heading")
-
-            override val isValid: Boolean get() = originUniform != null && headingUniform != null
-
-            override fun setOnProgram(renderTarget: RenderTarget) {
-                val movingHead = renderTarget.fixture.modelEntity as MovingHead
-
-                originUniform!!.set(movingHead.origin)
-                headingUniform!!.set(movingHead.heading)
-            }
-        }
-    }
-
-    override fun release() {
-        refCounter.release()
-    }
 }

--- a/src/commonMain/kotlin/baaahs/gl/GlContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/GlContext.kt
@@ -3,6 +3,7 @@ package baaahs.gl
 import baaahs.gl.glsl.CompilationException
 import baaahs.gl.glsl.CompiledShader
 import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.ResourceAllocationException
 import baaahs.glsl.Uniform
 import baaahs.util.Logger
 import com.danielgergely.kgl.*
@@ -50,7 +51,12 @@ abstract class GlContext(
 
     fun compile(vertexShader: CompiledShader, fragShader: CompiledShader): Program {
         return runInContext {
-            val program = runInContext { check { createProgram() ?: throw IllegalStateException() } }
+            val program = runInContext {
+                check {
+                    createProgram()
+                        ?: throw ResourceAllocationException("Failed to allocate a GL program.")
+                }
+            }
             check { attachShader(program, vertexShader.shaderId) }
             check { attachShader(program, fragShader.shaderId) }
             check { linkProgram(program) }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/CompiledShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/CompiledShader.kt
@@ -12,7 +12,10 @@ class CompiledShader(
     internal val source: String
 ) {
     val shaderId: Shader = gl.runInContext {
-        gl.check { createShader(type) ?: throw IllegalStateException() }
+        gl.check {
+            createShader(type)
+                ?: throw ResourceAllocationException("Failed to allocate a GL shader.")
+        }
     }
 
     init {

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslAnalyzer.kt
@@ -35,19 +35,23 @@ class GlslAnalyzer(private val plugins: Plugins) {
     }
 
     fun import(src: String): Shader {
-        val glslCode = parse(src)
-        return analyze(glslCode).shader
-    }
-
-    fun analyze(src: String): ShaderAnalysis {
-        return analyze(parse(src))
+        return analyze(src).shader
     }
 
     fun analyze(shader: Shader): ShaderAnalysis {
-        return analyze(parse(shader.src), shader)
+        return analyze(shader.src, shader)
     }
 
-    fun analyze(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
+    fun analyze(src: String, shader: Shader? = null): ShaderAnalysis {
+        val glslCode = try {
+            parse(src)
+        } catch (e: GlslException) {
+            return ErrorsShaderAnalysis(src, e, shader ?: Shader("", src))
+        }
+        return analyze(glslCode, shader)
+    }
+
+    private fun analyze(glslCode: GlslCode, shader: Shader? = null): ShaderAnalysis {
         val dialect = detectDialect(glslCode)
         return dialect.analyze(glslCode, plugins, shader)
     }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslCode.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslCode.kt
@@ -129,6 +129,8 @@ class GlslCode(
         override val lineNumber: Int? = null,
         override val comments: List<String> = emptyList()
     ) : GlslStatement {
+        val glslType: GlslType.Struct = GlslType.Struct(name, fields)
+
         override fun stripSource() = copy(fullText = "", lineNumber = null)
 
         fun getSyntheticVar(): GlslVar {

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
@@ -1,19 +1,33 @@
 package baaahs.gl.glsl
 
-sealed class GlslType constructor(val glslLiteral: String) {
+sealed class GlslType constructor(
+    val glslLiteral: String,
+    val defaultInitializer: String = "$glslLiteral(0.)"
+) {
     init {
         @Suppress("LeakingThis")
         types[glslLiteral] = this
     }
 
-    open fun defaultInitializer(): String = "$glslLiteral(0.)"
-
     private class OtherGlslType(glslLiteral: String) : GlslType(glslLiteral)
-    data class Struct(
+    class Struct(
         val name: String,
-        val fields: Map<String, GlslType>
-    ) : GlslType(name) {
-        constructor(glslStruct: GlslCode.GlslStruct) : this(glslStruct.name, glslStruct.fields)
+        val fields: Map<String, GlslType>,
+        defaultInitializer: String = initializerFor(fields)
+    ) : GlslType(name, defaultInitializer) {
+        constructor(glslStruct: GlslCode.GlslStruct)
+                : this(glslStruct.name, glslStruct.fields)
+
+        constructor(
+            name: String,
+            vararg fields: Pair<String, GlslType>
+        ) : this(name, mapOf(*fields))
+
+        constructor(
+            name: String,
+            vararg fields: Pair<String, GlslType>,
+            defaultInitializer: String
+        ) : this(name, mapOf(*fields), defaultInitializer)
 
         fun toGlsl(namespace: GlslCode.Namespace?, publicStructNames: Set<String>): String {
             val buf = StringBuilder()
@@ -28,13 +42,45 @@ sealed class GlslType constructor(val glslLiteral: String) {
 
             return buf.toString()
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Struct) return false
+            if (!super.equals(other)) return false
+
+            if (name != other.name) return false
+            if (fields != other.fields) return false
+
+            return true
+        }
+
+        override fun hashCode(): kotlin.Int {
+            var result = super.hashCode()
+            result = 31 * result + name.hashCode()
+            result = 31 * result + fields.hashCode()
+            return result
+        }
+
+
+        companion object {
+            private fun initializerFor(fields: Map<String, GlslType>): String =
+                StringBuilder().apply {
+                    append("{ ")
+                    fields.entries.forEachIndexed { index, (_, glslType) ->
+                        if (index > 0)
+                            append(", ")
+                        append(glslType.defaultInitializer)
+                    }
+                    append(" }")
+                }.toString()
+        }
     }
 
-    object Float : GlslType("float")
+    object Float : GlslType("float", "0.")
     object Vec2 : GlslType("vec2")
     object Vec3 : GlslType("vec3")
     object Vec4 : GlslType("vec4")
-    object Int : GlslType("int")
+    object Int : GlslType("int", "0")
     object Sampler2D : GlslType("sampler2D")
     object Void : GlslType("void")
 

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
@@ -14,6 +14,20 @@ sealed class GlslType constructor(val glslLiteral: String) {
         val fields: Map<String, GlslType>
     ) : GlslType(name) {
         constructor(glslStruct: GlslCode.GlslStruct) : this(glslStruct.name, glslStruct.fields)
+
+        fun toGlsl(namespace: GlslCode.Namespace?, publicStructNames: Set<String>): String {
+            val buf = StringBuilder()
+            buf.append("struct ${namespace?.qualify(name) ?: name} {\n")
+            fields.forEach { (name, type) ->
+                val typeStr = if (type is Struct) {
+                    if (publicStructNames.contains(name)) name else namespace?.qualify(name) ?: name
+                } else type.glslLiteral
+                buf.append("    $typeStr $name;\n")
+            }
+            buf.append("};\n\n")
+
+            return buf.toString()
+        }
     }
 
     object Float : GlslType("float")

--- a/src/commonMain/kotlin/baaahs/gl/glsl/ShaderAnalysis.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/ShaderAnalysis.kt
@@ -2,6 +2,7 @@ package baaahs.gl.glsl
 
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OutputPort
+import baaahs.gl.shader.dialect.GenericShaderDialect
 import baaahs.gl.shader.dialect.ShaderDialect
 import baaahs.show.Shader
 
@@ -21,4 +22,18 @@ interface ShaderAnalysis {
     val errors: List<GlslError>
 
     val shader: Shader
+}
+
+class ErrorsShaderAnalysis(
+    private val src: String,
+    private val e: GlslException,
+    override val shader: Shader
+) : ShaderAnalysis {
+    override val glslCode: GlslCode get() = GlslCode(src, emptyList())
+    override val shaderDialect: ShaderDialect get() = GenericShaderDialect
+    override val entryPoint: GlslCode.GlslFunction? get() = null
+    override val inputPorts: List<InputPort> get() = emptyList()
+    override val outputPorts: List<OutputPort> get() = emptyList()
+    override val isValid: Boolean get() = false
+    override val errors: List<GlslError> get() = e.errors
 }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/errors.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/errors.kt
@@ -39,6 +39,8 @@ class CompilationException(
     }
 }
 
+class ResourceAllocationException(message: String) : Error(message)
+
 data class GlslError(val message: String, val row: Int = NO_LINE, val fileId: Int = -1) {
     constructor(message: String) :
             this(message, NO_LINE)

--- a/src/commonMain/kotlin/baaahs/gl/patch/Component.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/Component.kt
@@ -1,9 +1,6 @@
 package baaahs.gl.patch
 
-import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslType
-import baaahs.show.live.LinkedShaderInstance
-import baaahs.util.Logger
 
 interface Component {
     val title: String
@@ -15,102 +12,4 @@ interface Component {
     fun appendInvokeAndSet(buf: StringBuilder, prefix: String)
 
     fun getExpression(): String
-}
-
-class ShaderComponent(
-    val id: String,
-    val index: Int,
-    private val shaderInstance: LinkedShaderInstance,
-    findUpstreamComponent: (ProgramNode) -> Component
-) : Component {
-    override val title: String get() = shaderInstance.shader.title
-    private val prefix = "p$index"
-    private val namespace = GlslCode.Namespace(prefix + "_" + id)
-    private val portMap: Map<String, String>
-    private val resultInReturnValue: Boolean
-    private val resultVar: String
-
-    init {
-        val tmpPortMap = hashMapOf<String, String>()
-
-        shaderInstance.incomingLinks.forEach { (toPortId, fromLink) ->
-            val inputPort = shaderInstance.shader.findInputPort(toPortId)
-
-            val upstreamComponent = findUpstreamComponent(fromLink)
-            var expression = upstreamComponent.getExpression()
-            val type = upstreamComponent.resultType
-            if (inputPort.type != type) {
-                expression = inputPort.contentType.adapt(expression, type)
-            }
-            tmpPortMap[toPortId] = expression
-        }
-
-        var usesReturnValue = false
-        val outputPort = shaderInstance.shader.outputPort
-        if (outputPort.isReturnValue()) {
-            usesReturnValue = true
-            resultVar = namespace.internalQualify("result")
-        } else {
-            resultVar = namespace.qualify(outputPort.id)
-            tmpPortMap[outputPort.id] = resultVar
-        }
-
-        portMap = tmpPortMap
-        resultInReturnValue = usesReturnValue
-    }
-
-    override val outputVar: String = resultVar
-    override val resultType: GlslType
-        get() = shaderInstance.shader.outputPort.dataType
-
-    private val resolvedPortMap get() =
-        portMap + mapOf(shaderInstance.shader.outputPort.id to outputVar)
-
-    override fun appendStructs(buf: StringBuilder) {
-        val openShader = shaderInstance.shader
-        val portGlslTypes = openShader.inputPorts.map { it.contentType.glslType } +
-                openShader.outputPort.contentType.glslType
-        val publicStructs = portGlslTypes
-            .mapNotNull { if (it is GlslType.Struct) { it.name } else null }
-            .toSet()
-        openShader.glslCode.structs.forEach { struct ->
-            if (!portGlslTypes.contains(struct.glslType)) {
-                buf.append(struct.glslType.toGlsl(namespace, publicStructs))
-            }
-        }
-    }
-
-    override fun appendDeclarations(buf: StringBuilder) {
-        val openShader = shaderInstance.shader
-
-        buf.append("// Shader: ", openShader.title, "; namespace: ", prefix, "\n")
-        buf.append("// ", openShader.title, "\n")
-
-        buf.append("\n")
-        with(openShader.outputPort) {
-            buf.append("${dataType.glslLiteral} $resultVar = ${contentType.initializer(dataType)};\n")
-        }
-
-        buf.append(openShader.toGlsl(namespace, resolvedPortMap), "\n")
-    }
-
-    override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {
-        buf.append(prefix, "// Invoke ", title, "\n")
-        val invocationGlsl = shaderInstance.shader.invocationGlsl(namespace, resultVar, resolvedPortMap)
-        buf.append(prefix, invocationGlsl, ";\n")
-        buf.append("\n")
-    }
-
-    override fun getExpression(): String {
-        val outputPort = shaderInstance.shader.outputPort
-        return if (outputPort.isReturnValue()) {
-            resultVar
-        } else {
-            namespace.qualify(outputPort.id)
-        }
-    }
-
-    companion object {
-        private val logger = Logger<Component>()
-    }
 }

--- a/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
@@ -2,6 +2,7 @@ package baaahs.gl.patch
 
 import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslType
+import baaahs.plugin.core.MovingHeadParams
 
 class ContentType(
     val id: String,
@@ -73,8 +74,6 @@ class ContentType(
         val Int = ContentType("int", "Integer", GlslType.Int)
         val Media = ContentType("media", "Media", GlslType.Sampler2D)
 
-        val PanAndTilt = ContentType("pan-tilt", "Pan & Tilt", GlslType.Vec4)
-
         val coreTypes = listOf(
             PixelCoordinatesTexture,
             PreviewResolution,
@@ -93,7 +92,7 @@ class ContentType(
             Int,
             Media,
 
-            PanAndTilt
+            MovingHeadParams.contentType
         )
     }
 }

--- a/src/commonMain/kotlin/baaahs/gl/patch/DataSourceComponent.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/DataSourceComponent.kt
@@ -1,0 +1,36 @@
+package baaahs.gl.patch
+
+import baaahs.gl.glsl.GlslType
+import baaahs.show.DataSource
+
+class DataSourceComponent(val dataSource: DataSource, val varName: String) : Component {
+    override val title: String
+        get() = dataSource.title
+    override val outputVar: String?
+        get() = null
+    override val resultType: GlslType
+        get() = dataSource.getType()
+
+    override fun appendStructs(buf: StringBuilder) {
+        val glslType = dataSource.contentType.glslType
+        if (glslType is GlslType.Struct) {
+            buf.append(glslType.toGlsl(null, emptySet()))
+        }
+    }
+
+    override fun appendDeclarations(buf: StringBuilder) {
+        if (!dataSource.isImplicit()) {
+            buf.append("// Data source: ", dataSource.title, "\n")
+            dataSource.appendDeclaration(buf, varName)
+            buf.append("\n")
+        }
+    }
+
+    override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {
+        dataSource.appendInvokeAndSet(buf, prefix, varName)
+    }
+
+    override fun getExpression(): String {
+        return dataSource.getVarName(varName)
+    }
+}

--- a/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/LinkedPatch.kt
@@ -1,13 +1,11 @@
 package baaahs.gl.patch
 
-import baaahs.gl.glsl.GlslCode
 import baaahs.show.live.LiveShaderInstance.DataSourceLink
 
 class LinkedPatch(
     val rootNode: ProgramNode,
     private val components: List<Component>,
     val dataSourceLinks: Set<DataSourceLink>,
-    private var structs: Set<GlslCode.GlslStruct>,
     val warnings: List<String>
 ) {
     fun toGlsl(): String {
@@ -23,8 +21,8 @@ class LinkedPatch(
         }
         buf.append("\n")
 
-        structs.sortedBy { it.name }.forEach { struct ->
-            buf.append(struct.fullText.trim(), "\n\n")
+        components.forEach { component ->
+            component.appendStructs(buf)
         }
 
         components.forEach { component ->

--- a/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
@@ -76,11 +76,11 @@ class ProgramLinker(
             )
             .map { componentBuilder[it.programNode] }
 
-        return LinkedPatch(rootNode, components, dataSourceLinks, structs, warnings)
+        return LinkedPatch(rootNode, components, dataSourceLinks, warnings)
     }
 
     fun visit(openShader: OpenShader) {
-        structs.addAll(openShader.glslCode.structs)
+        // No-op for now. Previously we collected structs here.
     }
 
     fun idFor(shader: Shader): String = showBuilder.idFor(shader)
@@ -107,6 +107,9 @@ data class DefaultValueNode(
 
     override fun getNodeId(programLinker: ProgramLinker): String = "n/a"
 
+    override fun appendStructs(buf: StringBuilder) {
+    }
+
     override fun appendDeclarations(buf: StringBuilder) {
     }
 
@@ -132,18 +135,15 @@ data class ConstNode(val glsl: String, override val outputPort: OutputPort) : Pr
 
     override fun getNodeId(programLinker: ProgramLinker): String = "n/a"
 
-    override fun traverse(programLinker: ProgramLinker, depth: Int) {
-    }
+    override fun traverse(programLinker: ProgramLinker, depth: Int) {}
 
     override fun buildComponent(id: String, index: Int, findUpstreamComponent: (ProgramNode) -> Component): Component {
         return this
     }
 
-    override fun appendDeclarations(buf: StringBuilder) {
-    }
-
-    override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {
-    }
+    override fun appendStructs(buf: StringBuilder) {}
+    override fun appendDeclarations(buf: StringBuilder) {}
+    override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {}
 
     override fun getExpression(): String {
         return "($glsl)"

--- a/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
@@ -117,7 +117,7 @@ data class DefaultValueNode(
     }
 
     override fun getExpression(): String {
-        return contentType.glslType.defaultInitializer()
+        return contentType.glslType.defaultInitializer
     }
 
     override fun traverse(programLinker: ProgramLinker, depth: Int) {

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
@@ -1,0 +1,104 @@
+package baaahs.gl.patch
+
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslType
+import baaahs.show.live.LinkedShaderInstance
+import baaahs.util.Logger
+
+class ShaderComponent(
+    val id: String,
+    val index: Int,
+    private val shaderInstance: LinkedShaderInstance,
+    findUpstreamComponent: (ProgramNode) -> Component
+) : Component {
+    override val title: String get() = shaderInstance.shader.title
+    private val prefix = "p$index"
+    private val namespace = GlslCode.Namespace(prefix + "_" + id)
+    private val portMap: Map<String, String>
+    private val resultInReturnValue: Boolean
+    private val resultVar: String
+
+    init {
+        val tmpPortMap = hashMapOf<String, String>()
+
+        shaderInstance.incomingLinks.forEach { (toPortId, fromLink) ->
+            val inputPort = shaderInstance.shader.findInputPort(toPortId)
+
+            val upstreamComponent = findUpstreamComponent(fromLink)
+            var expression = upstreamComponent.getExpression()
+            val type = upstreamComponent.resultType
+            if (inputPort.type != type) {
+                expression = inputPort.contentType.adapt(expression, type)
+            }
+            tmpPortMap[toPortId] = expression
+        }
+
+        var usesReturnValue = false
+        val outputPort = shaderInstance.shader.outputPort
+        if (outputPort.isReturnValue()) {
+            usesReturnValue = true
+            resultVar = namespace.internalQualify("result")
+        } else {
+            resultVar = namespace.qualify(outputPort.id)
+            tmpPortMap[outputPort.id] = resultVar
+        }
+
+        portMap = tmpPortMap
+        resultInReturnValue = usesReturnValue
+    }
+
+    override val outputVar: String = resultVar
+    override val resultType: GlslType
+        get() = shaderInstance.shader.outputPort.dataType
+
+    private val resolvedPortMap get() =
+        portMap + mapOf(shaderInstance.shader.outputPort.id to outputVar)
+
+    override fun appendStructs(buf: StringBuilder) {
+        val openShader = shaderInstance.shader
+        val portGlslTypes = openShader.inputPorts.map { it.contentType.glslType } +
+                openShader.outputPort.contentType.glslType
+        val publicStructs = portGlslTypes
+            .mapNotNull { if (it is GlslType.Struct) { it.name } else null }
+            .toSet()
+        openShader.glslCode.structs.forEach { struct ->
+            if (!portGlslTypes.contains(struct.glslType)) {
+                buf.append(struct.glslType.toGlsl(namespace, publicStructs))
+            }
+        }
+    }
+
+    override fun appendDeclarations(buf: StringBuilder) {
+        val openShader = shaderInstance.shader
+
+        buf.append("// Shader: ", openShader.title, "; namespace: ", prefix, "\n")
+        buf.append("// ", openShader.title, "\n")
+
+        buf.append("\n")
+        with(openShader.outputPort) {
+            buf.append("${dataType.glslLiteral} $resultVar = ${contentType.initializer(dataType)};\n")
+        }
+
+        buf.append(openShader.toGlsl(namespace, resolvedPortMap), "\n")
+    }
+
+    override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {
+        buf.append(prefix, "// Invoke ", title, "\n")
+        val invocationGlsl = shaderInstance.shader.invocationGlsl(namespace, resultVar, resolvedPortMap)
+        buf.append(prefix, invocationGlsl, ";\n")
+        buf.append("\n")
+    }
+
+    override fun getExpression(): String {
+        val outputPort = shaderInstance.shader.outputPort
+        return if (outputPort.isReturnValue()) {
+            resultVar
+        } else {
+            namespace.qualify(outputPort.id)
+        }
+    }
+
+    companion object {
+        private val logger = Logger<Component>()
+    }
+}

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
@@ -56,14 +56,10 @@ class ShaderComponent(
 
     override fun appendStructs(buf: StringBuilder) {
         val openShader = shaderInstance.shader
-        val portGlslTypes = openShader.inputPorts.map { it.contentType.glslType } +
-                openShader.outputPort.contentType.glslType
-        val publicStructs = portGlslTypes
-            .mapNotNull { if (it is GlslType.Struct) { it.name } else null }
-            .toSet()
+        val portStructs = openShader.portStructs
         openShader.glslCode.structs.forEach { struct ->
-            if (!portGlslTypes.contains(struct.glslType)) {
-                buf.append(struct.glslType.toGlsl(namespace, publicStructs))
+            if (!portStructs.contains(struct.glslType)) {
+                buf.append(struct.glslType.toGlsl(namespace, portStructs.map { it.name }.toSet()))
             }
         }
     }

--- a/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/UnresolvedPatch.kt
@@ -38,7 +38,7 @@ class UnresolvedPatch(private val unresolvedShaderInstances: List<UnresolvedShad
                 it.incomingLinksOptions.entries.associate { (port, fromPortOptions) ->
                     port.id to
                             (fromPortOptions.firstOrNull()?.getMutablePort()
-                                ?: MutableConstPort(port.type.defaultInitializer(), port.type))
+                                ?: MutableConstPort(port.type.defaultInitializer, port.type))
                 }.toMutableMap(),
                 MutableShaderChannel(it.shaderChannel.id),
                 it.priority

--- a/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/OpenShader.kt
@@ -6,6 +6,7 @@ import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslCode.GlslFunction
 import baaahs.gl.glsl.GlslCode.Namespace
 import baaahs.gl.glsl.GlslError
+import baaahs.gl.glsl.GlslType
 import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.shader.dialect.ShaderDialect
 import baaahs.gl.shader.type.ShaderType
@@ -35,6 +36,10 @@ interface OpenShader : RefCounted {
     fun findInputPort(portId: String): InputPort =
         findInputPortOrNull(portId)
             ?: error(unknown("input port", portId, inputPorts))
+
+    val portStructs: List<GlslType.Struct> get() =
+        (inputPorts.map { it.contentType.glslType } + outputPort.contentType.glslType)
+            .filterIsInstance<GlslType.Struct>()
 
     fun toGlsl(namespace: Namespace, portMap: Map<String, String> = emptyMap()): String
 
@@ -82,7 +87,7 @@ interface OpenShader : RefCounted {
                         (outputPort.id == id && !outputPort.isParam)
             }
 
-            val symbolsToNamespace = glslCode.symbolNames.toSet()
+            val symbolsToNamespace = glslCode.symbolNames.toSet() - portStructs.map { it.name}
             val symbolMap = uniformGlobalsMap + nonUniformGlobalsMap
             glslCode.functions.forEach { glslFunction ->
                 buf.append(glslFunction.toGlsl(namespace, symbolsToNamespace, symbolMap))

--- a/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
@@ -12,9 +12,20 @@ object MoverShader : ShaderType {
 
     override val icon: Icon = CommonIcons.None
 
+    /**language=glsl*/
     override val template: String = """
-        vec4 main() {
-            return vec4(0., .5);
+        struct MovingHeadParams {
+            float pan;
+            float tilt;
+            float colorWheel;
+            float dimmer;
+        };
+        
+        // @param params moving-head-params
+        void main(out MovingHeadParams params) {
+            params.pan = 0.;
+            params.tilt = .5;
+            params.colorWheel = 0.;
         }
     """.trimIndent()
 

--- a/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
@@ -2,9 +2,9 @@ package baaahs.gl.shader.type
 
 import baaahs.app.ui.CommonIcons
 import baaahs.gl.glsl.ShaderAnalysis
-import baaahs.gl.patch.ContentType
 import baaahs.gl.preview.PreviewShaders
 import baaahs.gl.shader.OpenShader
+import baaahs.plugin.core.MovingHeadParams
 import baaahs.ui.Icon
 
 object MoverShader : ShaderType {
@@ -19,7 +19,7 @@ object MoverShader : ShaderType {
     """.trimIndent()
 
     override fun matches(shaderAnalysis: ShaderAnalysis): ShaderType.MatchLevel {
-        return if (shaderAnalysis.outputIs(ContentType.PanAndTilt))
+        return if (shaderAnalysis.outputIs(MovingHeadParams.contentType))
             ShaderType.MatchLevel.Match
         else ShaderType.MatchLevel.NoMatch
     }

--- a/src/commonMain/kotlin/baaahs/model/Model.kt
+++ b/src/commonMain/kotlin/baaahs/model/Model.kt
@@ -47,6 +47,11 @@ abstract class Model : ModelInfo {
         val deviceType: DeviceType
     }
 
+    interface FixtureInfo {
+        val origin: Vector3F?
+        val heading: Vector3F?
+    }
+
     /** A named surface in the geometry model. */
     open class Surface(
         override val name: String,

--- a/src/commonMain/kotlin/baaahs/model/MovingHead.kt
+++ b/src/commonMain/kotlin/baaahs/model/MovingHead.kt
@@ -12,9 +12,9 @@ abstract class MovingHead(
     override val name: String,
     override val description: String,
     val baseDmxChannel: Int,
-    val origin: Vector3F,
-    val heading: Vector3F
-) : Model.Entity {
+    override val origin: Vector3F,
+    override val heading: Vector3F
+) : Model.Entity, Model.FixtureInfo {
     abstract val dmxChannelCount: Int
 
     abstract val colorModel: ColorModel

--- a/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/CorePlugin.kt
@@ -16,6 +16,7 @@ import baaahs.gl.shader.dialect.GenericShaderDialect
 import baaahs.gl.shader.dialect.ShaderToyShaderDialect
 import baaahs.gl.shader.type.*
 import baaahs.glsl.Uniform
+import baaahs.plugin.core.FixtureInfoDataSource
 import baaahs.show.*
 import baaahs.show.mutable.*
 import baaahs.util.Logger
@@ -599,7 +600,7 @@ class CorePlugin(private val pluginContext: PluginContext) : Plugin {
             ResolutionDataSource,
             PreviewResolutionDataSource,
             SliderDataSource,
-            MovingHeadInfoDataSource,
+            FixtureInfoDataSource,
             RasterCoordinateDataSource
         )
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
@@ -8,7 +8,6 @@ import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeed
 import baaahs.gl.data.Feed
 import baaahs.gl.data.ProgramFeed
-import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
@@ -25,30 +24,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 
-val fixtureInfoStruct = GlslCode.GlslStruct(
+val fixtureInfoStruct = GlslType.Struct(
     "FixtureInfo",
-    mapOf(
-        "origin" to GlslType.Vec3,
-        "heading" to GlslType.Vec3
-    ),
-    fullText = """
-            struct FixtureInfo {
-                vec3 origin;            
-                vec3 heading; // in Euler angles
-            }
-        """.trimIndent(),
-    varName = null
+    "origin" to GlslType.Vec3,
+    "heading" to GlslType.Vec3
 )
 
-val fixtureInfoType = GlslType.Struct(fixtureInfoStruct)
-val fixtureInfoContentType = ContentType("fixture-info", "Fixture Info", fixtureInfoType)
+val fixtureInfoContentType = ContentType("fixture-info", "Fixture Info", fixtureInfoStruct)
 
 @Serializable
 @SerialName("baaahs.Core.FixtureInfo")
 data class FixtureInfoDataSource(@Transient val `_`: Boolean = true) : DataSource {
     override val pluginPackage: String get() = CorePlugin.id
     override val title: String get() = "Fixture Info"
-    override fun getType(): GlslType = fixtureInfoType
+    override fun getType(): GlslType = fixtureInfoStruct
     override val contentType: ContentType
         get() = fixtureInfoContentType
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
@@ -1,0 +1,94 @@
+package baaahs.plugin.core
+
+import baaahs.RefCounted
+import baaahs.RefCounter
+import baaahs.ShowPlayer
+import baaahs.geom.Vector3F
+import baaahs.gl.GlContext
+import baaahs.gl.data.EngineFeed
+import baaahs.gl.data.Feed
+import baaahs.gl.data.ProgramFeed
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.patch.ContentType
+import baaahs.gl.render.RenderTarget
+import baaahs.gl.shader.InputPort
+import baaahs.model.Model
+import baaahs.plugin.CorePlugin
+import baaahs.plugin.classSerializer
+import baaahs.show.DataSource
+import baaahs.show.DataSourceBuilder
+import baaahs.show.UpdateMode
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+
+val fixtureInfoStruct = GlslCode.GlslStruct(
+    "FixtureInfo",
+    mapOf(
+        "origin" to GlslType.Vec3,
+        "heading" to GlslType.Vec3
+    ),
+    fullText = """
+            struct FixtureInfo {
+                vec3 origin;            
+                vec3 heading; // in Euler angles
+            }
+        """.trimIndent(),
+    varName = null
+)
+
+val fixtureInfoType = GlslType.Struct(fixtureInfoStruct)
+val fixtureInfoContentType = ContentType("fixture-info", "Fixture Info", fixtureInfoType)
+
+@Serializable
+@SerialName("baaahs.Core.FixtureInfo")
+data class FixtureInfoDataSource(@Transient val `_`: Boolean = true) : DataSource {
+    override val pluginPackage: String get() = CorePlugin.id
+    override val title: String get() = "Fixture Info"
+    override fun getType(): GlslType = fixtureInfoType
+    override val contentType: ContentType
+        get() = fixtureInfoContentType
+
+    override fun createFeed(showPlayer: ShowPlayer, id: String): Feed {
+        return FixtureInfoFeed(getVarName(id))
+    }
+
+    companion object : DataSourceBuilder<FixtureInfoDataSource> {
+        override val resourceName: String get() = "baaahs.Core.FixtureInfo"
+        override val contentType: ContentType get() = fixtureInfoContentType
+        override val serializerRegistrar get() = classSerializer(serializer())
+
+        override fun build(inputPort: InputPort): FixtureInfoDataSource {
+            return FixtureInfoDataSource()
+        }
+    }
+}
+
+class FixtureInfoFeed(
+    private val id: String,
+    private val refCounter: RefCounter = RefCounter()
+) : Feed, RefCounted by refCounter {
+    override fun bind(gl: GlContext): EngineFeed = object : EngineFeed {
+        override fun bind(glslProgram: GlslProgram) = object : ProgramFeed {
+            override val updateMode: UpdateMode get() = UpdateMode.PER_FIXTURE
+
+            private val originUniform = glslProgram.getUniform("$id.origin")
+            private val headingUniform = glslProgram.getUniform("$id.heading")
+
+            override val isValid: Boolean get() = originUniform != null && headingUniform != null
+
+            override fun setOnProgram(renderTarget: RenderTarget) {
+                val fixtureInfo = renderTarget.fixture.modelEntity as? Model.FixtureInfo
+                originUniform!!.set(fixtureInfo?.origin ?: Vector3F.origin)
+                headingUniform!!.set(fixtureInfo?.heading ?: Vector3F.origin)
+            }
+        }
+    }
+
+    override fun release() {
+        refCounter.release()
+    }
+}

--- a/src/commonMain/kotlin/baaahs/plugin/core/MovingHeadParams.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/MovingHeadParams.kt
@@ -1,0 +1,10 @@
+package baaahs.plugin.core
+
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.patch.ContentType
+
+class MovingHeadParams {
+    companion object {
+        val contentType = ContentType("moving-head-params", "Moving Head Params", GlslType.Vec4)
+    }
+}

--- a/src/commonMain/kotlin/baaahs/plugin/core/MovingHeadParams.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/MovingHeadParams.kt
@@ -1,10 +1,64 @@
 package baaahs.plugin.core
 
+import baaahs.fixtures.FloatsResultType
+import baaahs.fixtures.ResultBuffer
+import baaahs.fixtures.ResultType
+import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
+import com.danielgergely.kgl.GL_RGBA
 
-class MovingHeadParams {
+data class MovingHeadParams(
+    val pan: Float,
+    val tilt: Float,
+    val colorWheel: Float,
+    val dimmer: Float
+) {
+
     companion object {
-        val contentType = ContentType("moving-head-params", "Moving Head Params", GlslType.Vec4)
+        val struct = GlslType.Struct(
+            "MovingHeadParams",
+            "pan" to GlslType.Float,
+            "tilt" to GlslType.Float,
+            "colorWheel" to GlslType.Float,
+            "dimmer" to GlslType.Float,
+            defaultInitializer = "MovingHeadParams(0., 0., 0., 1.)"
+        )
+
+        val contentType = ContentType(
+            "moving-head-params", "Moving Head Params",
+            struct, outputRepresentation = GlslType.Vec4
+        )
+
+        val resultType: ResultType = object : FloatsResultType(4, GlContext.GL_RGBA32F, GL_RGBA) {
+            override fun createParamBuffer(gl: GlContext, index: Int): ResultBuffer {
+                return ParamBuffer(gl, index, this)
+            }
+        }
+    }
+
+    class ParamBuffer(gl: GlContext, index: Int, type: ResultType) : FloatsResultType.Buffer(gl, index, type) {
+        operator fun get(pixelIndex: Int): MovingHeadParams {
+            val offset = pixelIndex * type.stride
+
+            return MovingHeadParams(
+                pan = floatBuffer[offset],
+                tilt = floatBuffer[offset + 1],
+                colorWheel = floatBuffer[offset + 2],
+                dimmer = floatBuffer[offset + 3]
+            )
+        }
+
+        override fun getView(pixelOffset: Int, pixelCount: Int): baaahs.fixtures.ResultView {
+            return ResultView(this, pixelOffset, pixelCount)
+        }
+    }
+
+    class ResultView(
+        val buffer: ParamBuffer,
+        pixelOffset: Int,
+        pixelCount: Int
+    ) : baaahs.fixtures.ResultView(pixelOffset, pixelCount) {
+        operator fun get(pixelIndex: Int): MovingHeadParams = buffer[pixelOffset + pixelIndex]
     }
 }

--- a/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
@@ -123,6 +123,13 @@ class LiveShaderInstance(
                 override val resultType: GlslType
                     get() = dataSource.getType()
 
+                override fun appendStructs(buf: StringBuilder) {
+                    val glslType = dataSource.contentType.glslType
+                    if (glslType is GlslType.Struct) {
+                        buf.append(glslType.toGlsl(null, emptySet()))
+                    }
+                }
+
                 override fun appendDeclarations(buf: StringBuilder) {
                     if (!dataSource.isImplicit()) {
                         buf.append("// Data source: ", dataSource.title, "\n")

--- a/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/LiveShaderInstance.kt
@@ -115,37 +115,7 @@ class LiveShaderInstance(
             index: Int,
             findUpstreamComponent: (ProgramNode) -> Component
         ): Component {
-            return object : Component {
-                override val title: String
-                    get() = dataSource.title
-                override val outputVar: String?
-                    get() = null
-                override val resultType: GlslType
-                    get() = dataSource.getType()
-
-                override fun appendStructs(buf: StringBuilder) {
-                    val glslType = dataSource.contentType.glslType
-                    if (glslType is GlslType.Struct) {
-                        buf.append(glslType.toGlsl(null, emptySet()))
-                    }
-                }
-
-                override fun appendDeclarations(buf: StringBuilder) {
-                    if (!dataSource.isImplicit()) {
-                        buf.append("// Data source: ", dataSource.title, "\n")
-                        dataSource.appendDeclaration(buf, varName)
-                        buf.append("\n")
-                    }
-                }
-
-                override fun appendInvokeAndSet(buf: StringBuilder, prefix: String) {
-                    dataSource.appendInvokeAndSet(buf, prefix, varName)
-                }
-
-                override fun getExpression(): String {
-                    return dataSource.getVarName(varName)
-                }
-            }
+            return DataSourceComponent(dataSource, varName)
         }
     }
 

--- a/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
+++ b/src/commonTest/kotlin/baaahs/ShowRunnerTest.kt
@@ -57,7 +57,7 @@ class ShowRunnerTest {
         val model = TestModel
         val renderManager = RenderManager(model) { fakeGlslContext }
         fixtureManager = FixtureManager(renderManager)
-        MovingHeadManager(fixtureManager, dmxUniverse, emptyList(), FakeFs())
+        MovingHeadManager(fixtureManager, dmxUniverse, emptyList())
         stageManager = StageManager(
             testPlugins(), renderManager, server, Storage(fs, testPlugins()), fixtureManager,
             FakeClock(), sheepModel, testCoroutineContext

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -15,6 +15,7 @@ import baaahs.only
 import baaahs.toBeSpecified
 import baaahs.toEqual
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
+import ch.tutteli.atrium.api.fluent.en_GB.startsWith
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
@@ -322,6 +323,24 @@ object GlslAnalyzerSpec : Spek({
                     it("is ShaderToy") {
                         expect(dialect).toBe(ShaderToyShaderDialect)
                     }
+                }
+            }
+
+            context("analyze") {
+                override(shaderText) {
+                    """
+                        struct Whatever {
+                            float a;
+                            float b;
+                        }
+                        void main() { ... };
+                    """.trimIndent()
+                }
+
+                it("catches analyzer exceptions") {
+                    val analysis = glslAnalyzer.analyze(shaderText)
+                    expect(analysis.errors.only().message)
+                        .startsWith("huh? couldn't find a struct")
                 }
             }
 

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -42,7 +42,7 @@ object GlslAnalyzerSpec : Spek({
                     uniform vec2  resolution;
                     
                     // @@AnotherClass key=value key2=value2
-                    uniform struct MovingHeadInfo {
+                    uniform struct FixtureInfo {
                         vec3 origin;
                         vec3 heading;
                     } leftEye;
@@ -88,9 +88,9 @@ object GlslAnalyzerSpec : Spek({
                             GlslVar(
                                 "leftEye",
                                 GlslType.Struct(
-                                    "MovingHeadInfo",
+                                    "FixtureInfo",
                                     mapOf("origin" to GlslType.Vec3, "heading" to GlslType.Vec3)),
-                                "uniform struct MovingHeadInfo {\n" +
+                                "uniform struct FixtureInfo {\n" +
                                         "    vec3 origin;\n" +
                                         "    vec3 heading;\n" +
                                         "} leftEye;",
@@ -139,10 +139,10 @@ object GlslAnalyzerSpec : Spek({
                             ), GlslVar(
                                 "leftEye",
                                 GlslType.Struct(
-                                    "MovingHeadInfo",
+                                    "FixtureInfo",
                                     mapOf("origin" to GlslType.Vec3, "heading" to GlslType.Vec3)
                                 ),
-                                fullText = "uniform MovingHeadInfo leftEye;", lineNumber = 13,
+                                fullText = "uniform FixtureInfo leftEye;", lineNumber = 13,
                                 comments = listOf(" @@AnotherClass key=value key2=value2")
                             )
                         )
@@ -159,7 +159,7 @@ object GlslAnalyzerSpec : Spek({
                 it("finds the structs") {
                     expect(glslCode.structs.map { "${it.lineNumber}: ${it.fullText}" })
                         .containsExactly(
-                            "13: uniform struct MovingHeadInfo {\n    vec3 origin;\n    vec3 heading;\n} leftEye;"
+                            "13: uniform struct FixtureInfo {\n    vec3 origin;\n    vec3 heading;\n} leftEye;"
                         )
                 }
 

--- a/src/commonTest/kotlin/baaahs/gl/patch/AutoWirerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/AutoWirerSpec.kt
@@ -1,6 +1,5 @@
 package baaahs.gl.patch
 
-import baaahs.fixtures.MovingHeadInfoDataSource
 import baaahs.fixtures.PixelLocationDataSource
 import baaahs.gl.expects
 import baaahs.gl.override
@@ -12,6 +11,7 @@ import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.only
 import baaahs.plugin.CorePlugin
+import baaahs.plugin.core.FixtureInfoDataSource
 import baaahs.show.Shader
 import baaahs.show.ShaderChannel
 import baaahs.show.live.FakeOpenShader
@@ -406,15 +406,15 @@ object AutoWirerSpec : Spek({
                 override(shaderText) {
                     /**language=glsl*/
                     """
-                        struct MovingHeadInfo {
+                        struct FixtureInfo {
                             vec3 origin;
                             vec3 heading;
                         };
                         
-                        uniform MovingHeadInfo movingHeadInfo;
+                        uniform FixtureInfo fixtureInfo;
                         
                         vec4 main() {
-                            return vec4(movingHeadInfo.heading.xy, movingHeadInfo.origin.xy);
+                            return vec4(fixtureInfo.heading.xy, fixtureInfo.origin.xy);
                         }
                     """.trimIndent()
                 }
@@ -425,7 +425,7 @@ object AutoWirerSpec : Spek({
                             MutableShaderInstance(
                                 MutableShader(mainShader),
                                 hashMapOf(
-                                    "movingHeadInfo" to MovingHeadInfoDataSource().editor()
+                                    "fixtureInfo" to FixtureInfoDataSource().editor()
                                 )
                             )
                         )

--- a/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
@@ -1,6 +1,5 @@
 package baaahs.gl.patch
 
-import baaahs.fixtures.MovingHeadInfoDataSource
 import baaahs.fixtures.PixelLocationDataSource
 import baaahs.gl.kexpect
 import baaahs.gl.override
@@ -8,6 +7,7 @@ import baaahs.gl.patch.ContentType.Companion.Color
 import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.plugin.CorePlugin
+import baaahs.plugin.core.FixtureInfoDataSource
 import baaahs.show.ShaderChannel
 import baaahs.show.mutable.MutableDataSourcePort
 import baaahs.show.mutable.MutablePatch
@@ -574,16 +574,16 @@ object GlslGenerationSpec : Spek({
             override(shaderText) {
                 /**language=glsl*/
                 """
-                    struct MovingHeadInfo {
+                    struct FixtureInfo {
                         vec3 origin;            
                         vec3 heading; // in Euler angles
                     };
                     
-                    uniform MovingHeadInfo movingHeadInfo;
+                    uniform FixtureInfo fixtureInfo;
                     
                     // @return pan-tilt
                     vec4 main() {
-                        return vec4(movingHeadInfo.origin.xy, movingHeadInfo.heading.xy);
+                        return vec4(fixtureInfo.origin.xy, fixtureInfo.heading.xy);
                     }
                 """.trimIndent()
             }
@@ -591,7 +591,7 @@ object GlslGenerationSpec : Spek({
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
-                    link("movingHeadInfo", MovingHeadInfoDataSource())
+                    link("fixtureInfo", FixtureInfoDataSource())
                 }
             }
 
@@ -607,13 +607,13 @@ object GlslGenerationSpec : Spek({
 
                         layout(location = 0) out vec4 sm_result;
 
-                        struct MovingHeadInfo {
+                        struct FixtureInfo {
                             vec3 origin;
                             vec3 heading;
                         };
 
-                        // Data source: Moving Head Info
-                        uniform MovingHeadInfo in_movingHeadInfo;
+                        // Data source: Fixture Info
+                        uniform FixtureInfo in_fixtureInfo;
 
                         // Shader: Untitled Shader; namespace: p0
                         // Untitled Shader
@@ -622,7 +622,7 @@ object GlslGenerationSpec : Spek({
 
                         #line 9
                         vec4 p0_untitledShader_main() {
-                            return vec4(in_movingHeadInfo.origin.xy, in_movingHeadInfo.heading.xy);
+                            return vec4(in_fixtureInfo.origin.xy, in_fixtureInfo.heading.xy);
                         }
 
 
@@ -659,7 +659,7 @@ object GlslGenerationSpec : Spek({
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
-                    link("movingHeadInfo", MovingHeadInfoDataSource())
+                    link("fixtureInfo", FixtureInfoDataSource())
                 }
             }
 
@@ -727,7 +727,7 @@ object GlslGenerationSpec : Spek({
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
-                    link("movingHeadInfo", MovingHeadInfoDataSource())
+                    link("fixtureInfo", FixtureInfoDataSource())
                 }
             }
 

--- a/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
@@ -582,9 +582,19 @@ object GlslGenerationSpec : Spek({
                     
                     uniform FixtureInfo fixtureInfo;
                     
-                    // @return moving-head-params
-                    vec4 main() {
-                        return vec4(fixtureInfo.origin.xy, fixtureInfo.heading.xy);
+                    struct MovingHeadParams {
+                        float pan;
+                        float tilt;
+                        float colorWheel;
+                        float dimmer;
+                    };
+ 
+                    // @param params moving-head-params
+                    void main(out MovingHeadParams params) {
+                        params.pan = fixtureInfo.origin.x;
+                        params.tilt = fixtureInfo.origin.y,
+                        params.colorWheel = fixtureInfo.heading.x,
+                        params.dimmer = fixtureInfo.heading.y;
                     }
                 """.trimIndent()
             }
@@ -608,6 +618,13 @@ object GlslGenerationSpec : Spek({
 
                         layout(location = 0) out vec4 sm_result;
 
+                        struct MovingHeadParams {
+                            float pan;
+                            float tilt;
+                            float colorWheel;
+                            float dimmer;
+                        };
+
                         struct FixtureInfo {
                             vec3 origin;
                             vec3 heading;
@@ -619,20 +636,28 @@ object GlslGenerationSpec : Spek({
                         // Shader: Untitled Shader; namespace: p0
                         // Untitled Shader
 
-                        vec4 p0_untitledShaderi_result = vec4(0.);
+                        MovingHeadParams p0_untitledShader_params = MovingHeadParams(0., 0., 0., 1.);
 
-                        #line 9
-                        vec4 p0_untitledShader_main() {
-                            return vec4(in_fixtureInfo.origin.xy, in_fixtureInfo.heading.xy);
+                        #line 16
+                        void p0_untitledShader_main(out MovingHeadParams params) {
+                            params.pan = in_fixtureInfo.origin.x;
+                            params.tilt = in_fixtureInfo.origin.y,
+                            params.colorWheel = in_fixtureInfo.heading.x,
+                            params.dimmer = in_fixtureInfo.heading.y;
                         }
 
 
                         #line 10001
                         void main() {
                           // Invoke Untitled Shader
-                          p0_untitledShaderi_result = p0_untitledShader_main();
+                          p0_untitledShader_main(p0_untitledShader_params);
 
-                          sm_result = p0_untitledShaderi_result;
+                          sm_result = vec4(
+                            p0_untitledShader_params.pan,
+                            p0_untitledShader_params.tilt,
+                            p0_untitledShader_params.colorWheel,
+                            p0_untitledShader_params.dimmer
+                          );
                         }
                     """.trimIndent()
                 )
@@ -648,11 +673,18 @@ object GlslGenerationSpec : Spek({
                         float second;
                     };
                     AnotherStruct a;
-                    
+
+                    struct MovingHeadParams {
+                        float pan;
+                        float tilt;
+                        float colorWheel;
+                        float dimmer;
+                    };
+
                     // @return moving-head-params
-                    vec4 main() {
+                    MovingHeadParams main() {
                         AnotherStruct b;
-                        return vec4(a.first, a.second, 0., 0.);
+                        return MovingHeadParams(a.first, a.second, 0., 0.);
                     }
                 """.trimIndent()
             }
@@ -676,6 +708,13 @@ object GlslGenerationSpec : Spek({
 
                         layout(location = 0) out vec4 sm_result;
 
+                        struct MovingHeadParams {
+                            float pan;
+                            float tilt;
+                            float colorWheel;
+                            float dimmer;
+                        };
+                        
                         struct p0_untitledShader_AnotherStruct {
                             float first;
                             float second;
@@ -684,15 +723,15 @@ object GlslGenerationSpec : Spek({
                         // Shader: Untitled Shader; namespace: p0
                         // Untitled Shader
 
-                        vec4 p0_untitledShaderi_result = vec4(0.);
+                        MovingHeadParams p0_untitledShaderi_result = MovingHeadParams(0., 0., 0., 1.);
 
                         #line 5
                         p0_untitledShader_AnotherStruct p0_untitledShader_a;
 
-                        #line 8
-                        vec4 p0_untitledShader_main() {
+                        #line 15
+                        MovingHeadParams p0_untitledShader_main() {
                             p0_untitledShader_AnotherStruct b;
-                            return vec4(p0_untitledShader_a.first, p0_untitledShader_a.second, 0., 0.);
+                            return MovingHeadParams(p0_untitledShader_a.first, p0_untitledShader_a.second, 0., 0.);
                         }
 
 
@@ -701,7 +740,12 @@ object GlslGenerationSpec : Spek({
                           // Invoke Untitled Shader
                           p0_untitledShaderi_result = p0_untitledShader_main();
 
-                          sm_result = p0_untitledShaderi_result;
+                          sm_result = vec4(
+                            p0_untitledShaderi_result.pan,
+                            p0_untitledShaderi_result.tilt,
+                            p0_untitledShaderi_result.colorWheel,
+                            p0_untitledShaderi_result.dimmer
+                          );
                         }
                     """.trimIndent()
                 )
@@ -717,14 +761,14 @@ object GlslGenerationSpec : Spek({
                         float second;
                     } a;
                     
-                    // @return moving-head-params
+                    // @return color
                     vec4 main() {
                         AnotherStruct b;
                         return vec4(a.first, a.second, 0., 0.);
                     }
                 """.trimIndent()
             }
-            override(resultContentType) { MovingHeadParams.contentType }
+            override(resultContentType) { Color }
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
@@ -752,7 +796,7 @@ object GlslGenerationSpec : Spek({
                         // Shader: Untitled Shader; namespace: p0
                         // Untitled Shader
 
-                        vec4 p0_untitledShaderi_result = vec4(0.);
+                        vec4 p0_untitledShaderi_result = vec4(0., 0., 0., 1.);
 
                         #line 1
                         p0_untitledShader_AnotherStruct p0_untitledShader_a;

--- a/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
@@ -8,6 +8,7 @@ import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders.cylindricalProjection
 import baaahs.plugin.CorePlugin
 import baaahs.plugin.core.FixtureInfoDataSource
+import baaahs.plugin.core.MovingHeadParams
 import baaahs.show.ShaderChannel
 import baaahs.show.mutable.MutableDataSourcePort
 import baaahs.show.mutable.MutablePatch
@@ -581,13 +582,13 @@ object GlslGenerationSpec : Spek({
                     
                     uniform FixtureInfo fixtureInfo;
                     
-                    // @return pan-tilt
+                    // @return moving-head-params
                     vec4 main() {
                         return vec4(fixtureInfo.origin.xy, fixtureInfo.heading.xy);
                     }
                 """.trimIndent()
             }
-            override(resultContentType) { ContentType.PanAndTilt }
+            override(resultContentType) { MovingHeadParams.contentType }
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
@@ -648,14 +649,14 @@ object GlslGenerationSpec : Spek({
                     };
                     AnotherStruct a;
                     
-                    // @return pan-tilt
+                    // @return moving-head-params
                     vec4 main() {
                         AnotherStruct b;
                         return vec4(a.first, a.second, 0., 0.);
                     }
                 """.trimIndent()
             }
-            override(resultContentType) { ContentType.PanAndTilt }
+            override(resultContentType) { MovingHeadParams.contentType }
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {
@@ -716,14 +717,14 @@ object GlslGenerationSpec : Spek({
                         float second;
                     } a;
                     
-                    // @return pan-tilt
+                    // @return moving-head-params
                     vec4 main() {
                         AnotherStruct b;
                         return vec4(a.first, a.second, 0., 0.);
                     }
                 """.trimIndent()
             }
-            override(resultContentType) { ContentType.PanAndTilt }
+            override(resultContentType) { MovingHeadParams.contentType }
 
             beforeEachTest {
                 mutablePatch.addShaderInstance(mainShader) {

--- a/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/GlslGenerationSpec.kt
@@ -570,7 +570,7 @@ object GlslGenerationSpec : Spek({
             }
         }
 
-        context("with a shader using a struct input") {
+        context("with a shader using a struct uniform") {
             override(shaderText) {
                 /**language=glsl*/
                 """
@@ -608,8 +608,8 @@ object GlslGenerationSpec : Spek({
                         layout(location = 0) out vec4 sm_result;
 
                         struct MovingHeadInfo {
-                            vec3 origin;            
-                            vec3 heading; // in Euler angles
+                            vec3 origin;
+                            vec3 heading;
                         };
 
                         // Data source: Moving Head Info
@@ -623,6 +623,143 @@ object GlslGenerationSpec : Spek({
                         #line 9
                         vec4 p0_untitledShader_main() {
                             return vec4(in_movingHeadInfo.origin.xy, in_movingHeadInfo.heading.xy);
+                        }
+
+
+                        #line 10001
+                        void main() {
+                          // Invoke Untitled Shader
+                          p0_untitledShaderi_result = p0_untitledShader_main();
+
+                          sm_result = p0_untitledShaderi_result;
+                        }
+                    """.trimIndent()
+                )
+            }
+        }
+
+        context("with a shader using a struct internally") {
+            override(shaderText) {
+                /**language=glsl*/
+                """
+                    struct AnotherStruct {
+                        float first;
+                        float second;
+                    };
+                    AnotherStruct a;
+                    
+                    // @return pan-tilt
+                    vec4 main() {
+                        AnotherStruct b;
+                        return vec4(a.first, a.second, 0., 0.);
+                    }
+                """.trimIndent()
+            }
+            override(resultContentType) { ContentType.PanAndTilt }
+
+            beforeEachTest {
+                mutablePatch.addShaderInstance(mainShader) {
+                    link("movingHeadInfo", MovingHeadInfoDataSource())
+                }
+            }
+
+            it("generates GLSL") {
+                kexpect(glsl).toBe(
+                    /**language=glsl*/
+                    """
+                        #ifdef GL_ES
+                        precision mediump float;
+                        #endif
+
+                        // SparkleMotion-generated GLSL
+
+                        layout(location = 0) out vec4 sm_result;
+
+                        struct p0_untitledShader_AnotherStruct {
+                            float first;
+                            float second;
+                        };
+
+                        // Shader: Untitled Shader; namespace: p0
+                        // Untitled Shader
+
+                        vec4 p0_untitledShaderi_result = vec4(0.);
+
+                        #line 5
+                        p0_untitledShader_AnotherStruct p0_untitledShader_a;
+
+                        #line 8
+                        vec4 p0_untitledShader_main() {
+                            p0_untitledShader_AnotherStruct b;
+                            return vec4(p0_untitledShader_a.first, p0_untitledShader_a.second, 0., 0.);
+                        }
+
+
+                        #line 10001
+                        void main() {
+                          // Invoke Untitled Shader
+                          p0_untitledShaderi_result = p0_untitledShader_main();
+
+                          sm_result = p0_untitledShaderi_result;
+                        }
+                    """.trimIndent()
+                )
+            }
+        }
+
+        context("with a shader using a struct internally, declaring a global") {
+            override(shaderText) {
+                /**language=glsl*/
+                """
+                    struct AnotherStruct {
+                        float first;            
+                        float second;
+                    } a;
+                    
+                    // @return pan-tilt
+                    vec4 main() {
+                        AnotherStruct b;
+                        return vec4(a.first, a.second, 0., 0.);
+                    }
+                """.trimIndent()
+            }
+            override(resultContentType) { ContentType.PanAndTilt }
+
+            beforeEachTest {
+                mutablePatch.addShaderInstance(mainShader) {
+                    link("movingHeadInfo", MovingHeadInfoDataSource())
+                }
+            }
+
+            it("generates GLSL") {
+                kexpect(glsl).toBe(
+                    /**language=glsl*/
+                    """
+                        #ifdef GL_ES
+                        precision mediump float;
+                        #endif
+
+                        // SparkleMotion-generated GLSL
+
+                        layout(location = 0) out vec4 sm_result;
+
+                        struct p0_untitledShader_AnotherStruct {
+                            float first;
+                            float second;
+                        };
+
+                        // Shader: Untitled Shader; namespace: p0
+                        // Untitled Shader
+
+                        vec4 p0_untitledShaderi_result = vec4(0.);
+
+                        #line 1
+                        p0_untitledShader_AnotherStruct p0_untitledShader_a;
+
+                        #line 7
+                        vec4 p0_untitledShader_main() {
+                            p0_untitledShader_AnotherStruct b;
+                            return vec4(p0_untitledShader_a.first, p0_untitledShader_a.second, 0., 0.);
                         }
 
 

--- a/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/patch/PatchResolverSpec.kt
@@ -280,7 +280,7 @@ object PatchResolverSpec : Spek({
                         // Shader: Wobbly Time Filter; namespace: p1
                         // Wobbly Time Filter
 
-                        float p1_wobblyTimeFilteri_result = float(0.);
+                        float p1_wobblyTimeFilteri_result = 0.;
 
                         #line 3
                         float p1_wobblyTimeFilter_main() { return in_time + sin(in_time); }
@@ -433,7 +433,7 @@ object PatchResolverSpec : Spek({
                         // Shader: Wobbly Time Filter; namespace: p1
                         // Wobbly Time Filter
 
-                        float p1_wobblyTimeFilteri_result = float(0.);
+                        float p1_wobblyTimeFilteri_result = 0.;
 
                         #line 3
                         float p1_wobblyTimeFilter_main() { return in_time + sin(in_time); }

--- a/src/commonTest/kotlin/baaahs/gl/render/PerFixtureDataSourceForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerFixtureDataSourceForTest.kt
@@ -17,8 +17,7 @@ class PerFixtureDataSourceForTest(val updateMode: UpdateMode) : DataSource {
     override val pluginPackage: String get() = error("not implemented")
     override val title: String get() = "Per Fixture Data Source For Test"
     override fun getType(): GlslType = GlslType.Float
-    override val contentType: ContentType
-        get() = error("not implemented")
+    override val contentType: ContentType get() = ContentType.Unknown
 
     val feeds = mutableListOf<TestFeed>()
     val engineFeeds = mutableListOf<TestEngineFeed>()

--- a/src/commonTest/kotlin/baaahs/gl/render/PerPixelDataSourceForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerPixelDataSourceForTest.kt
@@ -17,8 +17,7 @@ class PerPixelDataSourceForTest(val updateMode: UpdateMode) : DataSource {
     override val pluginPackage: String get() = error("not implemented")
     override val title: String get() = "Per Pixel Data Source For Test"
     override fun getType(): GlslType = GlslType.Float
-    override val contentType: ContentType
-        get() = error("not implemented")
+    override val contentType: ContentType get() = ContentType.Unknown
 
     val feeds = mutableListOf<TestFeed>()
     val engineFeeds = mutableListOf<TestEngineFeed>()

--- a/src/commonTest/kotlin/baaahs/plugin/core/FixtureInfoDataSourceSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/core/FixtureInfoDataSourceSpec.kt
@@ -1,4 +1,4 @@
-package baaahs.fixtures
+package baaahs.plugin.core
 
 import baaahs.TestMovingHead
 import baaahs.TestRenderContext
@@ -10,27 +10,27 @@ import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 
 @Suppress("unused")
-object MovingHeadInfoDataSourceSpec : Spek({
-    describe<MovingHeadInfoDataSource> {
+object FixtureInfoDataSourceSpec : Spek({
+    describe<FixtureInfoDataSource> {
         val movingHead by value { TestMovingHead() }
 
         val shaderText by value {
             """
-                struct MovingHeadInfo {
+                struct FixtureInfo {
                     vec3 origin;
                     vec3 heading;
                 };
-                uniform MovingHeadInfo movingHeadInfo;
+                uniform FixtureInfo fixtureInfo;
         
                 void main(void) {
-                    gl_FragColor = vec4(movingHeadInfo.origin.xy, movingHeadInfo.heading.zw);
+                    gl_FragColor = vec4(fixtureInfo.origin.xy, fixtureInfo.heading.zw);
                 }
             """.trimIndent()
         }
 
         val testRenderContext by value { TestRenderContext(movingHead) }
         val program by value { testRenderContext.createProgram(shaderText, mapOf(
-            "movingHeadInfo" to MovingHeadInfoDataSource().link("movingHeadInfo")
+            "fixtureInfo" to FixtureInfoDataSource().link("fixtureInfo")
         )) }
 
         beforeEachTest {
@@ -42,10 +42,10 @@ object MovingHeadInfoDataSourceSpec : Spek({
         it("should set uniforms for origin and heading") {
             val glProgram = testRenderContext.gl.findProgram(program.id)
 
-            val originUniform = glProgram.getUniform<List<Float>>("in_movingHeadInfo.origin")
+            val originUniform = glProgram.getUniform<List<Float>>("in_fixtureInfo.origin")
             expect(originUniform.asVector3F()).toEqual(movingHead.origin)
 
-            val headingUniform = glProgram.getUniform<List<Float>>("in_movingHeadInfo.heading")
+            val headingUniform = glProgram.getUniform<List<Float>>("in_fixtureInfo.heading")
             expect(headingUniform.asVector3F()).toEqual(movingHead.heading)
         }
     }


### PR DESCRIPTION
e.g.:

```glsl
struct MovingHeadParams {
    float pan;
    float tilt;
    float colorWheel;
    float dimmer; 
};

// @param params moving-head-params
void main(out MovingHeadParams params) {
    params.pan = 0.;
    params.tilt = .5;
    params.colorWheel = 0.;
}
```

* Fixed support for shader-private structs.