### PR TITLE
Prettier port extraction refactor in shader editor

### DIFF
--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -45,14 +45,8 @@ import react.*
 import react.dom.code
 import react.dom.div
 import react.dom.p
-import styled.injectGlobal
 
 val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
-    onChange("global styles") {
-        injectGlobal(Styles.global.toString())
-        injectGlobal(baaahs.app.ui.controls.Styles.global.toString())
-    }
-
     val webClient = props.webClient
     observe(webClient)
 
@@ -95,8 +89,11 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
         }
     }
 
-    val themeStyles = myAppContext.allStyles.appUi
-    onChange("theme global styles", themeStyles) { injectGlobal(themeStyles.global.toString()) }
+    val allStyles = myAppContext.allStyles
+    onChange("global styles", allStyles) {
+        allStyles.injectGlobals()
+    }
+    val themeStyles = allStyles.appUi
 
     var appDrawerOpen by state { false }
     var layoutEditorDialogOpen by state { false }

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -11,10 +11,18 @@ import materialui.styles.palette.dark
 import materialui.styles.transitions.create
 import materialui.styles.transitions.sharp
 import styled.StyleSheet
+import styled.injectGlobal
 
 class AllStyles(val theme: MuiTheme) {
     val appUi by lazy { ThemeStyles(theme) }
     val shaderEditor by lazy { ShaderEditorStyles(theme) }
+    val appUiEditor by lazy { baaahs.ui.editor.Styles(theme) }
+
+    fun injectGlobals() {
+        injectGlobal(Styles.global.toString())
+        injectGlobal(appUi.global.toString())
+        injectGlobal(baaahs.app.ui.controls.Styles.global.toString())
+    }
 }
 
 private fun linearRepeating(

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/TextEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/TextEditor.kt
@@ -36,6 +36,7 @@ val TextEditor = xComponent<TextEditorProps>("TextEditor", isPure = true) { prop
     onMount {
         aceEditor.current?.let { props.onAceEditor(it) }
     }
+    aceEditor.current?.let { props.onAceEditor(it) }
 
     useResizeListener(rootEl) {
         aceEditor.current?.editor?.resize()

--- a/src/jsMain/kotlin/baaahs/ui/PromptDialog.kt
+++ b/src/jsMain/kotlin/baaahs/ui/PromptDialog.kt
@@ -3,6 +3,7 @@ package baaahs.ui
 import kotlinx.html.InputType
 import kotlinx.html.js.onChangeFunction
 import kotlinx.html.js.onClickFunction
+import kotlinx.html.js.onKeyUpFunction
 import materialui.components.button.button
 import materialui.components.button.enums.ButtonColor
 import materialui.components.dialog.dialog
@@ -44,6 +45,11 @@ val PromptDialog = xComponent<PromptDialogProps>("PromptDialog") { props ->
         event.stopPropagation()
     }
 
+    val handleKeyUp = handler("keyUp", prompt) { event: Event ->
+        if (event.asDynamic().key == "Enter" && isInvalidMessage == null) {
+            handleSubmitClick(event)
+        }
+    }
 
     dialog {
         attrs.open = true
@@ -64,6 +70,7 @@ val PromptDialog = xComponent<PromptDialogProps>("PromptDialog") { props ->
                     attrs.error = true
                     attrs.helperText = it.asTextNode()
                 }
+                attrs.onKeyUpFunction = handleKeyUp
                 attrs.onChangeFunction = handleChange
             }
         }

--- a/src/jsMain/kotlin/baaahs/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/ui/Styles.kt
@@ -73,26 +73,12 @@ object Styles : StyleSheet("ui", isStatic = true) {
         marginTop = .5.em
     }
 
-    val shaderEditorActions by css {
-        display = Display.flex
-        flexDirection = FlexDirection.column
-        flex()
-        minWidth = 10.em
-    }
-
     val textEditor by css {
         width = 100.pct
         height = 100.pct
         display = Display.flex
         flexDirection = FlexDirection.row
         marginTop = .5.em
-    }
-
-    val glslNumber by css {
-        display = Display.block
-        backgroundColor = Color("#0D0")
-        position = Position.absolute
-        zIndex = 10
     }
 
     val fileDialogFileList by css {

--- a/src/jsMain/kotlin/baaahs/ui/editor/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/ui/editor/Styles.kt
@@ -1,0 +1,37 @@
+package baaahs.ui.editor
+
+import kotlinx.css.*
+import kotlinx.css.properties.border
+import kotlinx.css.properties.scale
+import kotlinx.css.properties.transform
+import materialui.styles.muitheme.MuiTheme
+import materialui.styles.muitheme.shadows
+import materialui.styles.palette.light
+import materialui.styles.palette.main
+import materialui.styles.palette.paper
+import styled.StyleSheet
+
+class Styles(theme: MuiTheme) : StyleSheet("ui-editor", isStatic = true) {
+    val editorActionMenuAffordance by css {
+        minWidth = 10.em
+        border(2.px, BorderStyle.solid, theme.palette.primary.light)
+        borderRadius = 5.px
+        position = Position.fixed
+        marginTop = 5.px
+        transform { scale(.5) }
+        padding(2.px)
+        display = Display.flex
+        minWidth = 0.px
+        backgroundColor = theme.palette.background.paper
+        boxShadow = theme.shadows[3]
+    }
+
+    val refactorMarker by css {
+        display = Display.block
+        position = Position.absolute
+        border(2.px, BorderStyle.solid, theme.palette.primary.main)
+        marginLeft = (-1).px
+        marginRight = (-1).px
+        zIndex = 10
+    }
+}

--- a/src/jsMain/kotlin/materialui/icons/Icons.kt
+++ b/src/jsMain/kotlin/materialui/icons/Icons.kt
@@ -39,6 +39,8 @@ external object Icons {
     val InsertDriveFile: Icon
     val Map: Icon
     val Menu: Icon
+    val MoreHoriz: Icon
+    val MoreVert: Icon
     val NotInterested: Icon
     val NotificationImportant: Icon
     val OpenInBrowser: Icon


### PR DESCRIPTION
Shader editor now shows a refactoring affordance with popup menu for the Extract Port refactor.

![image](https://user-images.githubusercontent.com/40298/103963366-e8f92980-510d-11eb-82f5-4fe92cd609be.png)
