### PR TITLE
Validate panel grid arrangement in layout editor

### DIFF
--- a/src/commonMain/kotlin/baaahs/show/LayoutValidator.kt
+++ b/src/commonMain/kotlin/baaahs/show/LayoutValidator.kt
@@ -1,0 +1,5 @@
+package baaahs.show
+
+class LayoutValidator {
+    fun findInvalidRegions(tab: Tab): Set<String> = TODO("not implemented")
+}

--- a/src/commonTest/kotlin/baaahs/show/LayoutValidatorSpec.kt
+++ b/src/commonTest/kotlin/baaahs/show/LayoutValidatorSpec.kt
@@ -1,0 +1,63 @@
+package baaahs.show
+
+import baaahs.describe
+import baaahs.gl.override
+import baaahs.toBeSpecified
+import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
+import ch.tutteli.atrium.api.fluent.en_GB.isEmpty
+import ch.tutteli.atrium.api.verbs.expect
+import org.spekframework.spek2.Spek
+
+object LayoutValidatorSpec : Spek({
+    describe<LayoutValidator> {
+        val layoutValidator by value { LayoutValidator() }
+        val tab by value<Tab> { toBeSpecified() }
+        val invalidRegions by value { layoutValidator.findInvalidRegions(tab) }
+
+        context("when all regions are single cells") {
+            override(tab) { tab(3, 3, "ABC DEF GHI") }
+            it("should return no invalid regions") {
+                expect(invalidRegions).isEmpty()
+            }
+        }
+
+        context("when all regions are rectangular") {
+            override(tab) { tab(3, 3, "AAB AAC DDC") }
+            it("should return no invalid regions") {
+                expect(invalidRegions).isEmpty()
+            }
+        }
+
+        context("when a region isn't rectangular") {
+            override(tab) { tab(3, 3, "AAB AEC DDC") }
+            it("should return the non-rectangular region") {
+                expect(invalidRegions).containsExactly("A")
+            }
+        }
+
+        context("when multiple regions aren't rectangular") {
+            override(tab) { tab(3, 3, "AAB ADC DDC") }
+            it("should return the non-rectangular region") {
+                expect(invalidRegions).containsExactly("A", "D")
+            }
+        }
+
+        context("when a region is non-contiguous") {
+            override(tab) { tab(3, 3, "AAB AAC DDA") }
+            it("should return the non-contiguous region") {
+                expect(invalidRegions).containsExactly("A")
+            }
+        }
+    }
+})
+
+fun tab(columns: Int, rows: Int, areas: String): Tab {
+    val areaNames = areas.filter { it != ' ' }.map { it.toString() }
+    if (areaNames.size != columns * rows) error("should be ${columns * rows} areas")
+    return Tab(
+        "Main",
+        Array(columns) { "1fr" }.toList(),
+        Array(rows) { "1fr" }.toList(),
+        areaNames.toList()
+    )
+}


### PR DESCRIPTION
Multi-cell panels in the grid must follow CSS Grid rules: they must be rectangular and contiguous.

If the arrangement is invalid, show that there's an error, maybe indicate which panels are invalid, and refuse to apply the change.