### PR TITLE
Add support for Interactive Shader Format (ISF)

### DIFF
--- a/src/commonMain/kotlin/baaahs/app/ui/editor/LinkOption.kt
+++ b/src/commonMain/kotlin/baaahs/app/ui/editor/LinkOption.kt
@@ -8,6 +8,7 @@ interface LinkOption {
     val title: String
     val icon: Icon
     val groupName: String?
+    val isAdvanced: Boolean get() = false
 
     fun getMutablePort(): MutablePort?
     fun matches(otherPort: MutablePort?): Boolean = otherPort == getMutablePort()
@@ -24,6 +25,9 @@ class PortLinkOption(
     val isDefaultBinding: Boolean = false,
     val createsFilter: Boolean = false
 ): LinkOption {
+    override val isAdvanced: Boolean
+        get() = !isExactContentType
+
     override val title get() = mutablePort.title
     override val icon get() = mutablePort.icon
     override val groupName get() = mutablePort.groupName

--- a/src/commonMain/kotlin/baaahs/control/ColorPickerControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/ColorPickerControl.kt
@@ -85,6 +85,10 @@ class OpenColorPickerControl(
 
     override fun applyState(state: Map<String, JsonElement>) = colorPicker.applyState(state)
 
+    override fun resetToDefault() {
+        colorPicker.color = colorPicker.initialValue
+    }
+
     override fun toNewMutable(mutableShow: MutableShow): MutableControl {
         return MutableColorPickerControl(
             colorPicker.title, colorPicker.initialValue, controlledDataSource

--- a/src/commonMain/kotlin/baaahs/control/SliderControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/SliderControl.kt
@@ -102,6 +102,10 @@ class OpenSliderControl(
 
     override fun applyState(state: Map<String, JsonElement>) = slider.applyState(state)
 
+    override fun resetToDefault() {
+        slider.position = slider.initialValue
+    }
+
     override fun toNewMutable(mutableShow: MutableShow): MutableControl {
         return MutableSliderControl(
             slider.title, slider.initialValue, slider.minValue, slider.maxValue, slider.stepValue, controlledDataSource

--- a/src/commonMain/kotlin/baaahs/gadgets/Slider.kt
+++ b/src/commonMain/kotlin/baaahs/gadgets/Slider.kt
@@ -30,8 +30,9 @@ data class Slider(
     var position: Float by updatable("position", initialValue, Float.serializer())
 
     override fun adjustALittleBit() {
+        val factor = .125f
         val spread = maxValue - minValue
-        val amount = Random.nextFloat() * spread * .25f - spread * .125f
+        val amount = (Random.nextFloat() - .5f) * spread * factor
         position = constrain(position + amount, minValue, maxValue)
     }
 }

--- a/src/commonMain/kotlin/baaahs/gadgets/Switch.kt
+++ b/src/commonMain/kotlin/baaahs/gadgets/Switch.kt
@@ -14,12 +14,10 @@ data class Switch(
     /** The label for this switch. */
     override val title: String,
 
-    /** The initial value for this color picker. */
+    /** The initial value for this switch. */
     val initiallyEnabled: Boolean = false
 ) : Gadget() {
 
-    /** The selected color. */
-    @JsName("color")
     var enabled: Boolean by updatable("enabled", initiallyEnabled, Boolean.serializer())
 
     override fun adjustALittleBit() {

--- a/src/commonMain/kotlin/baaahs/gl/GlContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/GlContext.kt
@@ -73,7 +73,7 @@ abstract class GlContext(
 
     fun useProgram(glslProgram: GlslProgram) {
         if (activeProgram !== glslProgram) {
-            check { useProgram(glslProgram.id) }
+            glslProgram.use()
             activeProgram = glslProgram
         }
     }

--- a/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/glsl/GlslType.kt
@@ -81,6 +81,7 @@ sealed class GlslType constructor(
         }
     }
 
+    object Bool : GlslType("bool", GlslExpr("false"))
     object Float : GlslType("float", GlslExpr("0."))
     object Vec2 : GlslType("vec2")
     object Vec3 : GlslType("vec3")

--- a/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
@@ -100,6 +100,14 @@ class ContentType(
             if (type == GlslType.Vec4) GlslExpr("vec4(0., 0., 0., 1.)") else type.defaultInitializer
         }
         val Time = ContentType("time", "Time", GlslType.Float)
+        val TimeDelta = ContentType("time-delta", "Time Delta", GlslType.Float,
+            description = "Elapsed seconds since the last frame was rendered; 0 for the first frame.")
+        val Date = ContentType("date", "Date", GlslType.Vec4,
+            description = "The first element of the vector is the year, the second element is the month, the third element is the day, and the fourth element is the time (in seconds) within the day.")
+        val PassIndex = ContentType("pass-index", "Pass Index", GlslType.Int,
+            description = "For multipass renders, this would indicate which pass we're on. For now, always 0.")
+        val FrameIndex = ContentType("frame-index", "Frame Index", GlslType.Int,
+            description = "Starting from 0.")
 
         val Boolean = ContentType("boolean", "Boolean", GlslType.Bool)
         val Float = ContentType("float", "Float", GlslType.Float)
@@ -120,6 +128,10 @@ class ContentType(
             XyzCoordinate,
             Color,
             Time,
+            TimeDelta,
+            Date,
+            PassIndex,
+            FrameIndex,
 
             Boolean,
             Float,

--- a/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
@@ -14,6 +14,7 @@ class ContentType(
     private val typeAdaptations: Map<GlslType, (GlslExpr) -> GlslExpr> = emptyMap(),
     /** If [glslType] is a [GlslType.Struct], we currently need to provide a hint for converting it to a vector. */
     val outputRepresentation: GlslType = glslType,
+    val description: String? = null,
     private val defaultInitializer: ((GlslType) -> GlslExpr)? = null
 ) {
     fun initializer(dataType: GlslType): GlslExpr =
@@ -88,7 +89,8 @@ class ContentType(
 
         val UvCoordinate = ContentType(
             "uv-coordinate", "U/V Coordinate", GlslType.Vec2,
-            typeAdaptations = mapOf(GlslType.Vec4 to { GlslExpr("${it.s}.xy") })
+            typeAdaptations = mapOf(GlslType.Vec4 to { GlslExpr("${it.s}.xy") }),
+            description = "U/V coordinate of the pixel being rendered, with [0, 0] being bottom-left and [1, 1] being top-right."
         )
         val XyCoordinate = ContentType("xy-coordinate", "X/Y Coordinate", GlslType.Vec2)
         val ModelInfo = ContentType("model-info", "Model Info", MoreTypes.ModelInfo.glslType)
@@ -98,6 +100,8 @@ class ContentType(
             if (type == GlslType.Vec4) GlslExpr("vec4(0., 0., 0., 1.)") else type.defaultInitializer
         }
         val Time = ContentType("time", "Time", GlslType.Float)
+
+        val Boolean = ContentType("boolean", "Boolean", GlslType.Bool)
         val Float = ContentType("float", "Float", GlslType.Float)
         val Int = ContentType("int", "Integer", GlslType.Int)
         val Media = ContentType("media", "Media", GlslType.Sampler2D)
@@ -116,6 +120,8 @@ class ContentType(
             XyzCoordinate,
             Color,
             Time,
+
+            Boolean,
             Float,
             Int,
             Media,

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderInstanceOptions.kt
@@ -104,18 +104,19 @@ class ShaderInstanceOptions(
 
             contentTypes.forEach { contentType ->
                 val defaultPort = defaultPorts[contentType]
+                val isExactContentType = contentType == exactContentType || exactContentType.isUnknown()
                 options.add(
                     if (defaultPort != null) {
                         PortLinkOption(
                             defaultPort,
-                            isExactContentType = contentType == exactContentType,
+                            isExactContentType = isExactContentType,
                             isLocalShaderOut = true,
                             isDefaultBinding = true
                         )
                     } else {
                         PortLinkOption(
                             MutableShaderChannel(shaderChannel.id),
-                            isExactContentType = contentType == exactContentType,
+                            isExactContentType = isExactContentType,
                             isDefaultBinding = true,
                         )
                     }
@@ -127,7 +128,7 @@ class ShaderInstanceOptions(
                             // TODO: this is dumb and broken.
                             mutableShaderChannel,
                             isShaderChannel = true,
-                            isExactContentType = contentType == exactContentType
+                            isExactContentType = isExactContentType
                         )
                     )
                 }
@@ -138,7 +139,7 @@ class ShaderInstanceOptions(
                             shaderChannel.toMutable(),
                             createsFilter = true,
                             isShaderChannel = true,
-                            isExactContentType = contentType == exactContentType
+                            isExactContentType = isExactContentType
                         )
                     )
                 }

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -1,6 +1,8 @@
 package baaahs.gl.preview
 
 import baaahs.BaseShowPlayer
+import baaahs.control.OpenButtonControl
+import baaahs.control.OpenColorPickerControl
 import baaahs.control.OpenSliderControl
 import baaahs.fixtures.*
 import baaahs.getValue
@@ -150,8 +152,16 @@ class PreviewShaderBuilder(
                 dataSource.buildControl()?.let {
                     // TODO: De-gnarl this mess.
                     val openControl = it.previewOpen()
-                    if (openControl is OpenSliderControl) {
-                        showPlayer.registerGadget(dataSource.suggestId(), openControl.slider, dataSource)
+                    val gadget = when (openControl) {
+                        is OpenButtonControl -> openControl.switch
+                        is OpenColorPickerControl -> openControl.colorPicker
+                        is OpenSliderControl -> openControl.slider
+                        else -> null
+                    }
+                    if (gadget == null) {
+                        logger.warn { "No gadget for $openControl" }
+                    } else {
+                        showPlayer.registerGadget(dataSource.suggestId(), gadget, dataSource)
                     }
                     mutableGadgets.add(ShaderBuilder.GadgetPreview(id, openControl, dataSource))
                 }

--- a/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
+++ b/src/commonMain/kotlin/baaahs/gl/preview/PreviewShaderBuilder.kt
@@ -169,6 +169,8 @@ class PreviewShaderBuilder(
                 dataSource.createFeed(showPlayer, id)
                     .also { feeds.add(it) }
             }
+
+            mutableGadgets.sortBy { it.id }
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderEngine.kt
@@ -5,6 +5,7 @@ import baaahs.gl.data.EngineFeed
 import baaahs.gl.data.Feed
 import baaahs.gl.glsl.FeedResolver
 import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.GlslProgramImpl
 import baaahs.gl.patch.LinkedPatch
 import baaahs.show.DataSource
 import baaahs.timeSync
@@ -22,7 +23,7 @@ abstract class RenderEngine(val gl: GlContext) {
     }
 
     open fun compile(linkedPatch: LinkedPatch, feedResolver: FeedResolver): GlslProgram {
-        return GlslProgram(gl, linkedPatch) { id: String, dataSource: DataSource ->
+        return GlslProgramImpl(gl, linkedPatch) { id: String, dataSource: DataSource ->
             val feed = feedResolver.openFeed(id, dataSource)
             feed?.let { cachedEngineFeed(it)}
         }

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/BaseShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/BaseShaderDialect.kt
@@ -1,0 +1,138 @@
+package baaahs.gl.shader.dialect
+
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslError
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.glsl.ShaderAnalysis
+import baaahs.gl.shader.InputPort
+import baaahs.gl.shader.OutputPort
+import baaahs.plugin.Plugins
+import baaahs.show.Shader
+
+abstract class BaseShaderDialect(id: String) : ShaderDialect(id) {
+    open val implicitInputPorts: List<InputPort> = emptyList()
+    open val wellKnownInputPorts: List<InputPort> = emptyList()
+    open val defaultInputPortsByType: Map<GlslType, InputPort> = emptyMap()
+    abstract val entryPointName: String
+
+    override fun matches(glslCode: GlslCode): MatchLevel {
+        return glslCode.findFunctionOrNull(entryPointName)
+            ?.let { MatchLevel.Good }
+            ?: MatchLevel.NoMatch
+    }
+
+    open fun additionalOutputPorts(glslCode: GlslCode, plugins: Plugins): List<OutputPort> = emptyList()
+
+    open fun adjustInputPorts(inputPorts: List<InputPort>): List<InputPort> = inputPorts
+    open fun adjustOutputPorts(outputPorts: List<OutputPort>): List<OutputPort> = outputPorts
+
+    private val wellKnownInputPortsById by lazy { wellKnownInputPorts.associateBy { it.id } }
+
+    override fun analyze(glslCode: GlslCode, plugins: Plugins, shader: Shader?): ShaderAnalysis {
+        val proFormaInputPorts: List<InputPort> =
+            implicitInputPorts.mapNotNull { glslCode.ifRefersTo(it)?.copy(isImplicit = true) }
+
+        val entryPoint = findEntryPointOrNull(glslCode)
+
+        val entryPointParams =
+            entryPoint?.params?.filter { it.isIn } ?: emptyList()
+
+        val inputPorts = adjustInputPorts(
+            proFormaInputPorts +
+                    (glslCode.globalInputVars + entryPointParams).map {
+                        it.resolveInputPort(entryPoint, plugins)
+                    } +
+                    glslCode.functions.filter { it.isAbstract }.map {
+                        toInputPort(it, plugins)
+                    } +
+                    findMagicInputPorts(glslCode)
+        )
+
+        val entryPointReturn: OutputPort? =
+            findEntryPointOutputPort(entryPoint, plugins)
+
+        val outputPorts = adjustOutputPorts(
+            listOfNotNull(entryPointReturn) +
+                    (entryPoint?.getParamOutputPorts(plugins) ?: emptyList()) +
+                    additionalOutputPorts(glslCode, plugins)
+        )
+
+        return object : ShaderAnalysis {
+            override val glslCode = glslCode
+            override val shaderDialect = this@BaseShaderDialect
+            override val entryPoint = entryPoint
+            override val inputPorts = inputPorts
+            override val outputPorts = outputPorts
+
+            override val isValid: Boolean =
+                entryPoint != null &&
+                        outputPorts.size == 1
+
+            override val errors: List<GlslError> = arrayListOf<GlslError>().apply {
+                operator fun GlslError.unaryPlus() = this@apply.add(this)
+
+                if (entryPoint == null)
+                    +GlslError("No entry point \"$entryPointName\" among ${glslCode.functionNames.sorted()}")
+
+                if (outputPorts.isEmpty())
+                    +GlslError("No output port found.")
+
+                if (outputPorts.size > 1)
+                    +GlslError("Too many output ports found: " +
+                            "${outputPorts.map { it.argSiteName }.sorted()}.", entryPoint?.lineNumber
+                    )
+
+                inputPorts.forEach { inputPort ->
+                    if (inputPort.contentType.isUnknown())
+                        +GlslError(
+                            "Input port \"${inputPort.id}\" " +
+                                    "content type is \"${inputPort.contentType.id}\"", inputPort.glslArgSite?.lineNumber
+                        )
+                }
+
+                outputPorts.forEach { outputPort ->
+                    if (outputPort.contentType.isUnknown())
+                        +GlslError(
+                            "Output port \"${outputPort.argSiteName}\" " +
+                                    "content type is \"${outputPort.contentType.id}\"",
+                            outputPort.lineNumber ?: entryPoint?.lineNumber
+                        )
+                }
+            }
+
+            override val shader: Shader = shader
+                ?: Shader(
+                    findTitle(glslCode) ?: "Untitled Shader",
+                    glslCode.src
+                )
+
+        }
+    }
+
+    abstract fun findEntryPointOutputPort(entryPoint: GlslCode.GlslFunction?, plugins: Plugins): OutputPort?
+
+    abstract fun toInputPort(it: GlslCode.GlslFunction, plugins: Plugins): InputPort
+
+    private fun GlslCode.GlslArgSite.resolveInputPort(entryPoint: GlslCode.GlslFunction?, plugins: Plugins) =
+        (wellKnownInputPortsById[name]?.copy(type = type, glslArgSite = this)
+            ?: defaultInputPortsByType[type]
+                ?.copy(id = name, varName = name, glslArgSite = this)
+            ?: toInputPort(plugins, entryPoint))
+
+    private fun GlslCode.ifRefersTo(inputPort: InputPort) =
+        if (refersToGlobal(inputPort.id)) inputPort else null
+
+    open fun findTitle(glslCode: GlslCode): String? {
+        return Regex("^// (.*)").find(glslCode.src)?.groupValues?.get(1)
+    }
+
+    fun findEntryPoint(glslCode: GlslCode): GlslCode.GlslFunction {
+        return glslCode.findFunction(entryPointName)
+    }
+
+    fun findEntryPointOrNull(glslCode: GlslCode): GlslCode.GlslFunction? {
+        return glslCode.findFunctionOrNull(entryPointName)
+    }
+
+    open fun findMagicInputPorts(glslCode: GlslCode): List<InputPort> = emptyList()
+}

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/HintedShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/HintedShaderDialect.kt
@@ -8,6 +8,21 @@ import baaahs.gl.shader.OutputPort
 import baaahs.plugin.Plugins
 
 abstract class HintedShaderDialect(id: String) : BaseShaderDialect(id) {
+    override fun findDeclaredInputPorts(
+        glslCode: GlslCode,
+        plugins: Plugins
+    ): List<InputPort> {
+        val entryPoint = findEntryPointOrNull(glslCode)
+        val entryPointParams =
+            entryPoint?.params?.filter { it.isIn } ?: emptyList()
+
+        return (glslCode.globalInputVars + entryPointParams).map {
+            it.resolveInputPort(entryPoint, plugins)
+        } + glslCode.functions.filter { it.isAbstract }.map {
+            toInputPort(it, plugins)
+        }
+    }
+
     override fun toInputPort(it: GlslCode.GlslFunction, plugins: Plugins) =
         it.toInputPort(plugins, null)
 

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/HintedShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/HintedShaderDialect.kt
@@ -1,137 +1,24 @@
 package baaahs.gl.shader.dialect
 
-import baaahs.getValue
 import baaahs.gl.glsl.GlslCode
-import baaahs.gl.glsl.GlslError
 import baaahs.gl.glsl.GlslType
-import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OutputPort
 import baaahs.plugin.Plugins
-import baaahs.show.Shader
 
-abstract class HintedShaderDialect(id: String) : ShaderDialect(id) {
-    open val implicitInputPorts: List<InputPort> = emptyList()
-    open val wellKnownInputPorts: List<InputPort> = emptyList()
-    open val defaultInputPortsByType: Map<GlslType, InputPort> = emptyMap()
-    abstract val entryPointName: String
+abstract class HintedShaderDialect(id: String) : BaseShaderDialect(id) {
+    override fun toInputPort(it: GlslCode.GlslFunction, plugins: Plugins) =
+        it.toInputPort(plugins, null)
 
-    override fun matches(glslCode: GlslCode): MatchLevel {
-        return glslCode.findFunctionOrNull(entryPointName)
-            ?.let { MatchLevel.Good }
-            ?: MatchLevel.NoMatch
+    override fun findEntryPointOutputPort(
+        entryPoint: GlslCode.GlslFunction?,
+        plugins: Plugins
+    ) = if (entryPoint == null || entryPoint.returnType == GlslType.Void) null else {
+        val contentType = entryPoint.hint?.contentType("return", plugins)
+            ?: ContentType.unknown(entryPoint.returnType)
+        OutputPort(contentType, dataType = entryPoint.returnType)
     }
-
-    open fun additionalOutputPorts(glslCode: GlslCode, plugins: Plugins): List<OutputPort> = emptyList()
-
-    open fun adjustInputPorts(inputPorts: List<InputPort>): List<InputPort> = inputPorts
-    open fun adjustOutputPorts(outputPorts: List<OutputPort>): List<OutputPort> = outputPorts
-
-    private val wellKnownInputPortsById by lazy { wellKnownInputPorts.associateBy { it.id } }
-
-    override fun analyze(glslCode: GlslCode, plugins: Plugins, shader: Shader?): ShaderAnalysis {
-        val proFormaInputPorts: List<InputPort> =
-            implicitInputPorts.mapNotNull { glslCode.ifRefersTo(it)?.copy(isImplicit = true) }
-
-        val entryPoint = findEntryPointOrNull(glslCode)
-
-        val entryPointParams =
-            entryPoint?.params?.filter { it.isIn } ?: emptyList()
-
-        val inputPorts = adjustInputPorts(
-            proFormaInputPorts +
-                    (glslCode.globalInputVars + entryPointParams).map {
-                        it.resolveInputPort(entryPoint, plugins)
-                    } +
-                    glslCode.functions.filter { it.isAbstract }.map {
-                        it.toInputPort(plugins, null)
-                    } +
-                    findMagicInputPorts(glslCode)
-        )
-
-        val entryPointReturn: OutputPort? =
-            if (entryPoint == null || entryPoint.returnType == GlslType.Void) null else {
-                val contentType = entryPoint.hint?.contentType("return", plugins)
-                    ?: ContentType.unknown(entryPoint.returnType)
-                OutputPort(contentType, dataType = entryPoint.returnType)
-            }
-
-        val outputPorts = adjustOutputPorts(
-            listOfNotNull(entryPointReturn) +
-                    (entryPoint?.getParamOutputPorts(plugins) ?: emptyList()) +
-                    additionalOutputPorts(glslCode, plugins)
-        )
-
-        return object : ShaderAnalysis {
-            override val glslCode = glslCode
-            override val shaderDialect = this@HintedShaderDialect
-            override val entryPoint = entryPoint
-            override val inputPorts = inputPorts
-            override val outputPorts = outputPorts
-
-            override val isValid: Boolean =
-                entryPoint != null &&
-                        outputPorts.size == 1
-
-            override val errors: List<GlslError> = arrayListOf<GlslError>().apply {
-                operator fun GlslError.unaryPlus() = this@apply.add(this)
-
-                if (entryPoint == null)
-                    +GlslError("No entry point \"$entryPointName\" among ${glslCode.functionNames.sorted()}")
-
-                if (outputPorts.isEmpty())
-                    +GlslError("No output port found.")
-
-                if (outputPorts.size > 1)
-                    +GlslError("Too many output ports found: " +
-                            "${outputPorts.map { it.argSiteName }.sorted()}.", entryPoint?.lineNumber)
-
-                inputPorts.forEach { inputPort ->
-                    if (inputPort.contentType.isUnknown())
-                        +GlslError("Input port \"${inputPort.id}\" " +
-                                "content type is \"${inputPort.contentType.id}\"", inputPort.glslArgSite?.lineNumber)
-                }
-
-                outputPorts.forEach { outputPort ->
-                    if (outputPort.contentType.isUnknown())
-                        +GlslError("Output port \"${outputPort.argSiteName}\" " +
-                                "content type is \"${outputPort.contentType.id}\"",
-                            outputPort.lineNumber ?: entryPoint?.lineNumber)
-                }
-            }
-
-            override val shader: Shader = shader
-                ?: Shader(
-                    findTitle(glslCode) ?: "Untitled Shader",
-                    glslCode.src
-                )
-
-        }
-    }
-
-    private fun GlslCode.GlslArgSite.resolveInputPort(entryPoint: GlslCode.GlslFunction?, plugins: Plugins) =
-        (wellKnownInputPortsById[name]?.copy(type = type, glslArgSite = this)
-            ?: defaultInputPortsByType[type]
-                ?.copy(id = name, varName = name, glslArgSite = this)
-            ?: toInputPort(plugins, entryPoint))
-
-    private fun GlslCode.ifRefersTo(inputPort: InputPort) =
-        if (refersToGlobal(inputPort.id)) inputPort else null
-
-    open fun findTitle(glslCode: GlslCode): String? {
-        return Regex("^// (.*)").find(glslCode.src)?.groupValues?.get(1)
-    }
-
-    fun findEntryPoint(glslCode: GlslCode): GlslCode.GlslFunction {
-        return glslCode.findFunction(entryPointName)
-    }
-
-    fun findEntryPointOrNull(glslCode: GlslCode): GlslCode.GlslFunction? {
-        return glslCode.findFunctionOrNull(entryPointName)
-    }
-
-    open fun findMagicInputPorts(glslCode: GlslCode): List<InputPort> = emptyList()
 }
 
 fun GlslCode.GlslFunction.findContentType(param: GlslCode.GlslParam, plugins: Plugins): ContentType? =
@@ -152,3 +39,40 @@ fun GlslCode.GlslFunction.getParamOutputPorts(plugins: Plugins) =
             val contentType = findContentType(param, plugins) ?: ContentType.unknown(param.type)
             OutputPort(contentType, dataType = param.type, id = param.name, isParam = true)
         }
+
+fun GlslCode.GlslArgSite.toInputPort(plugins: Plugins, parent: GlslCode.GlslFunction?): InputPort {
+    val contentTypeFromPlugin = try {
+        hint?.pluginRef
+            ?.let { plugins.findDataSourceBuilder(it).contentType }
+    } catch (e: Exception) {
+        null
+    }
+
+    return InputPort(
+        name,
+        contentType = contentTypeFromPlugin
+            ?: findContentType(plugins, parent)
+            ?: plugins.resolveContentType(type),
+        type = type,
+        title = title,
+        pluginRef = hint?.pluginRef,
+        pluginConfig = hint?.config,
+        glslArgSite = this,
+        injectedData = findInjectedData(plugins)
+    )
+}
+
+fun GlslCode.GlslArgSite.findContentType(plugins: Plugins, parent: GlslCode.GlslFunction?): ContentType? {
+    return when (this) {
+        is GlslCode.GlslFunction ->
+            hint?.contentType("return", plugins)
+                ?: hint?.contentType("type", plugins)
+
+        is GlslCode.GlslParam ->
+            hint?.contentType("type", plugins)
+                ?: parent?.findContentType(this, plugins)
+
+        else ->
+            hint?.contentType("type", plugins)
+    }
+}

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/IsfShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/IsfShaderDialect.kt
@@ -1,0 +1,262 @@
+package baaahs.gl.shader.dialect
+
+import baaahs.englishize
+import baaahs.gl.glsl.AnalysisException
+import baaahs.gl.glsl.GlslCode
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.patch.ContentType
+import baaahs.gl.shader.InputPort
+import baaahs.gl.shader.OutputPort
+import baaahs.listOf
+import baaahs.plugin.PluginRef
+import baaahs.plugin.Plugins
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+object IsfShaderDialect : BaseShaderDialect("baaahs.Core:ISF") {
+    private val json = Json {
+        classDiscriminator = "TYPE"
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    override val title: String = "ISF"
+    override val entryPointName: String = "main"
+
+    override val implicitInputPorts = listOf(
+        InputPort("gl_FragCoord", ContentType.UvCoordinate, GlslType.Vec4, "Coordinates"),
+//        InputPort("isf_FragNormCoord", ContentType.UvCoordinate, GlslType.Vec2, "Coordinates"),
+    )
+
+    // See https://docs.isf.video/ref_variables.html#automatically-declared-variables
+    override val wellKnownInputPorts = listOf(
+        InputPort("PASSINDEX", ContentType.PassIndex, title = ContentType.PassIndex.title),
+        InputPort("RENDERSIZE", ContentType.Resolution, title = ContentType.Resolution.title),
+        InputPort("isf_FragNormCoord", ContentType.UvCoordinate, GlslType.Vec2, title = ContentType.UvCoordinate.title, isImplicit = true),
+        InputPort("TIME", ContentType.Time, title = ContentType.Time.title),
+        InputPort("TIMEDELTA", ContentType.TimeDelta, title = ContentType.TimeDelta.title),
+        InputPort("DATE", ContentType.Date, title = ContentType.Date.title),
+        InputPort("FRAMEINDEX", ContentType.FrameIndex, title = ContentType.FrameIndex.title),
+    )
+
+    override fun matches(glslCode: GlslCode): MatchLevel {
+        return if (glslCode.src.startsWith("/*{") &&
+            run {
+                val entryPoint = glslCode.findFunctionOrNull("main")
+                entryPoint?.returnType == GlslType.Void && entryPoint.params.isEmpty()
+            }
+        ) MatchLevel.Excellent else MatchLevel.NoMatch
+    }
+
+    override fun findDeclaredInputPorts(
+        glslCode: GlslCode,
+        plugins: Plugins
+    ): List<InputPort> {
+        val isfShader = findIsfShaderDeclaration(glslCode)
+            ?: return emptyList()
+
+        return isfShader.INPUTS.map { input ->
+            when (input) {
+                is IsfEventInput -> null
+                is IsfBoolInput -> createSwitch(input)
+                is IsfLongInput -> null
+                is IsfFloatInput -> createSlider(input)
+                is IsfPoint2DInput -> null
+                is IsfColorInput -> createColor(input)
+                is IsfImageInput -> createImage(input)
+                is IsfAudioInput -> null
+                is IsfAudioFftInput -> null
+                else -> throw AnalysisException("unknown ISF input type \"${input.TYPE}\"")
+            } ?: throw AnalysisException("unsupported ISF input type \"${input.TYPE}\"")
+        }
+    }
+
+    private fun createSwitch(input: IsfBoolInput): InputPort {
+        return InputPort(
+            input.NAME, ContentType.Boolean, title = input.LABEL ?: input.NAME.englishize(),
+            pluginRef = PluginRef("baaahs.Core", "Switch"),
+            pluginConfig = buildJsonObject {
+                input.DEFAULT?.let<String, Unit> { put("default", JsonPrimitive(it.toFloat() != 0f)) }
+            }
+        )
+    }
+
+    private fun createSlider(input: IsfFloatInput): InputPort {
+        return InputPort(
+            input.NAME, ContentType.Float, title = input.LABEL ?: input.NAME.englishize(),
+            pluginRef = PluginRef("baaahs.Core", "Slider"),
+            pluginConfig = buildJsonObject {
+                input.MIN?.let { put("min", JsonPrimitive(it.toFloat())) }
+                input.MAX?.let { put("max", JsonPrimitive(it.toFloat())) }
+                input.DEFAULT?.let<String, Unit> { put("default", JsonPrimitive(it.toFloat())) }
+            }
+        )
+    }
+
+    private fun createColor(input: IsfColorInput): InputPort {
+        return InputPort(
+            input.NAME, ContentType.Color, title = input.LABEL ?: input.NAME.englishize(),
+            pluginRef = PluginRef("baaahs.Core", "ColorPicker"),
+            pluginConfig = buildJsonObject {
+            }
+        )
+    }
+
+    private fun createImage(input: IsfImageInput): InputPort {
+        // TODO: image, not color?
+        return InputPort(
+            input.NAME, ContentType.Color, title = input.LABEL ?: input.NAME.englishize(),
+            pluginRef = PluginRef("baaahs.Core", "ColorPicker"),
+            pluginConfig = buildJsonObject {
+            }
+        )
+    }
+
+    private fun findIsfShaderDeclaration(glslCode: GlslCode): IsfShader? {
+        val match = Regex("^/\\*(\\{[\\s\\S]*})\\*/").find(glslCode.src)
+            ?: return null
+
+        val (jsonDecl) = match.destructured
+        try {
+            return json.decodeFromString(IsfShader.serializer(), jsonDecl)
+        } catch (e: SerializationException) {
+            throw AnalysisException(e.message ?: "Invalid JSON", 1)
+        }
+    }
+
+    override fun additionalOutputPorts(glslCode: GlslCode, plugins: Plugins): List<OutputPort> {
+        return if (glslCode.refersToGlobal("gl_FragColor")) {
+            OutputPort(ContentType.Color, id = "gl_FragColor", dataType = GlslType.Vec4, description = "Output Color")
+                .listOf()
+        } else emptyList()
+    }
+
+    private val defaultContentTypes = mapOf<GlslType, ContentType>(
+        GlslType.Vec4 to ContentType.Color
+    )
+
+    override fun adjustInputPorts(inputPorts: List<InputPort>): List<InputPort> {
+        return super.adjustInputPorts(inputPorts).map { it.copy(isImplicit = true) }
+    }
+
+    override fun adjustOutputPorts(outputPorts: List<OutputPort>): List<OutputPort> {
+        return outputPorts.map {
+            if (it.contentType == ContentType.Unknown) {
+                it.copy(contentType = defaultContentTypes[it.dataType] ?: ContentType.Unknown)
+            } else it
+        }
+    }
+
+    override fun findEntryPointOutputPort(entryPoint: GlslCode.GlslFunction?, plugins: Plugins): OutputPort? = null
+
+    override fun toInputPort(it: GlslCode.GlslFunction, plugins: Plugins): InputPort {
+        TODO("not implemented")
+    }
+}
+
+@Serializable
+private data class IsfShader(
+    val DESCRIPTION: String? = null,
+    val CREDIT: String? = null,
+    val ISFVSN: String? = null,
+    val VSN: String? = null,
+    val CATEGORIES: List<String> = emptyList(),
+    val INPUTS: List<IsfInput> = emptyList()
+)
+
+@Serializable
+@Suppress("PropertyName")
+private sealed class IsfInput {
+    abstract val NAME: String
+    abstract val TYPE: String
+    abstract val LABEL: String?
+}
+
+@Serializable
+@SerialName("event")
+private class IsfEventInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+    val DEFAULT: String? = null,
+    val MIN: String? = null,
+    val MAX: String? = null
+) : IsfInput()
+
+@Serializable
+@SerialName("bool")
+private class IsfBoolInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+    val DEFAULT: String? = null,
+    val MIN: String? = null,
+    val MAX: String? = null
+) : IsfInput()
+
+@Serializable
+@SerialName("long")
+private class IsfLongInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+    val DEFAULT: String? = null,
+    val MIN: String? = null,
+    val MAX: String? = null
+) : IsfInput()
+
+@Serializable
+@SerialName("float")
+private class IsfFloatInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+    val DEFAULT: String? = null,
+    val MIN: String? = null,
+    val MAX: String? = null
+) : IsfInput()
+
+@Serializable
+@SerialName("point2D")
+private class IsfPoint2DInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+) : IsfInput()
+
+@Serializable
+@SerialName("color")
+private class IsfColorInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+    val DEFAULT: Array<String>? = null,
+    ) : IsfInput()
+
+@Serializable
+@SerialName("image")
+private class IsfImageInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+) : IsfInput()
+
+@Serializable
+@SerialName("audio")
+private class IsfAudioInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+) : IsfInput()
+
+@Serializable
+@SerialName("audioFFT")
+private class IsfAudioFftInput(
+    override val NAME: String,
+    override val TYPE: String,
+    override val LABEL: String? = null,
+) : IsfInput()

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/ShaderToyShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/ShaderToyShaderDialect.kt
@@ -64,8 +64,6 @@ object ShaderToyShaderDialect : HintedShaderDialect("baaahs.Core:ShaderToy") {
         InputPort("sm_FragCoord", ContentType.UvCoordinate, GlslType.Vec2, "U/V Coordinates")
     ).associateBy { it.type }
 
-    private val iPortsById = wellKnownInputPorts.associateBy { it.id }
-
     override fun adjustInputPorts(inputPorts: List<InputPort>): List<InputPort> {
         return inputPorts.map {
             if (it.type == GlslType.Vec2 && it.contentType.isUnknown()) {
@@ -80,18 +78,6 @@ object ShaderToyShaderDialect : HintedShaderDialect("baaahs.Core:ShaderToy") {
                 it.copy(contentType = ContentType.Color, description = "Output Color")
             } else it
         }
-    }
-
-    override fun findMagicInputPorts(glslCode: GlslCode): List<InputPort> {
-        // ShaderToy shaders have a set of uniforms that are automatically declared;
-        // see if we're using any of them.
-        val iVars = glslCode.functions.flatMap { glslFunction ->
-            Regex("\\w+").findAll(glslFunction.fullText).map { it.value }.filter { word ->
-                iPortsById.containsKey(word)
-            }.toList()
-        }.toSet()
-
-        return wellKnownInputPorts.filter { inputPort -> iVars.contains(inputPort.id) }
     }
 
     override val title: String = "Paint"

--- a/src/commonMain/kotlin/baaahs/gl/shader/dialect/ShaderToyShaderDialect.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/dialect/ShaderToyShaderDialect.kt
@@ -7,8 +7,12 @@ import baaahs.gl.glsl.ShaderAnalysis
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.OutputPort
+import baaahs.plugin.PluginRef
 import baaahs.plugin.Plugins
+import baaahs.plugin.core.CorePlugin
 import baaahs.show.Shader
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 object ShaderToyShaderDialect : HintedShaderDialect("baaahs.Core:ShaderToy") {
 
@@ -46,9 +50,12 @@ object ShaderToyShaderDialect : HintedShaderDialect("baaahs.Core:ShaderToy") {
 */
         InputPort("iMouse", ContentType.Mouse, GlslType.Vec4, "Mouse"),
 
-//          vec4 iDate: year-1, month-1, day, seconds(+fracs) since midnight.
+//          vec4 iDate: year, month-1, day, seconds(+fracs) since midnight.
+        InputPort("iDate", ContentType.Date, GlslType.Vec4, "Date",
+            pluginRef = PluginRef(CorePlugin.id, "Date"),
+            pluginConfig = buildJsonObject { put("zeroBasedMonth", JsonPrimitive(true)) }
+        ),
 /*
-        InputPort("iDate", GlslType.Vec4, "Date"),
         InputPort("iSampleRate", GlslType.Float, "Sample Rate"),
         InputPort("iChannelResolution", GlslType.from("vec3[4]"), "Channel Resolution"),
 */

--- a/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
@@ -6,21 +6,33 @@ import baaahs.gl.glsl.GlslProgram
 import com.danielgergely.kgl.Kgl
 import com.danielgergely.kgl.UniformLocation
 
-class Uniform internal constructor(
+interface Uniform {
+    fun set(x: Int)
+    fun set(x: Int, y: Int)
+    fun set(x: Int, y: Int, z: Int)
+    fun set(x: Float)
+    fun set(x: Float, y: Float)
+    fun set(x: Float, y: Float, z: Float)
+    fun set(x: Float, y: Float, z: Float, w: Float)
+    fun set(vector3F: Vector3F)
+    fun set(textureUnit: GlContext.TextureUnit)
+}
+
+class UniformImpl internal constructor(
     private val glslProgram: GlslProgram,
     private val uniformLocation: UniformLocation
-) {
-    fun set(x: Int) = withProgram { uniform1i(uniformLocation, x) }
-    fun set(x: Int, y: Int) = withProgram { uniform2i(uniformLocation, x, y) }
-    fun set(x: Int, y: Int, z: Int) = withProgram { uniform3i(uniformLocation, x, y, z) }
-    fun set(x: Float) = withProgram { uniform1f(uniformLocation, x) }
-    fun set(x: Float, y: Float) = withProgram { uniform2f(uniformLocation, x, y) }
-    fun set(x: Float, y: Float, z: Float) = withProgram { uniform3f(uniformLocation, x, y, z) }
-    fun set(x: Float, y: Float, z: Float, w: Float) = withProgram { uniform4f(uniformLocation, x, y, z, w) }
+): Uniform {
+    override fun set(x: Int) = withProgram { uniform1i(uniformLocation, x) }
+    override fun set(x: Int, y: Int) = withProgram { uniform2i(uniformLocation, x, y) }
+    override fun set(x: Int, y: Int, z: Int) = withProgram { uniform3i(uniformLocation, x, y, z) }
+    override fun set(x: Float) = withProgram { uniform1f(uniformLocation, x) }
+    override fun set(x: Float, y: Float) = withProgram { uniform2f(uniformLocation, x, y) }
+    override fun set(x: Float, y: Float, z: Float) = withProgram { uniform3f(uniformLocation, x, y, z) }
+    override fun set(x: Float, y: Float, z: Float, w: Float) = withProgram { uniform4f(uniformLocation, x, y, z, w) }
 
-    fun set(vector3F: Vector3F) = set(vector3F.x, vector3F.y, vector3F.z)
+    override fun set(vector3F: Vector3F) = set(vector3F.x, vector3F.y, vector3F.z)
 
-    fun set(textureUnit: GlContext.TextureUnit) = textureUnit.setUniform(this)
+    override fun set(textureUnit: GlContext.TextureUnit) = textureUnit.setUniform(this)
 
     private fun <T> withProgram(fn: Kgl.() -> T): T {
         return glslProgram.withProgram(fn)

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
@@ -66,7 +66,8 @@ class BeatLinkPlugin internal constructor(
                             PortLinkOption(
                                 MutableDataSourcePort(beatLinkDataSource),
                                 wasPurposeBuilt = true,
-                                isExactContentType = inputPort.contentType == beatDataContentType,
+                                isExactContentType = inputPort.contentType == beatDataContentType
+                                        || inputPort.contentType.isUnknown(),
                                 isPluginSuggestion = true
                             )
                         )

--- a/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
@@ -9,6 +9,7 @@ import baaahs.fixtures.PixelArrayDevice
 import baaahs.gl.data.Feed
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.dialect.GenericShaderDialect
+import baaahs.gl.shader.dialect.IsfShaderDialect
 import baaahs.gl.shader.dialect.ShaderToyShaderDialect
 import baaahs.gl.shader.type.*
 import baaahs.plugin.*
@@ -72,7 +73,8 @@ class CorePlugin(private val pluginContext: PluginContext) : Plugin {
     override val shaderDialects
         get() = listOf(
             GenericShaderDialect,
-            ShaderToyShaderDialect
+            ShaderToyShaderDialect,
+            IsfShaderDialect
         )
 
     override val shaderTypes: List<ShaderType>

--- a/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
@@ -102,6 +102,7 @@ class CorePlugin(private val pluginContext: PluginContext) : Plugin {
             TimeDataSource,
             ResolutionDataSource,
             PreviewResolutionDataSource,
+            SwitchDataSource,
             SliderDataSource,
             FixtureInfoDataSource,
             RasterCoordinateDataSource

--- a/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/CorePlugin.kt
@@ -101,6 +101,7 @@ class CorePlugin(private val pluginContext: PluginContext) : Plugin {
             ModelInfoDataSource,
             XyPadDataSource,
             ColorPickerDataSource,
+            DateDataSource,
             TimeDataSource,
             ResolutionDataSource,
             PreviewResolutionDataSource,

--- a/src/commonMain/kotlin/baaahs/plugin/core/datasource/DateDataSource.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/datasource/DateDataSource.kt
@@ -1,0 +1,69 @@
+package baaahs.plugin.core.datasource
+
+import baaahs.RefCounted
+import baaahs.RefCounter
+import baaahs.ShowPlayer
+import baaahs.gl.GlContext
+import baaahs.gl.data.EngineFeed
+import baaahs.gl.data.Feed
+import baaahs.gl.data.ProgramFeed
+import baaahs.gl.data.SingleUniformFeed
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.patch.ContentType
+import baaahs.gl.shader.InputPort
+import baaahs.plugin.classSerializer
+import baaahs.plugin.core.CorePlugin
+import baaahs.show.DataSource
+import baaahs.show.DataSourceBuilder
+import com.soywiz.klock.DateTime
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+
+@Serializable
+@SerialName("baaahs.Core:Date")
+data class DateDataSource(
+    val zeroBasedMonth: Boolean = false,
+    val zeroBasedDay: Boolean = false
+) : DataSource {
+
+    companion object : DataSourceBuilder<DateDataSource> {
+        const val SECONDS_PER_DAY = (24 * 60 * 60).toDouble()
+
+        override val resourceName: String get() = "Date"
+        override val contentType: ContentType get() = ContentType.Date
+        override val serializerRegistrar get() = classSerializer(serializer())
+        override fun build(inputPort: InputPort): DateDataSource =
+            DateDataSource(
+                inputPort.pluginConfig?.get("zeroBasedMonth") == JsonPrimitive(true),
+                inputPort.pluginConfig?.get("zeroBasedDay") == JsonPrimitive(true)
+            )
+    }
+
+    override val pluginPackage: String get() = CorePlugin.id
+    override val title: String get() = "Date"
+    override fun getType(): GlslType = GlslType.Vec4
+    override val contentType: ContentType
+        get() = ContentType.Date
+
+    override fun createFeed(showPlayer: ShowPlayer, id: String): Feed =
+        object : Feed, RefCounted by RefCounter() {
+            override fun bind(gl: GlContext): EngineFeed = object : EngineFeed {
+                override fun bind(glslProgram: GlslProgram): ProgramFeed {
+                    val clock = showPlayer.toolchain.plugins.pluginContext.clock
+                    return SingleUniformFeed(glslProgram, this@DateDataSource, id) { uniform ->
+                        val dateTime = DateTime(clock.now() * 1000)
+                        uniform.set(
+                            dateTime.yearInt.toFloat(),
+                            dateTime.month1.toFloat() - if (zeroBasedMonth) 1 else 0,
+                            dateTime.dayOfMonth.toFloat() - if (zeroBasedDay) 1 else 0,
+                            (dateTime.yearOneMillis / 1000.0 % SECONDS_PER_DAY).toFloat()
+                        )
+                    }
+                }
+            }
+
+            override fun release() = Unit
+        }
+}

--- a/src/commonMain/kotlin/baaahs/plugin/core/datasource/SwitchDataSource.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/datasource/SwitchDataSource.kt
@@ -4,8 +4,9 @@ import baaahs.RefCounted
 import baaahs.RefCounter
 import baaahs.ShowPlayer
 import baaahs.camelize
-import baaahs.control.MutableSliderControl
-import baaahs.gadgets.Slider
+import baaahs.control.ButtonControl
+import baaahs.control.MutableButtonControl
+import baaahs.gadgets.Switch
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeed
 import baaahs.gl.data.Feed
@@ -20,52 +21,49 @@ import baaahs.plugin.core.CorePlugin
 import baaahs.show.DataSource
 import baaahs.show.DataSourceBuilder
 import baaahs.show.mutable.MutableControl
+import baaahs.show.mutable.MutableShow
 import baaahs.util.Logger
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.float
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
-@SerialName("baaahs.Core:Slider")
-data class SliderDataSource(
+@SerialName("baaahs.Core:Switch")
+data class SwitchDataSource(
     @SerialName("title")
-    val sliderTitle: String,
-    val initialValue: Float,
-    val minValue: Float,
-    val maxValue: Float,
-    val stepValue: Float? = null
+    val buttonTitle: String,
+    val initiallyEnabled: Boolean,
+    val activationType: ButtonControl.ActivationType = ButtonControl.ActivationType.Toggle
 ) : DataSource {
-    override val title: String get() = "$sliderTitle Slider"
+    override val title: String get() = "$buttonTitle $resourceName"
     override val pluginPackage: String get() = CorePlugin.id
-    override fun getType(): GlslType = GlslType.Float
+    override fun getType(): GlslType = GlslType.Bool
     override val contentType: ContentType
-        get() = ContentType.Float
+        get() = ContentType.Boolean
     override fun suggestId(): String = title.camelize()
 
-    fun createGadget(): Slider =
-        Slider(sliderTitle, initialValue, minValue, maxValue, stepValue)
+    fun createGadget(): ButtonControl =
+        ButtonControl(buttonTitle, activationType)
 
     override fun buildControl(): MutableControl {
-        return MutableSliderControl(sliderTitle, initialValue, minValue, maxValue, stepValue, this)
+        return MutableButtonControl(createGadget(), MutableShow("Temp Show"), this)
     }
 
     override fun createFeed(showPlayer: ShowPlayer, id: String): Feed {
-//        val channel = showPlayer.useChannel<Float>(id)
-        val slider = showPlayer.useGadget(this)
+        val switch = showPlayer.useGadget<Switch>(this)
             ?: run {
                 logger.debug { "No control gadget registered for datasource $id, creating one. This is probably busted." }
-                createGadget()
+                Switch(buttonTitle, initiallyEnabled)
             }
 
         return object : Feed, RefCounted by RefCounter() {
             override fun bind(gl: GlContext): EngineFeed = object : EngineFeed {
                 override fun bind(glslProgram: GlslProgram): ProgramFeed {
-                    return SingleUniformFeed(glslProgram, this@SliderDataSource, id) { uniform ->
-//                        uniform.set(channel.value)
-                        uniform.set(slider.position)
+                    return SingleUniformFeed(glslProgram, this@SwitchDataSource, id) { uniform ->
+                        uniform.set(if (switch.enabled) 1 else 0)
                     }
                 }
             }
@@ -74,28 +72,25 @@ data class SliderDataSource(
         }
     }
 
-    companion object : DataSourceBuilder<SliderDataSource> {
-        override val resourceName: String get() = "Slider"
-        override val contentType: ContentType get() = ContentType.Float
+    companion object : DataSourceBuilder<SwitchDataSource> {
+        override val resourceName: String get() = "Switch"
+        override val contentType: ContentType get() = ContentType.Boolean
         override val serializerRegistrar get() = classSerializer(serializer())
 
         override fun looksValid(inputPort: InputPort): Boolean =
             inputPort.dataTypeIs(GlslType.Float)
 
-        override fun build(inputPort: InputPort): SliderDataSource {
+        override fun build(inputPort: InputPort): SwitchDataSource {
             val config = inputPort.pluginConfig
-            return SliderDataSource(
+            return SwitchDataSource(
                 inputPort.title,
-                initialValue = config.getFloat("default") ?: 1f,
-                minValue = config.getFloat("min") ?: 0f,
-                maxValue = config.getFloat("max") ?: 1f,
-                stepValue = config.getFloat("step")
+                initiallyEnabled = config.getBoolean("default") ?: true
             )
         }
 
-        private fun JsonObject?.getFloat(key: String): Float? {
+        private fun JsonObject?.getBoolean(key: String): Boolean? {
             return try {
-                this?.get(key)?.jsonPrimitive?.float
+                this?.get(key)?.jsonPrimitive?.boolean
             } catch (e: NumberFormatException) {
                 logger.debug(e) {
                     "Invalid number for key \"$key\": ${this?.get(key)?.jsonPrimitive?.contentOrNull}"
@@ -104,6 +99,6 @@ data class SliderDataSource(
             }
         }
 
-        private val logger = Logger<SliderDataSource>()
+        private val logger = Logger<SwitchDataSource>()
     }
 }

--- a/src/commonMain/kotlin/baaahs/show/DataSource.kt
+++ b/src/commonMain/kotlin/baaahs/show/DataSource.kt
@@ -30,6 +30,7 @@ interface DataSourceBuilder<T : DataSource> {
                     wasPurposeBuilt = dataSource.appearsToBePurposeBuiltFor(inputPort),
                     isPluginSuggestion = true,
                     isExactContentType = dataSource.contentType == inputPort.contentType
+                            || inputPort.contentType.isUnknown()
                 )
             }
         } else emptyList()

--- a/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenControl.kt
@@ -19,6 +19,7 @@ interface OpenControl {
     fun controlledDataSources(): Set<DataSource> = emptySet()
     fun addTo(activePatchSetBuilder: ActivePatchSetBuilder, panel: Panel, depth: Int) {}
     fun applyConstraints() {}
+    fun resetToDefault() {}
     fun toNewMutable(mutableShow: MutableShow): MutableControl
     fun getView(controlProps: ControlProps): View
     fun getEditIntent(): EditIntent? = ControlEditIntent(id)

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslAnalyzerSpec.kt
@@ -140,7 +140,8 @@ object GlslAnalyzerSpec : Spek({
                                     InputPort("gl_FragCoord", ContentType.UvCoordinate, GlslType.Vec4, "Coordinates", isImplicit = true),
                                     InputPort("channelA", ContentType.Color, GlslType.Vec4, "Channel A", isImplicit = false, injectedData = mapOf(
                                         "uv" to ContentType.UvCoordinate
-                                    ))
+                                    )),
+                                    InputPort("resolution", ContentType.Resolution, GlslType.Vec2, "Resolution", isImplicit = false),
                                 )
                         }
                     }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslCodeSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslCodeSpec.kt
@@ -28,6 +28,11 @@ object GlslCodeSpec : Spek({
                 expectValue(GlslCode.GlslVar("i", GlslType.Int, "int i;")) { variable }
             }
 
+            context("arrays") {
+                override(text) { "vec4 colorsArray[9];" }
+                expectValue(GlslCode.GlslVar("colorsArray", GlslType.Vec4, "vec4 colorsArray[9];")) { variable }
+            }
+
             context("const") {
                 override(text) { "const int i = 3;" }
                 expectValue(GlslCode.GlslVar("i", GlslType.Int, "const int i = 3;", isConst = true)) { variable }

--- a/src/commonTest/kotlin/baaahs/gl/glsl/GlslParserSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/glsl/GlslParserSpec.kt
@@ -8,6 +8,7 @@ import baaahs.only
 import baaahs.toBeSpecified
 import baaahs.toEqual
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
+import ch.tutteli.atrium.api.fluent.en_GB.isEmpty
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
@@ -246,6 +247,24 @@ object GlslParserSpec : Spek({
                                             "}\n".trimIndent()
                                 )
                         }
+                    }
+                }
+
+                context("hash signs inside of comments") {
+                    override(shaderText) {
+                        /**language=glsl*/
+                        """
+                            // Title
+                            
+                            void main() {
+                              // this #is ignored                             
+                            }
+                        """.trimIndent()
+                    }
+
+                    it("finds the global variables and performs substitutions") {
+                        // Shouldn't throw "analysis error: directive #is ignored"
+                        expect(glslCode.globalVars.toList()).isEmpty()
                     }
                 }
 

--- a/src/commonTest/kotlin/baaahs/gl/shader/dialect/IsfShaderDialectSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/shader/dialect/IsfShaderDialectSpec.kt
@@ -1,0 +1,186 @@
+package baaahs.gl.shader.dialect
+
+import baaahs.describe
+import baaahs.gl.glsl.ErrorsShaderAnalysis
+import baaahs.gl.glsl.GlslAnalyzer
+import baaahs.gl.glsl.GlslError
+import baaahs.gl.glsl.GlslType
+import baaahs.gl.override
+import baaahs.gl.patch.ContentType
+import baaahs.gl.shader.InputPort
+import baaahs.gl.shader.OutputPort
+import baaahs.gl.testToolchain
+import baaahs.plugin.PluginRef
+import baaahs.show.Shader
+import baaahs.toBeSpecified
+import baaahs.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.contains
+import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
+import ch.tutteli.atrium.api.fluent.en_GB.isA
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.expect
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.spekframework.spek2.Spek
+
+@Suppress("unused")
+object IsfShaderDialectSpec : Spek({
+    describe<IsfShaderDialect> {
+        val src by value<String> { toBeSpecified() }
+        val dialect by value { IsfShaderDialect }
+        val plugins by value { testToolchain.plugins }
+        val analyzer by value { GlslAnalyzer(plugins) }
+        val shaderAnalysis by value { testToolchain.analyze(Shader("Shader", src)) }
+        val glslCode by value { shaderAnalysis.glslCode }
+        val openShader by value { analyzer.openShader(shaderAnalysis) }
+
+        context("a shader having an ISF block at the top") {
+            override(src) {
+                """
+                    /*{
+                        "DESCRIPTION": "Demonstrates a float input",
+                        "CREDIT": "by VIDVOX",
+                        "ISFVSN": "2.0",
+                        "CATEGORIES": [
+                            "TEST-GLSL"
+                        ],
+                        "INPUTS": [
+                            {
+                                "NAME": "level",
+                                "TYPE": "float",
+                                "LABEL": "Gray Level",
+                                "DEFAULT": 0.5,
+                                "MIN": 0.0,
+                                "MAX": 1.0
+                            }
+                        ]
+                    }*/
+    
+                    void main() {
+                        gl_FragColor = vec4(level,level,level,1.0);
+                    }
+                """.trimIndent()
+            }
+
+            it("is an poor match (so this one acts as a fallback)") {
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.Excellent)
+            }
+
+            it("finds the input port") {
+                expect(openShader.inputPorts).containsExactly(
+                    InputPort(
+                        "level", ContentType.Float, GlslType.Float, "Gray Level",
+                        pluginRef = PluginRef("baaahs.Core", "Slider"),
+                        pluginConfig = buildJsonObject {
+                            put("min", JsonPrimitive(0f))
+                            put("max", JsonPrimitive(1f))
+                            put("default", JsonPrimitive(.5f))
+                        },
+                        isImplicit = true
+                    )
+                )
+            }
+
+            it("finds the output port") {
+                expect(shaderAnalysis.outputPorts).containsExactly(
+                    OutputPort(ContentType.Color, description = "Output Color", id = "gl_FragColor")
+                )
+            }
+
+            context("when a shader refers to gl_FragCoord") {
+                override(src) {
+                    """
+                        /*{}*/
+                        void main() {
+                            gl_FragColor = vec4(gl_FragCoord.xy, 0., 1.);
+                        }
+                    """.trimIndent()
+                }
+
+                it("includes it as an input port") {
+                    expect(openShader.inputPorts).containsExactly(
+                        InputPort(
+                            "gl_FragCoord", ContentType.UvCoordinate, GlslType.Vec4,
+                            "Coordinates", isImplicit = true
+                        )
+                    )
+                }
+            }
+
+            context("when a shader refers to isf_FragNormCoord") {
+                override(src) {
+                    """
+                        /*{ }*/
+                        void main() {
+                            gl_FragColor = vec4(isf_FragNormCoord.xy, 0., 1.);
+                        }
+                    """.trimIndent()
+                }
+
+                it("includes it as an input port") {
+                    expect(openShader.inputPorts).containsExactly(
+                        InputPort(
+                            "isf_FragNormCoord", ContentType.UvCoordinate, GlslType.Vec2,
+                            "U/V Coordinate", isImplicit = true
+                        )
+                    )
+                }
+            }
+
+            context("using TIME") {
+                override(src) {
+                    """
+                        /*{ }*/
+                        void main() { gl_FragColor = vec4(TIME, TIME, TIME, 0.); }
+                    """.trimIndent()
+
+                }
+
+                it("includes it as an input port") {
+                    expect(openShader.inputPorts).containsExactly(
+                        InputPort("TIME", ContentType.Time, GlslType.Float, "Time", isImplicit = true)
+                    )
+                }
+            }
+
+            context("with multiple out parameters") {
+                override(src) {
+                    "void main(in vec2 fragCoord, out vec4 fragColor, out float other) { gl_FragColor = vec4(gl_FragCoord, 0., 1.); };"
+                }
+
+                it("fails to validate") {
+                    expect(shaderAnalysis.isValid).toBe(false)
+
+                    expect(shaderAnalysis.errors).contains(
+                        GlslError("Too many output ports found: [fragColor, gl_FragColor, other].", row = 1)
+                    )
+                }
+            }
+
+            context("which isn't valid JSON") {
+                override(src) {
+                    """
+                        /*{ "DESC }*/
+                        void main() { gl_FragColor = vec4(level,level,level,1.0); }
+                    """.trimIndent()
+                }
+
+                it("returns an ErrorShaderAnalysis") {
+                    expect(shaderAnalysis).isA<ErrorsShaderAnalysis>()
+                    shaderAnalysis as ErrorsShaderAnalysis
+                    expect(shaderAnalysis.errors).containsExactly(
+                        GlslError("Unexpected JSON token at offset 9: EOF\n" +
+                                "JSON input: { \"DESC }", 1)
+                    )
+                }
+            }
+        }
+
+        context("a shader without an ISF block at the top") {
+            override(src) { "void main() {\n  gl_FragColor = vec4(level,level,level,1.0);\n}" }
+            it("is not a match") {
+                expect(dialect.matches(glslCode)).toEqual(MatchLevel.NoMatch)
+            }
+        }
+    }
+})

--- a/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/CorePluginSpec.kt
@@ -4,7 +4,7 @@ import baaahs.FakeClock
 import baaahs.describe
 import baaahs.gl.RootToolchain
 import baaahs.gl.autoWire
-import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.glsl.GlslProgramImpl
 import baaahs.gl.patch.ContentType
 import baaahs.gl.testPlugins
 import baaahs.glsl.Shaders
@@ -27,7 +27,7 @@ object CorePluginSpec : Spek({
         val program by value {
             val linkedPatch = toolchain.autoWire(Shaders.red).acceptSuggestedLinkOptions()
                 .confirm().openForPreview(toolchain, ContentType.Color)!!
-            GlslProgram(gl, linkedPatch) { _, _ -> null }
+            GlslProgramImpl(gl, linkedPatch) { _, _ -> null }
         }
         val programFeed by value { glFeed.bind(program) }
 

--- a/src/commonTest/kotlin/baaahs/plugin/core/FixtureInfoDataSourceSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/core/FixtureInfoDataSourceSpec.kt
@@ -4,6 +4,7 @@ import baaahs.TestMovingHead
 import baaahs.TestRenderContext
 import baaahs.describe
 import baaahs.geom.Vector3F
+import baaahs.gl.glsl.GlslProgramImpl
 import baaahs.show.live.link
 import baaahs.toEqual
 import ch.tutteli.atrium.api.verbs.expect
@@ -31,7 +32,7 @@ object FixtureInfoDataSourceSpec : Spek({
         val testRenderContext by value { TestRenderContext(movingHead) }
         val program by value { testRenderContext.createProgram(shaderText, mapOf(
             "fixtureInfo" to FixtureInfoDataSource().link("fixtureInfo")
-        )) }
+        )) as GlslProgramImpl }
 
         beforeEachTest {
             testRenderContext.addFixtures()

--- a/src/commonTest/kotlin/baaahs/plugin/core/datasource/DateDataSourceSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/core/datasource/DateDataSourceSpec.kt
@@ -1,0 +1,73 @@
+package baaahs.plugin.core.datasource
+
+import baaahs.FakeClock
+import baaahs.describe
+import baaahs.geom.Vector4F
+import baaahs.gl.override
+import baaahs.gl.shader.InputPort
+import baaahs.gl.shader.dialect.IsfShaderDialect
+import baaahs.gl.shader.dialect.ShaderToyShaderDialect
+import baaahs.glsl.Uniform
+import baaahs.shows.FakeGlContext
+import baaahs.shows.FakeShowPlayer
+import baaahs.shows.FakeUniform
+import baaahs.shows.StubGlslProgram
+import baaahs.toBeSpecified
+import baaahs.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import com.danielgergely.kgl.Kgl
+import org.spekframework.spek2.Spek
+
+object DateDataSourceSpec : Spek({
+    describe<DateDataSource> {
+
+        val builder by value { DateDataSource }
+        val inputPort by value { toBeSpecified<InputPort>() }
+        val dataSource by value { builder.build(inputPort) }
+        val time by value { 1619099367.792 } // 2021-04-22 00:13:49.793 UTC
+        val uniform by value { FakeUniform() }
+        val feed by value {
+            val showPlayer = FakeShowPlayer().also {
+                (it.toolchain.plugins.pluginContext.clock as FakeClock).time = time
+            }
+            val gl = FakeGlContext()
+            val fakeProgram = object : StubGlslProgram() {
+                override fun getUniform(name: String): Uniform = uniform
+                override fun <T> withProgram(fn: Kgl.() -> T): T = fn(gl.kgl)
+            }
+
+            dataSource.createFeed(showPlayer, "date")
+                .bind(gl)
+                .bind(fakeProgram)
+        }
+
+        context("for ShaderToy shaders") {
+            override(inputPort) { ShaderToyShaderDialect.wellKnownInputPorts.find { it.id == "iDate" } }
+
+            it("builds a datasource with zero-based months and one-based days") {
+                expect(dataSource).toEqual(DateDataSource(zeroBasedMonth = true, zeroBasedDay = false))
+            }
+
+            it("sets correct uniform values") {
+                feed.setOnProgram()
+                expect(uniform.value.toString())
+                    .toEqual(Vector4F(2021f, 3f, 22f, 49767.793f).toString())
+            }
+        }
+
+        context("for ISF shaders") {
+            override(inputPort) { IsfShaderDialect.wellKnownInputPorts.find { it.id == "DATE" } }
+
+            it("builds a datasource with zero-based months and zero-based days") {
+                expect(dataSource).toEqual(DateDataSource(zeroBasedMonth = false, zeroBasedDay = false))
+            }
+
+
+            it("sets correct uniform values") {
+                feed.setOnProgram()
+                expect(uniform.value.toString())
+                    .toEqual(Vector4F(2021f, 4f, 22f, 49767.793f).toString())
+            }
+        }
+    }
+})

--- a/src/commonTest/kotlin/baaahs/shows/FakeKgl.kt
+++ b/src/commonTest/kotlin/baaahs/shows/FakeKgl.kt
@@ -1,10 +1,17 @@
 package baaahs.shows
 
+import baaahs.geom.Vector2F
+import baaahs.geom.Vector3F
+import baaahs.geom.Vector4F
 import baaahs.getBang
 import baaahs.gl.GlContext
+import baaahs.gl.glsl.CompiledShader
+import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.render.RenderTarget
+import baaahs.glsl.Uniform
 import com.danielgergely.kgl.*
 
-class FakeGlContext(private val kgl: FakeKgl = FakeKgl()) : GlContext(kgl, "1234") {
+class FakeGlContext(internal val kgl: FakeKgl = FakeKgl()) : GlContext(kgl, "1234") {
     val programs get() = kgl.programs.let { it.subList(1, it.size) }
     val textures get() = kgl.textures.let { it.subList(1, it.size) }
     val allocatedTextureUnits get() = textureUnits
@@ -435,5 +442,58 @@ class FakeKgl : Kgl {
                 is FloatBuffer -> this.contents()
                 else -> error("unknown type")
             }
+    }
+}
+
+class FakeUniform : Uniform {
+    var value: Any? = null
+
+    override fun set(x: Int) { value = x }
+    override fun set(x: Int, y: Int) { value = listOf(x, y) }
+    override fun set(x: Int, y: Int, z: Int) { value = listOf(x, y, z) }
+    override fun set(x: Float) { value = x }
+    override fun set(x: Float, y: Float) { value = Vector2F(x, y) }
+    override fun set(x: Float, y: Float, z: Float) { value = Vector3F(x, y, z) }
+    override fun set(x: Float, y: Float, z: Float, w: Float) { value = Vector4F(x, y, z, w) }
+    override fun set(vector3F: Vector3F) { value = vector3F }
+    override fun set(textureUnit: GlContext.TextureUnit) { value = textureUnit }
+}
+
+open class StubGlslProgram : GlslProgram {
+    override val title: String
+        get() = TODO("not implemented")
+
+    override val fragShader: CompiledShader
+        get() = TODO("not implemented")
+
+    override val vertexAttribLocation: Int
+        get() = TODO("not implemented")
+
+    override fun setResolution(x: Float, y: Float) {
+        TODO("not implemented")
+    }
+
+    override fun aboutToRenderFrame() {
+        TODO("not implemented")
+    }
+
+    override fun aboutToRenderFixture(renderTarget: RenderTarget) {
+        TODO("not implemented")
+    }
+
+    override fun getUniform(name: String): Uniform? {
+        TODO("not implemented")
+    }
+
+    override fun <T> withProgram(fn: Kgl.() -> T): T {
+        TODO("not implemented")
+    }
+
+    override fun use() {
+        TODO("not implemented")
+    }
+
+    override fun release() {
+        TODO("not implemented")
     }
 }

--- a/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
@@ -107,6 +107,7 @@ fun jsonFor(control: Control): JsonElement {
             put("title", control.title)
             put("activationType", control.activationType.name)
             addPatchHolder(control)
+            put("controlledDataSourceId", control.controlledDataSourceId)
         }
         is ButtonGroupControl -> buildJsonObject {
             put("type", "baaahs.Core:ButtonGroup")

--- a/src/jsMain/kotlin/baaahs/app/ui/ShaderCard.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/ShaderCard.kt
@@ -3,6 +3,7 @@ package baaahs.app.ui
 import baaahs.app.ui.editor.EditableStyles
 import baaahs.gl.Toolchain
 import baaahs.gl.openShader
+import baaahs.gl.preview.GadgetAdjuster
 import baaahs.show.mutable.MutableShaderInstance
 import baaahs.ui.on
 import baaahs.ui.unaryPlus
@@ -60,7 +61,7 @@ val ShaderInstanceCard = xComponent<ShaderInstanceCardProps>("ShaderCard") { pro
             attrs.shader = shader
             attrs.width = styles.cardWidth
             attrs.height = styles.cardWidth
-            attrs.adjustGadgets = true
+            attrs.adjustGadgets = GadgetAdjuster.Mode.FULL_RANGE
             attrs.toolchain = props.toolchain
         }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/ShaderDiagnostics.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/ShaderDiagnostics.kt
@@ -1,0 +1,64 @@
+package baaahs.app.ui
+
+import baaahs.gl.preview.ShaderBuilder
+import baaahs.ui.on
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
+import materialui.components.divider.divider
+import materialui.components.popover.enums.PopoverStyle
+import materialui.components.popover.popover
+import org.w3c.dom.events.EventTarget
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+import react.dom.code
+import react.dom.div
+import react.dom.header
+import react.dom.pre
+
+val ShaderDiagnostics = xComponent<ShaderDiagnosticsProps>("ShaderDiagnostics") { props ->
+
+    val glslErrors = props.builder.glslErrors
+    val linkedPatch = props.builder.linkedPatch
+
+    popover(ShaderPreviewStyles.errorPopup on PopoverStyle.paper) {
+        attrs.open = props.anchor != null
+        attrs.anchorEl(props.anchor)
+        attrs.onClose = { event, _ ->
+            props.onClose()
+            event.stopPropagation()
+        }
+
+        header { +"Errors:" }
+
+        div {
+            if (props.anchor != null) {
+                pre(+ShaderPreviewStyles.errorMessage) {
+                    if (glslErrors.isNotEmpty()) {
+                        +glslErrors.joinToString("\n")
+                    } else {
+                        +"No errors."
+                    }
+                }
+
+                divider {}
+
+                pre(+ShaderPreviewStyles.errorSourceCode) {
+                    (linkedPatch?.toFullGlsl("x") ?: "No source!?")
+                        .split("\n")
+                        .forEach { code { +it }; +"\n" }
+                }
+            }
+        }
+    }
+}
+
+external interface ShaderDiagnosticsProps : RProps {
+    var anchor: EventTarget?
+    var builder: ShaderBuilder
+    var onClose: () -> Unit
+}
+
+fun RBuilder.shaderDiagnostics(handler: RHandler<ShaderDiagnosticsProps>) =
+    child(ShaderDiagnostics, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/ShowLayout.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/ShowLayout.kt
@@ -94,7 +94,11 @@ val ShowLayout = xComponent<ShowLayoutProps>("ShowLayout") { props ->
                             this.direction = Direction.horizontal.name
                             this.isDropDisabled = !props.editMode
                         }) { droppableProvided, _ ->
-                            val style = Styles.controlSections[panelBucket.section.depth]
+                            val style = if (Styles.controlSections.size > panelBucket.section.depth)
+                                Styles.controlSections[panelBucket.section.depth]
+                            else
+                                Styles.controlSections.last()
+
                             div(+Styles.layoutControls and style) {
                                 install(droppableProvided)
 

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/ColorPickerControl.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/ColorPickerControl.kt
@@ -1,0 +1,32 @@
+package baaahs.app.ui.controls
+
+import baaahs.control.OpenColorPickerControl
+import baaahs.jsx.ColorPicker
+import baaahs.jsx.ColorPickerProps
+import baaahs.show.live.ControlProps
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
+import kotlinext.js.jsObject
+import react.RBuilder
+import react.RHandler
+import react.RProps
+import react.child
+import react.dom.div
+
+val ColorPickerControl = xComponent<ColorPickerControlProps>("ColorPickerControl") { props ->
+    val colorPickerControl = props.colorPickerControl
+
+    child(ColorPicker, jsObject<ColorPickerProps> {
+        gadget = colorPickerControl.colorPicker
+    }) {}
+
+    div(+Styles.dataSourceTitle) { +colorPickerControl.colorPicker.title }
+}
+
+external interface ColorPickerControlProps : RProps {
+    var controlProps: ControlProps
+    var colorPickerControl: OpenColorPickerControl
+}
+
+fun RBuilder.colorPickerControl(handler: RHandler<ColorPickerControlProps>) =
+    child(ColorPickerControl, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditorStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditorStyles.kt
@@ -86,6 +86,20 @@ class ShaderEditorStyles(private val theme: MuiTheme) : StyleSheet("app-ui-edito
         important(::textAlign, TextAlign.right)
     }
 
+    val previewContainer by css {
+        position = Position.relative
+    }
+
+    val settingsMenuAffordance by css {
+        position = Position.absolute
+        padding(2.px)
+        backgroundColor = Color.white.withAlpha(.5)
+        width = 2.em
+        height = 2.em
+        right = .5.em
+        bottom = .5.em
+    }
+
     val showAdvancedMenuItem by css {
         paddingTop = 0.px
         paddingBottom = 0.px

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditorStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderEditorStyles.kt
@@ -86,6 +86,21 @@ class ShaderEditorStyles(private val theme: MuiTheme) : StyleSheet("app-ui-edito
         important(::textAlign, TextAlign.right)
     }
 
+    val showAdvancedMenuItem by css {
+        paddingTop = 0.px
+        paddingBottom = 0.px
+        paddingLeft = 8.px
+
+        svg {
+            width = .75.em
+            height = .75.em
+        }
+
+        span {
+            fontSize = .95.em
+        }
+    }
+
     companion object {
         val previewWidth = 250.px
         val previewHeight = 250.px

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderInstanceEditor.kt
@@ -1,44 +1,28 @@
 package baaahs.app.ui.editor
 
-import baaahs.app.ui.CommonIcons
 import baaahs.app.ui.appContext
 import baaahs.app.ui.shaderPreview
-import baaahs.englishize
 import baaahs.gl.preview.PreviewShaderBuilder
 import baaahs.gl.withCache
-import baaahs.show.ShaderChannel
 import baaahs.show.mutable.EditingShader
 import baaahs.show.mutable.MutablePatch
-import baaahs.show.mutable.MutableShaderChannel
 import baaahs.show.mutable.MutableShaderInstance
-import baaahs.ui.*
-import kotlinx.html.InputType
+import baaahs.ui.addObserver
+import baaahs.ui.on
+import baaahs.ui.unaryPlus
+import baaahs.ui.xComponent
 import kotlinx.html.js.onChangeFunction
-import materialui.components.divider.divider
-import materialui.components.formcontrol.formControl
 import materialui.components.formcontrollabel.enums.FormControlLabelStyle
 import materialui.components.formcontrollabel.formControlLabel
-import materialui.components.formhelpertext.formHelperText
-import materialui.components.inputlabel.inputLabel
-import materialui.components.listitemicon.listItemIcon
-import materialui.components.listitemtext.listItemText
-import materialui.components.menuitem.menuItem
-import materialui.components.select.select
 import materialui.components.switches.switch
 import materialui.components.tab.enums.TabStyle
 import materialui.components.tab.tab
 import materialui.components.tabs.enums.TabsStyle
 import materialui.components.tabs.tabs
-import materialui.components.textfield.textField
-import materialui.components.typography.enums.TypographyColor
-import materialui.components.typography.typography
 import materialui.components.typography.typographyH6
-import materialui.icon
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
 import react.*
-import react.dom.b
-import react.dom.br
 import react.dom.div
 
 private enum class PageTabs {
@@ -62,12 +46,6 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
         adjustGadgets = (event.target as HTMLInputElement).checked
     }
 
-    val handleUpdate =
-        handler("handleShaderUpdate", props.mutableShaderInstance) { block: MutableShaderInstance.() -> Unit ->
-            props.mutableShaderInstance.block()
-            props.editableManager.onChange()
-        }
-
     val editingShader = memo(props.mutableShaderInstance) {
         val newEditingShader =
             EditingShader(
@@ -88,30 +66,6 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
         newEditingShader
     }
 
-    val shaderInstance = props.mutableShaderInstance
-
-    val handleSelectShaderChannel = handler("select shader channel", handleUpdate) { event: Event ->
-        val channelId = event.target.value
-        if (channelId == "__new__") {
-            appContext.prompt(Prompt(
-                "Create A New Channel",
-                "Enter the name of the new channel.",
-                fieldLabel = "Channel Name",
-                cancelButtonLabel = "Cancel",
-                submitButtonLabel = "Create",
-                onSubmit = { name ->
-                    handleUpdate {
-                        shaderChannel = MutableShaderChannel.from(name)
-                    }
-                }
-            ))
-        } else {
-            handleUpdate {
-                shaderChannel = MutableShaderChannel.from(channelId)
-            }
-        }
-    }
-
     div(+shaderEditorStyles.propsAndPreview) {
         div(+shaderEditorStyles.propsTabsAndPanels) {
             tabs(shaderEditorStyles.tabsContainer on TabsStyle.flexContainer) {
@@ -128,95 +82,11 @@ val ShaderInstanceEditor = xComponent<ShaderInstanceEditorProps>("ShaderInstance
 
             div(+shaderEditorStyles.propsPanel) {
                 when (selectedTab) {
-                    PageTabs.Properties -> div(+shaderEditorStyles.shaderProperties) {
-                        div(+shaderEditorStyles.shaderName) {
-                            textFieldEditor {
-                                attrs.label = "Shader Name"
-                                attrs.getValue = { shaderInstance.mutableShader.title }
-                                attrs.setValue = { value -> shaderInstance.mutableShader.title = value }
-                                attrs.editableManager = props.editableManager
-                            }
-                        }
-
-                        div(+shaderEditorStyles.shaderChannel) {
-                            formControl {
-                                val main = ShaderChannel.Main
-                                inputLabel { +"Channel" }
-                                select {
-                                    attrs.renderValue<String> { it.asTextNode() }
-                                    attrs.value(shaderInstance.shaderChannel.id)
-                                    attrs.onChangeFunction = handleSelectShaderChannel
-
-                                    menuItem {
-                                        attrs["value"] = main.id
-                                        listItemIcon { icon(CommonIcons.ShaderChannel) }
-                                        listItemText { +"${main.id.englishize()} (default)" }
-                                    }
-
-                                    divider {}
-
-                                    val shaderChannels = editingShader.getShaderChannelOptions(excludeMain = true)
-                                    shaderChannels.forEach { shaderChannel ->
-                                        if (shaderChannel.id != main.id) {
-                                            menuItem {
-                                                attrs["value"] = shaderChannel.id
-                                                listItemIcon { icon(CommonIcons.ShaderChannel) }
-                                                listItemText { +shaderChannel.id.englishize() }
-                                            }
-                                        }
-                                    }
-
-                                    divider {}
-                                    menuItem {
-                                        attrs["value"] = "__new__"
-                                        listItemIcon { icon(CommonIcons.Add) }
-                                        listItemText { +"New Channel…" }
-                                    }
-                                }
-                                formHelperText { +"This shader's channel." }
-                            }
-                        }
-
-                        div(+shaderEditorStyles.shaderPriority) {
-                            formControl {
-                                textField {
-                                    attrs.label { +"Priority" }
-                                    attrs.type = InputType.number
-                                    attrs.value = shaderInstance.priority
-                                    attrs.onChangeFunction = { event: Event ->
-                                        val priorityStr = event.target.value
-                                        handleUpdate { priority = priorityStr.toFloat() }
-                                    }
-                                }
-                                formHelperText { +"This shader's priority in the patch." }
-                            }
-                        }
-
-                        div(+shaderEditorStyles.shaderReturnType) {
-                            val openShader = editingShader.openShader
-
-                            if (openShader != null) {
-                                val outputPort = openShader.outputPort
-
-                                typography { b { +"Returns: " } }
-                                typography {
-                                    if (outputPort.contentType.isUnknown()) {
-                                        attrs.color = TypographyColor.error
-                                    }
-                                    +outputPort.contentType.title
-                                }
-
-                                br {}
-
-                                typography { b { +"Shader Type: " } }
-                                typography {
-                                    +"${openShader.shaderType.title} (${openShader.shaderDialect.title})"
-                                }
-                            }
-
-                        }
+                    PageTabs.Properties -> shaderPropertiesEditor {
+                        attrs.editableManager = props.editableManager
+                        attrs.editingShader = editingShader
+                        attrs.mutableShaderInstance = props.mutableShaderInstance
                     }
-
                     PageTabs.Ports -> linksEditor {
                         attrs.editableManager = props.editableManager
                         attrs.editingShader = editingShader

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderPropertiesEditor.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/ShaderPropertiesEditor.kt
@@ -1,0 +1,163 @@
+package baaahs.app.ui.editor
+
+import baaahs.app.ui.CommonIcons
+import baaahs.app.ui.appContext
+import baaahs.englishize
+import baaahs.show.ShaderChannel
+import baaahs.show.mutable.EditingShader
+import baaahs.show.mutable.MutableShaderChannel
+import baaahs.show.mutable.MutableShaderInstance
+import baaahs.ui.*
+import kotlinx.html.InputType
+import kotlinx.html.js.onChangeFunction
+import materialui.components.divider.divider
+import materialui.components.formcontrol.formControl
+import materialui.components.formhelpertext.formHelperText
+import materialui.components.inputlabel.inputLabel
+import materialui.components.listitemicon.listItemIcon
+import materialui.components.listitemtext.listItemText
+import materialui.components.menuitem.menuItem
+import materialui.components.select.select
+import materialui.components.textfield.textField
+import materialui.components.typography.enums.TypographyColor
+import materialui.components.typography.typography
+import materialui.icon
+import org.w3c.dom.events.Event
+import react.*
+import react.dom.b
+import react.dom.br
+import react.dom.div
+
+val ShaderPropertiesEditor = xComponent<ShaderPropertiesEditorProps>("ShaderPropertiesEditor") { props ->
+    val appContext = useContext(appContext)
+    val shaderEditorStyles = appContext.allStyles.shaderEditor
+
+    val shaderInstance = props.mutableShaderInstance
+    val editingShader = props.editingShader
+
+    val handleUpdate =
+        handler("handleShaderUpdate", props.mutableShaderInstance) { block: MutableShaderInstance.() -> Unit ->
+            props.mutableShaderInstance.block()
+            props.editableManager.onChange()
+        }
+
+    val handleSelectShaderChannel = handler("select shader channel", handleUpdate) { event: Event ->
+        val channelId = event.target.value
+        if (channelId == "__new__") {
+            appContext.prompt(Prompt(
+                "Create A New Channel",
+                "Enter the name of the new channel.",
+                fieldLabel = "Channel Name",
+                cancelButtonLabel = "Cancel",
+                submitButtonLabel = "Create",
+                onSubmit = { name ->
+                    handleUpdate {
+                        shaderChannel = MutableShaderChannel.from(name)
+                    }
+                }
+            ))
+        } else {
+            handleUpdate {
+                shaderChannel = MutableShaderChannel.from(channelId)
+            }
+        }
+    }
+
+    div(+shaderEditorStyles.shaderProperties) {
+        div(+shaderEditorStyles.shaderName) {
+            textFieldEditor {
+                attrs.label = "Shader Name"
+                attrs.getValue = { shaderInstance.mutableShader.title }
+                attrs.setValue = { value -> shaderInstance.mutableShader.title = value }
+                attrs.editableManager = props.editableManager
+            }
+        }
+
+        div(+shaderEditorStyles.shaderChannel) {
+            formControl {
+                val main = ShaderChannel.Main
+                inputLabel { +"Channel" }
+                select {
+                    attrs.renderValue<String> { it.asTextNode() }
+                    attrs.value(shaderInstance.shaderChannel.id)
+                    attrs.onChangeFunction = handleSelectShaderChannel
+
+                    menuItem {
+                        attrs["value"] = main.id
+                        listItemIcon { icon(CommonIcons.ShaderChannel) }
+                        listItemText { +"${main.id.englishize()} (default)" }
+                    }
+
+                    divider {}
+
+                    val shaderChannels = editingShader.getShaderChannelOptions(excludeMain = true)
+                    shaderChannels.forEach { shaderChannel ->
+                        if (shaderChannel.id != main.id) {
+                            menuItem {
+                                attrs["value"] = shaderChannel.id
+                                listItemIcon { icon(CommonIcons.ShaderChannel) }
+                                listItemText { +shaderChannel.id.englishize() }
+                            }
+                        }
+                    }
+
+                    divider {}
+                    menuItem {
+                        attrs["value"] = "__new__"
+                        listItemIcon { icon(CommonIcons.Add) }
+                        listItemText { +"New Channel…" }
+                    }
+                }
+                formHelperText { +"This shader's channel." }
+            }
+        }
+
+        div(+shaderEditorStyles.shaderPriority) {
+            formControl {
+                textField {
+                    attrs.label { +"Priority" }
+                    attrs.type = InputType.number
+                    attrs.value = shaderInstance.priority
+                    attrs.onChangeFunction = { event: Event ->
+                        val priorityStr = event.target.value
+                        handleUpdate { priority = priorityStr.toFloat() }
+                    }
+                }
+                formHelperText { +"This shader's priority in the patch." }
+            }
+        }
+
+        div(+shaderEditorStyles.shaderReturnType) {
+            val openShader = editingShader.openShader
+
+            if (openShader != null) {
+                val outputPort = openShader.outputPort
+
+                typography { b { +"Returns: " } }
+                typography {
+                    if (outputPort.contentType.isUnknown()) {
+                        attrs.color = TypographyColor.error
+                    }
+                    +outputPort.contentType.title
+                }
+
+                br {}
+
+                typography { b { +"Shader Type: " } }
+                typography {
+                    +"${openShader.shaderType.title} (${openShader.shaderDialect.title})"
+                }
+            }
+
+        }
+    }
+}
+
+external interface ShaderPropertiesEditorProps : RProps {
+    var editableManager: EditableManager
+    var editingShader: EditingShader
+    var mutableShaderInstance: MutableShaderInstance
+}
+
+fun RBuilder.shaderPropertiesEditor(handler: RHandler<ShaderPropertiesEditorProps>) =
+    child(ShaderPropertiesEditor, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/editor/layout/LayoutSizeCell.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/editor/layout/LayoutSizeCell.kt
@@ -73,7 +73,7 @@ val LayoutSizeCell = xComponent<LayoutSizeCellProps>("LayoutSizeCell") { props -
             }
         }
 
-        gridSizeMenuAnchor?.let { gridSizeMenu ->
+        gridSizeMenuAnchor?.let {
             menu {
                 attrs.anchorEl(gridSizeMenuAnchor)
                 attrs.anchorOrigin {

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/Slider.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/Slider.kt
@@ -38,7 +38,6 @@ private val slider = xComponent<SliderProps>("Slider") { props ->
     val domain = memo(props.minValue, props.maxValue) {
         arrayOf(props.minValue, props.maxValue)
     }
-    val stepValue = memo { props.stepValue ?: 0.01f }
 
     div(+styles.wrapper) {
         label(+styles.label) {
@@ -51,7 +50,7 @@ private val slider = xComponent<SliderProps>("Slider") { props ->
             attrs.vertical = true
             attrs.reversed = props.reversed
             attrs.mode = 1
-            attrs.step = stepValue
+            attrs.step = props.stepValue ?: (props.maxValue - props.minValue) / 256
             attrs.domain = domain.asDynamic()
             attrs.onSlideStart = disableScroll.asDynamic()
             attrs.onSlideEnd = enableScroll.asDynamic()

--- a/src/jsMain/kotlin/baaahs/show/live/ControlViews.kt
+++ b/src/jsMain/kotlin/baaahs/show/live/ControlViews.kt
@@ -2,12 +2,9 @@ package baaahs.show.live
 
 import baaahs.app.ui.controls.*
 import baaahs.control.*
-import baaahs.jsx.ColorPicker
-import baaahs.jsx.ColorPickerProps
 import baaahs.plugin.core.OpenTransitionControl
 import baaahs.ui.View
 import baaahs.ui.renderWrapper
-import kotlinext.js.jsObject
 
 actual fun getControlViews(): ControlViews = object : ControlViews {
     override fun forButton(openButtonControl: OpenButtonControl, controlProps: ControlProps): View = renderWrapper {
@@ -25,9 +22,10 @@ actual fun getControlViews(): ControlViews = object : ControlViews {
     }
 
     override fun forColorPicker(openColorPickerControl: OpenColorPickerControl, controlProps: ControlProps) = renderWrapper {
-        child(ColorPicker, jsObject<ColorPickerProps> {
-            gadget = openColorPickerControl.colorPicker
-        }) {}
+        colorPickerControl {
+            attrs.controlProps = controlProps
+            attrs.colorPickerControl = openColorPickerControl
+        }
     }
 
     override fun forSlider(openSlider: OpenSliderControl, controlProps: ControlProps) = renderWrapper {

--- a/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
+++ b/src/jvmTest/kotlin/baaahs/show/mutable/EditingShaderSpec.kt
@@ -222,7 +222,7 @@ object EditingShaderSpec : Spek({
                             - Main Channel
                             Data Source:
                             - BeatLink
-                            - Custom slider Slider
+                            - Custom slider Slider (advanced)
                             * The Scale Slider
                             - Time
                         """.trimIndent())
@@ -277,9 +277,9 @@ object EditingShaderSpec : Spek({
                             Channel:
                             - Main Channel
                             Data Source:
-                            - BeatLink
+                            - BeatLink (advanced)
                             * Time
-                            - Time Slider
+                            - Time Slider (advanced)
                         """.trimIndent())
                 }
 
@@ -290,6 +290,7 @@ object EditingShaderSpec : Spek({
                             Channel:
                             * Main Channel
                             Data Source:
+                            - Date (advanced)
                             - In Color Color Picker
                         """.trimIndent())
                 }
@@ -308,6 +309,7 @@ object EditingShaderSpec : Spek({
                                     * Main Channel
                                     - Other Channel
                                     Data Source:
+                                    - Date (advanced)
                                     - In Color Color Picker
                                 """.trimIndent())
                         }
@@ -322,6 +324,7 @@ object EditingShaderSpec : Spek({
                                     Channel:
                                     * Main Channel
                                     Data Source:
+                                    - Date (advanced)
                                     - In Color Color Picker
                                 """.trimIndent())
                         }
@@ -429,7 +432,8 @@ fun List<LinkOption>?.stringify(): String {
             groupName?.let { lines.add(it) }
         }
         val selected = if (linkOption == first()) "*" else "-"
-        lines.add("$selected ${linkOption.title}")
+        val advanced = if (linkOption.isAdvanced) " (advanced)" else ""
+        lines.add("$selected ${linkOption.title}$advanced")
     }
     return lines.joinToString("\n")
 }


### PR DESCRIPTION
Add dialect to support [Interactive Shader Format](https://docs.isf.video/).

* Top-level JSON attributes are ignored.
* ISF filters and transitions are not yet supported, only generators.
* Multi-pass shaders and persistent buffers are not yet supported.
* `event`, `long`, `point2D`, `image`, `audio`, and `audioFFT` input types are not yet supported.

Other stuff:
* Add support for `bool` uniforms for all dialects.
* Implement datasource for `date` content type
* Fix various bugs.