### PR TITLE
Errors in datasource declaration comments don't crash UI

### DIFF
--- a/src/commonMain/kotlin/baaahs/gl/patch/PatchOptions.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/PatchOptions.kt
@@ -149,6 +149,8 @@ class PatchOptions(
                     options.add(PortLinkOption(MutableDataSourcePort(dataSource), isPluginRef = true))
                 } catch (e: LinkException) {
                     logger.warn(e) { "Incorrect plugin reference." }
+                } catch (e: Exception) {
+                    logger.warn(e) { "Error resolving data source for ${inputPort.id}." }
                 }
             }
 

--- a/src/commonMain/kotlin/baaahs/plugin/Plugins.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/Plugins.kt
@@ -398,6 +398,12 @@ sealed class Plugins(
 
     }
 
+    // TODO: We should report errors back somehow.
+    private fun safeBuild(
+        builder: DataSourceBuilder<out DataSource>,
+        inputPort: InputPort
+    ): DataSource? = builder.safeBuild(inputPort)
+
     companion object {
         private val logger = Logger<Plugins>()
 
@@ -516,7 +522,7 @@ sealed class Plugins(
             inputPort: InputPort
         ) = (
                 dataSourceBuilders.byContentType[contentType]
-                    ?.map { it.build(inputPort) }
+                    ?.mapNotNull { safeBuild(it, inputPort) }
                     ?: emptyList()
                 )
     }
@@ -538,7 +544,7 @@ sealed class Plugins(
         fun buildForContentType(contentType: ContentType, inputPort: InputPort): List<DataSource> {
             return all.flatMap { fixtureType ->
                 fixtureType.dataSourceBuilders.filter { dataSource -> dataSource.contentType == contentType }
-            }.map { it.build(inputPort) }
+            }.mapNotNull { safeBuild(it, inputPort) }
         }
     }
 


### PR DESCRIPTION
Fixes #482.

TODO: should report errors back to the UI.