### PR TITLE
Visualizers honor model scale

### DIFF
--- a/src/commonMain/kotlin/baaahs/Color.kt
+++ b/src/commonMain/kotlin/baaahs/Color.kt
@@ -300,6 +300,9 @@ data class Color(val argb: Int) {
         @JsName("fromInts")
         fun from(r: Int, g: Int, b: Int) = Color(r, g, b)
 
+        @JsName("fromBytes")
+        fun from(r: Byte, g: Byte, b: Byte) = Color(r, g, b)
+
         @JsName("fromString")
         fun from(hex: String): Color {
             var hexDigits = hex.trimStart('#')

--- a/src/commonMain/kotlin/baaahs/dmx/LixadaMiniMovingHead.kt
+++ b/src/commonMain/kotlin/baaahs/dmx/LixadaMiniMovingHead.kt
@@ -1,6 +1,7 @@
 package baaahs.dmx
 
 import baaahs.Color
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHead
 import baaahs.model.MovingHeadAdapter
 import baaahs.toRadians
@@ -30,7 +31,12 @@ object LixadaMiniMovingHead : MovingHeadAdapter {
     override val tiltMotorSpeed: Float = 1f
 
     override val visualizerInfo: MovingHeadAdapter.VisualizerInfo
-        get() = MovingHeadAdapter.VisualizerInfo(2.5f, 2f, 3f, 1f)
+        get() = MovingHeadAdapter.VisualizerInfo(
+            canRadius = 2.5f.`in`,
+            lensRadius = 2f.`in`,
+            canLengthInFrontOfLight = 3f.`in`,
+            canLengthBehindLight = 1f.`in`
+        )
 
     override fun newBuffer(dmxBuffer: Dmx.Buffer) = Buffer(dmxBuffer)
 
@@ -63,7 +69,7 @@ object LixadaMiniMovingHead : MovingHeadAdapter {
         }
 
         var color: Color
-            get() = Color(dmxBuffer[Channel.RED], dmxBuffer[Channel.GREEN], dmxBuffer[Channel.BLUE])
+            get() = Color.from(dmxBuffer[Channel.RED], dmxBuffer[Channel.GREEN], dmxBuffer[Channel.BLUE])
             set(value) {
                 dmxBuffer[Channel.RED] = value.redI.toByte()
                 dmxBuffer[Channel.GREEN] = value.greenI.toByte()
@@ -73,4 +79,6 @@ object LixadaMiniMovingHead : MovingHeadAdapter {
         override var colorWheelPosition: Float get() = error("not supported")
             set(_) {}
     }
+
+    private val Float.`in` get() = ModelUnit.Inches.toCm(this)
 }

--- a/src/commonMain/kotlin/baaahs/dmx/Shenzarpy.kt
+++ b/src/commonMain/kotlin/baaahs/dmx/Shenzarpy.kt
@@ -1,6 +1,7 @@
 package baaahs.dmx
 
 import baaahs.Color
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHead
 import baaahs.model.MovingHeadAdapter
 import baaahs.toRadians
@@ -35,7 +36,12 @@ object Shenzarpy : MovingHeadAdapter {
     override val tiltMotorSpeed: Float = 1.3f
 
     override val visualizerInfo: MovingHeadAdapter.VisualizerInfo
-        get() = MovingHeadAdapter.VisualizerInfo(5f, 3f, 9f, 3f)
+        get() = MovingHeadAdapter.VisualizerInfo(
+            canRadius = 5f.`in`,
+            lensRadius = 3f.`in`,
+            canLengthInFrontOfLight = 9f.`in`,
+            canLengthBehindLight = 3f.`in`
+        )
 
     override fun newBuffer(dmxBuffer: Dmx.Buffer) = Buffer(dmxBuffer)
 
@@ -107,4 +113,6 @@ object Shenzarpy : MovingHeadAdapter {
 
         override val offset = ordinal
     }
+
+    private val Float.`in` get() = ModelUnit.Inches.toCm(this)
 }

--- a/src/commonMain/kotlin/baaahs/model/ModelData.kt
+++ b/src/commonMain/kotlin/baaahs/model/ModelData.kt
@@ -39,6 +39,9 @@ enum class ModelUnit(val display: String, val inCentimeters: Double) {
     fun fromCm(value: Double) = value / inCentimeters
     fun fromCm(value: Float): Float = (value / inCentimeters).toFloat()
 
+    fun fromCm(range: ClosedFloatingPointRange<Float>) =
+        fromCm(range.start) .. fromCm(range.endInclusive)
+
     companion object {
         val default = Centimeters
     }

--- a/src/commonMain/kotlin/baaahs/model/MovingHead.kt
+++ b/src/commonMain/kotlin/baaahs/model/MovingHead.kt
@@ -57,6 +57,7 @@ interface MovingHeadAdapter {
         val map = all.associateBy { it.id }
     }
 
+    /** All dimensions in centimeters. */
     data class VisualizerInfo(
         val canRadius: Float,
         val lensRadius: Float,

--- a/src/commonMain/kotlin/baaahs/visualizer/EntityAdapter.kt
+++ b/src/commonMain/kotlin/baaahs/visualizer/EntityAdapter.kt
@@ -3,7 +3,11 @@ package baaahs.visualizer
 import baaahs.model.*
 import baaahs.sim.SimulationEnv
 
-expect class EntityAdapter(simulationEnv: SimulationEnv, isEditing: Boolean = false) : Adapter<Model.Entity> {
+expect class EntityAdapter(
+    simulationEnv: SimulationEnv,
+    units: ModelUnit,
+    isEditing: Boolean = false
+) : Adapter<Model.Entity> {
     fun createEntityGroupVisualizer(objGroup: Model.EntityGroup): ItemVisualizer<Model.EntityGroup>
     fun createLightBarVisualizer(lightBar: LightBar): ItemVisualizer<LightBar>
     fun createLightRingVisualizer(lightRing: LightRing): ItemVisualizer<LightRing>

--- a/src/commonMain/kotlin/baaahs/visualizer/IVisualizer.kt
+++ b/src/commonMain/kotlin/baaahs/visualizer/IVisualizer.kt
@@ -1,6 +1,10 @@
 package baaahs.visualizer
 
+import baaahs.model.ModelUnit
+
 interface IVisualizer {
+    var units: ModelUnit
+
     fun add(itemVisualizer: ItemVisualizer<*>)
     fun clear()
 }

--- a/src/commonMain/kotlin/baaahs/visualizer/movers/MovingHeadVisualizer.kt
+++ b/src/commonMain/kotlin/baaahs/visualizer/movers/MovingHeadVisualizer.kt
@@ -1,6 +1,7 @@
 package baaahs.visualizer.movers
 
 import baaahs.Color
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHead
 import baaahs.model.MovingHeadAdapter
 import baaahs.util.Clock
@@ -66,7 +67,11 @@ fun MovingHeadAdapter.colorAtPosition(position: Float, next: Boolean = false): C
     return colorWheelColors[colorIndex].color
 }
 
-expect class Cone(movingHeadAdapter: MovingHeadAdapter, colorMode: ColorMode = ColorMode.Rgb) {
+expect class Cone(
+    movingHeadAdapter: MovingHeadAdapter,
+    units: ModelUnit,
+    colorMode: ColorMode = ColorMode.Rgb
+) {
     fun addTo(parent: VizObj)
 
     fun update(state: State)

--- a/src/commonTest/kotlin/baaahs/TestMovingHeadAdapter.kt
+++ b/src/commonTest/kotlin/baaahs/TestMovingHeadAdapter.kt
@@ -2,6 +2,7 @@ package baaahs
 
 import baaahs.dmx.Dmx
 import baaahs.dmx.Shenzarpy
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHead
 import baaahs.model.MovingHeadAdapter
 
@@ -25,7 +26,12 @@ class TestMovingHeadAdapter(
     override val tiltMotorSpeed: Float = 1f,
 
     override val visualizerInfo: MovingHeadAdapter.VisualizerInfo =
-        MovingHeadAdapter.VisualizerInfo(5f, 3f, 9f, 3f),
+        MovingHeadAdapter.VisualizerInfo(
+            canRadius = 5f.`in`,
+            lensRadius = 3f.`in`,
+            canLengthInFrontOfLight = 9f.`in`,
+            canLengthBehindLight = 3f.`in`
+        ),
 
     override val shutterChannel: Dmx.Channel = TestChannel(6)
 ) : MovingHeadAdapter {
@@ -47,3 +53,5 @@ class TestMovingHeadAdapter(
 
     class TestChannel(override val offset: Int) : Dmx.Channel
 }
+
+private val Float.`in` get() = ModelUnit.Inches.toCm(this)

--- a/src/commonTest/kotlin/baaahs/visualizer/FakeVisualizer.kt
+++ b/src/commonTest/kotlin/baaahs/visualizer/FakeVisualizer.kt
@@ -1,6 +1,9 @@
 package baaahs.visualizer
 
+import baaahs.model.ModelUnit
+
 class FakeVisualizer(
+    override var units: ModelUnit,
     val itemVisualizers: MutableList<ItemVisualizer<*>> = mutableListOf()
 ) : IVisualizer {
     override fun add(itemVisualizer: ItemVisualizer<*>) {

--- a/src/commonTest/kotlin/baaahs/visualizer/remote/RemoteVisualizerClientSpec.kt
+++ b/src/commonTest/kotlin/baaahs/visualizer/remote/RemoteVisualizerClientSpec.kt
@@ -12,12 +12,12 @@ import baaahs.geom.Vector3F
 import baaahs.gl.testPlugins
 import baaahs.io.PubSubRemoteFsClientBackend
 import baaahs.model.FakeModelEntity
+import baaahs.model.ModelUnit
 import baaahs.scene.OpenScene
 import baaahs.scene.SceneMonitor
 import baaahs.sim.FakeNetwork
 import baaahs.sim.SimulationEnv
 import baaahs.sm.brain.proto.Ports
-import baaahs.visualizer.EntityAdapter
 import baaahs.visualizer.FakeItemVisualizer
 import baaahs.visualizer.FakeVisualizer
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
@@ -52,12 +52,12 @@ object RemoteVisualizerClientSpec : Spek({
                     .listenWebSocket("/ws/visualizer") { server }
             }
         }
-        val fakeVisualizer by value { FakeVisualizer() }
+        val fakeVisualizer by value { FakeVisualizer(ModelUnit.Centimeters) }
         val client by value {
             RemoteVisualizerClient(
                 clientLink, serverLink.myAddress,
                 fakeVisualizer, sceneManager, sceneMonitor,
-                EntityAdapter(SimulationEnv {  }), testPlugins()
+                SimulationEnv { }, testPlugins()
             )
         }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/model/ModelEditorView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/model/ModelEditorView.kt
@@ -31,20 +31,21 @@ private val ModelEditorView = xComponent<ModelEditorProps>("ModelEditor") { prop
     val appContext = useContext(appContext)
     val styles = appContext.allStyles.modelEditor
 
-    val entityAdapter = memo {
+    val mutableModel = props.mutableScene.model
+    val entityAdapter = memo(mutableModel.units) {
         EntityAdapter(
             SimulationEnv {
                 component(appContext.clock)
                 component(FakeDmxUniverse())
                 component<PixelArranger>(SwirlyPixelArranger(0.2f, 3f))
             },
+            mutableModel.units,
             true
         )
     }
 
     val lastSelectedEntity = ref<Model.Entity>(null)
 
-    val mutableModel = props.mutableScene.model
     val visualizer = memo(entityAdapter, props.onEdit) {
         ModelVisualEditor(mutableModel, appContext.clock, entityAdapter) {
             props.onEdit()

--- a/src/jsMain/kotlin/baaahs/app/ui/preview/ClientPreview.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/preview/ClientPreview.kt
@@ -53,9 +53,10 @@ class ClientPreview(
             component(clock)
             component(dmxUniverse)
             component<PixelArranger>(pixelArranger)
-            component(visualizer)
         }
-        val adapter = EntityAdapter(simulationEnv)
+        val adapter = EntityAdapter(simulationEnv, model.units)
+        theVisualizer.clear()
+        theVisualizer.units = model.units
 
         val allFixtures = model
             .allEntities.mapNotNull { entity ->

--- a/src/jsMain/kotlin/baaahs/di/JsModules.kt
+++ b/src/jsMain/kotlin/baaahs/di/JsModules.kt
@@ -29,7 +29,6 @@ import baaahs.sim.SimulationEnv
 import baaahs.sm.brain.proto.Ports
 import baaahs.util.Clock
 import baaahs.util.JsClock
-import baaahs.visualizer.EntityAdapter
 import baaahs.visualizer.PixelArranger
 import baaahs.visualizer.SwirlyPixelArranger
 import baaahs.visualizer.Visualizer
@@ -108,16 +107,13 @@ class JsMonitorWebClientModule : KModule {
             scoped { FileDialog() }
             scoped<IFileDialog> { get<FileDialog>() }
             scoped { Notifier(get()) }
-            scoped { Visualizer(get()) }
             scoped {
                 val simulationEnv = SimulationEnv {
                     component(get<Clock>())
                     component(FakeDmxUniverse())
                     component<PixelArranger>(SwirlyPixelArranger(0.2f, 3f))
-                    component(get<Visualizer>())
                 }
-                val entityAdapter = EntityAdapter(simulationEnv)
-                RemoteVisualizerClient(get(), pinkyAddress(), get<Visualizer>(), get(), get(), entityAdapter, get())
+                RemoteVisualizerClient(get(), pinkyAddress(), get<Visualizer>(), get(), get(), simulationEnv, get())
             }
             scoped { MonitorUi(get(), get()) }
         }

--- a/src/jsMain/kotlin/baaahs/sim/BrainSurfaceSimulation.kt
+++ b/src/jsMain/kotlin/baaahs/sim/BrainSurfaceSimulation.kt
@@ -27,7 +27,8 @@ actual class BrainSurfaceSimulation actual constructor(
         pixelPositions,
         surfaceGeometry.panelNormal,
         surface.transformation,
-        PixelFormat.default
+        PixelFormat.default,
+        adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
     ) }
 
     val brain by lazy {
@@ -50,7 +51,7 @@ actual class BrainSurfaceSimulation actual constructor(
         }
 
     override val itemVisualizer: SurfaceVisualizer by lazy {
-        SurfaceVisualizer(surface, surfaceGeometry, vizPixels)
+        SurfaceVisualizer(surface, adapter, surfaceGeometry, vizPixels)
     }
 
     override val previewFixture: Fixture by lazy {

--- a/src/jsMain/kotlin/baaahs/sim/FixturesSimulator.kt
+++ b/src/jsMain/kotlin/baaahs/sim/FixturesSimulator.kt
@@ -44,9 +44,7 @@ class FixturesSimulator(
         component(dmxUniverse)
         component(pixelArranger)
         component(wledsSimulator)
-        component(visualizer)
     }
-    private val entityAdapter = EntityAdapter(simulationEnv)
     private var fixtureSimulations: Map<Model.Entity, FixtureSimulation> = emptyMap()
 
     init {
@@ -70,6 +68,9 @@ class FixturesSimulator(
                         }
                     }
 
+                    val entityAdapter = EntityAdapter(simulationEnv, newOpenScene.model.units)
+                    visualizer.facade.clear()
+                    visualizer.facade.units = entityAdapter.units
                     buildMap {
                         newOpenScene.model.visit { entity ->
                             entity.createFixtureSimulation(entityAdapter)

--- a/src/jsMain/kotlin/baaahs/sim/LightRingSimulation.kt
+++ b/src/jsMain/kotlin/baaahs/sim/LightRingSimulation.kt
@@ -14,7 +14,7 @@ actual class LightRingSimulation actual constructor(
     override val pixelLocations by lazy { lightRing.calculatePixelLocalLocations(pixelCount) }
 
     override val itemVisualizer: LightRingVisualizer
-            by lazy { LightRingVisualizer(lightRing, vizPixels) }
+            by lazy { LightRingVisualizer(lightRing, adapter, vizPixels) }
 
 
     companion object {

--- a/src/jsMain/kotlin/baaahs/sim/PixelArraySimulation.kt
+++ b/src/jsMain/kotlin/baaahs/sim/PixelArraySimulation.kt
@@ -24,7 +24,8 @@ actual abstract class PixelArraySimulation actual constructor(
             pixelLocations.map { it.toVector3() }.toTypedArray(),
             LightBarSimulation.pixelVisualizationNormal,
             pixelArray.transformation,
-            PixelFormat.default
+            PixelFormat.default,
+            adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
         )
     }
 

--- a/src/jsMain/kotlin/baaahs/visualizer/EntityAdapter.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/EntityAdapter.kt
@@ -6,6 +6,7 @@ import baaahs.visualizer.movers.MovingHeadVisualizer
 
 actual class EntityAdapter actual constructor(
     val simulationEnv: SimulationEnv,
+    val units: ModelUnit,
     private val isEditing: Boolean
 ) : Adapter<Model.Entity> {
     override fun createVisualizer(entity: Model.Entity): ItemVisualizer<Model.Entity> {
@@ -20,7 +21,7 @@ actual class EntityAdapter actual constructor(
         LightBarVisualizer(lightBar, this)
 
     actual fun createLightRingVisualizer(lightRing: LightRing): ItemVisualizer<LightRing> =
-        LightRingVisualizer(lightRing, null)
+        LightRingVisualizer(lightRing, this, null)
 
     actual fun createMovingHeadVisualizer(movingHead: MovingHead): ItemVisualizer<MovingHead> =
         MovingHeadVisualizer(movingHead, this)
@@ -29,5 +30,5 @@ actual class EntityAdapter actual constructor(
         PolyLineVisualizer(polyLine, this, null)
 
     actual fun createSurfaceVisualizer(surface: Model.Surface): ItemVisualizer<Model.Surface> =
-        SurfaceVisualizer(surface, SurfaceGeometry(surface))
+        SurfaceVisualizer(surface, this, SurfaceGeometry(surface))
 }

--- a/src/jsMain/kotlin/baaahs/visualizer/LightRingVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/LightRingVisualizer.kt
@@ -10,6 +10,7 @@ import three_ext.clear
 
 class LightRingVisualizer(
     lightRing: LightRing,
+    private val adapter: EntityAdapter,
     vizPixels: VizPixels?
 ) : BaseEntityVisualizer<LightRing>(lightRing) {
     private val ringMesh = Mesh<RingGeometry, MeshBasicMaterial>()
@@ -80,7 +81,8 @@ class LightRingVisualizer(
             remoteConfig.pixelLocations.map { it.toVector3() }.toTypedArray(),
             LightBarSimulation.pixelVisualizationNormal,
             item.transformation,
-            remoteConfig.pixelFormat
+            remoteConfig.pixelFormat,
+            adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
         )
     }
 

--- a/src/jsMain/kotlin/baaahs/visualizer/ModelVisualEditor.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/ModelVisualEditor.kt
@@ -18,7 +18,7 @@ import three_ext.toVector3F
 class ModelVisualEditor(
     var mutableModel: MutableModel,
     clock: Clock,
-    private val adapter: EntityAdapter,
+    adapter: EntityAdapter,
     private val onChange: () -> Unit
 ) : BaseVisualizer(clock) {
     override val facade = Facade()
@@ -58,6 +58,11 @@ class ModelVisualEditor(
     }
 
     private val transformControls = findExtension(TransformControlsExtension::class).transformControls
+
+    init {
+        clear()
+        units = model.units
+    }
 
     private val groupVisualizer =
         GroupVisualizer("Model: ${model.name}", model.entities, adapter).also {
@@ -177,6 +182,8 @@ class ModelVisualEditor(
         if (modelData != newData) {
             modelData = newData
             model = newData.open()
+            clear()
+            units = model.units
 
             groupVisualizer.updateChildren(model.entities)
         }

--- a/src/jsMain/kotlin/baaahs/visualizer/SurfaceVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/SurfaceVisualizer.kt
@@ -8,6 +8,7 @@ import three.js.*
 
 class SurfaceVisualizer(
     private val surface: Model.Surface,
+    private val adapter: EntityAdapter,
     val surfaceGeometry: SurfaceGeometry,
     vizPixels: VizPixels? = null
 ) : BaseEntityVisualizer<Model.Surface>(surface) {
@@ -56,7 +57,8 @@ class SurfaceVisualizer(
             remoteConfig.pixelLocations.map { it.toVector3() }.toTypedArray(),
             surfaceGeometry.panelNormal,
             surface.transformation,
-            remoteConfig.pixelFormat
+            remoteConfig.pixelFormat,
+            adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
         )
     }
 

--- a/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
@@ -22,7 +22,7 @@ class VizPixels(
     val normal: Vector3,
     val transformation: Matrix4F,
     val pixelFormat: PixelFormat,
-    val pixelSizeRange: ClosedFloatingPointRange<Float> = 2f..5f
+    val pixelSizeRange: ClosedFloatingPointRange<Float>
 ) : Pixels {
     override val size = positions.size
     private val pixGeometry = BufferGeometry()
@@ -80,7 +80,7 @@ class VizPixels(
     }
 
     override fun get(i: Int): Color {
-        return Color(colorsAsInts[i])
+        return Color.from(colorsAsInts[i])
     }
 
     override fun set(i: Int, color: Color) {
@@ -173,5 +173,7 @@ class VizPixels(
             { println("progress!") },
             { println("error!") }
         )
+
+        val diffusedLedRangeCm: ClosedFloatingPointRange<Float> = 2f..5f
     }
 }

--- a/src/jsMain/kotlin/baaahs/visualizer/movers/Beam.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/movers/Beam.kt
@@ -1,5 +1,6 @@
 package baaahs.visualizer.movers
 
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHead
 import baaahs.model.MovingHeadAdapter
 import three.js.Group
@@ -11,19 +12,19 @@ interface Beam {
     fun update(state: State)
 
     companion object {
-        fun selectFor(movingHeadAdapter: MovingHeadAdapter): Beam {
+        fun selectFor(movingHeadAdapter: MovingHeadAdapter, units: ModelUnit): Beam {
             return when (movingHeadAdapter.colorModel) {
-                MovingHead.ColorModel.ColorWheel -> ColorWheelBeam(movingHeadAdapter)
-                MovingHead.ColorModel.RGB -> RgbBeam(movingHeadAdapter)
-                MovingHead.ColorModel.RGBW -> RgbBeam(movingHeadAdapter)
+                MovingHead.ColorModel.ColorWheel -> ColorWheelBeam(movingHeadAdapter, units)
+                MovingHead.ColorModel.RGB -> RgbBeam(movingHeadAdapter, units)
+                MovingHead.ColorModel.RGBW -> RgbBeam(movingHeadAdapter, units)
             }
         }
     }
 }
 
-class ColorWheelBeam(movingHeadAdapter: MovingHeadAdapter) : Beam {
-    private val primaryCone = Cone(movingHeadAdapter, ColorMode.Primary)
-    private val secondaryCone = Cone(movingHeadAdapter, ColorMode.Secondary)
+class ColorWheelBeam(movingHeadAdapter: MovingHeadAdapter, units: ModelUnit) : Beam {
+    private val primaryCone = Cone(movingHeadAdapter, units, ColorMode.Primary)
+    private val secondaryCone = Cone(movingHeadAdapter, units, ColorMode.Secondary)
     private val cones = Group().also {
         primaryCone.addTo(it)
         secondaryCone.addTo(it)
@@ -38,8 +39,8 @@ class ColorWheelBeam(movingHeadAdapter: MovingHeadAdapter) : Beam {
     }
 }
 
-class RgbBeam(movingHeadAdapter: MovingHeadAdapter) : Beam {
-    private val cone = Cone(movingHeadAdapter)
+class RgbBeam(movingHeadAdapter: MovingHeadAdapter, units: ModelUnit) : Beam {
+    private val cone = Cone(movingHeadAdapter, units)
     private val cones = Group().also {
         cone.addTo(it)
     }

--- a/src/jsMain/kotlin/baaahs/visualizer/movers/Cone.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/movers/Cone.kt
@@ -1,6 +1,7 @@
 package baaahs.visualizer.movers
 
 import baaahs.Color
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHeadAdapter
 import baaahs.visualizer.VizObj
 import baaahs.visualizer.toVector3
@@ -10,9 +11,10 @@ import kotlin.math.PI
 
 actual class Cone actual constructor(
     private val movingHeadAdapter: MovingHeadAdapter,
+    private val units: ModelUnit,
     private val colorMode: ColorMode
 ) {
-    private val coneLength = 1000.0
+    private val coneLength = 1000.0.cm
 
     private val clipPlane = Plane(Vector3(0, 0, Float.MAX_VALUE), 0)
 
@@ -26,12 +28,15 @@ actual class Cone actual constructor(
             clippingPlanes = arrayOf(clipPlane)
         }
     }
-    private val visualizerInfo = movingHeadAdapter.visualizerInfo
-    private val innerGeometry = CylinderGeometry(visualizerInfo.lensRadius * .4, 20, coneLength, openEnded = true)
-        .also {
-            it.translate(0.0, -coneLength / 2 - visualizerInfo.canLength / 2, 0.0)
-            it.rotateX(PI)
-        }
+    private val lensRadius = movingHeadAdapter.visualizerInfo.lensRadius.cm
+    private val canLength = movingHeadAdapter.visualizerInfo.canLength.cm
+
+    private val innerGeometry =
+        CylinderGeometry(lensRadius * .4, lensRadius * 6, coneLength, openEnded = true)
+            .also {
+                it.translate(0.0, -coneLength / 2 - canLength / 2, 0.0)
+                it.rotateX(PI)
+            }
     private val inner = Mesh(innerGeometry, innerMaterial)
 
     private val outerBaseOpacity = .4
@@ -45,11 +50,12 @@ actual class Cone actual constructor(
             clippingPlanes = arrayOf(clipPlane)
         }
     }
-    private val outerGeometry = CylinderGeometry(visualizerInfo.lensRadius, 50, coneLength, openEnded = true)
-        .also {
-            it.translate(0.0, -coneLength / 2 - visualizerInfo.canLength / 2, 0.0)
-            it.rotateX(PI)
-        }
+    private val outerGeometry =
+        CylinderGeometry(lensRadius, lensRadius * 16, coneLength, openEnded = true)
+            .also {
+                it.translate(0.0, -coneLength / 2 - canLength / 2, 0.0)
+                it.rotateX(PI)
+            }
     private val outer = Mesh(outerGeometry, outerMaterial)
 
     private val baseOpacities = listOf(innerBaseOpacity, outerBaseOpacity)
@@ -73,8 +79,8 @@ actual class Cone actual constructor(
             val colorSplit = (state.colorWheelPosition * movingHeadAdapter.colorWheelColors.size) % 1f
             val start = Vector3(
                 0,
-                visualizerInfo.canLength,
-                visualizerInfo.lensRadius * (colorSplit - .5)
+                canLength,
+                lensRadius * (colorSplit - .5)
             )
             val end = Vector3(
                 0,
@@ -98,4 +104,8 @@ actual class Cone actual constructor(
             material.visible = dimmer > .01f
         }
     }
+
+    private val Int.cm: Double get() = units.fromCm(this.toDouble())
+    private val Float.cm: Float get() = units.fromCm(this)
+    private val Double.cm: Double get() = units.fromCm(this)
 }

--- a/src/jsMain/kotlin/baaahs/visualizer/movers/MovingHeadVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/movers/MovingHeadVisualizer.kt
@@ -22,7 +22,7 @@ class MovingHeadVisualizer(
     private val clock = adapter.simulationEnv[Clock::class]
     private val physicalModel = PhysicalModel(movingHead.adapter, clock)
 
-    private val sharpyVisualizer = SharpyVisualizer(movingHead.adapter)
+    private val sharpyVisualizer = SharpyVisualizer(movingHead.adapter, adapter.units)
 
     init {
         update(item)

--- a/src/jsMain/kotlin/baaahs/visualizer/movers/SharpyVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/movers/SharpyVisualizer.kt
@@ -1,12 +1,14 @@
 package baaahs.visualizer.movers
 
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHeadAdapter
 import baaahs.visualizer.EntityStyle
 import three.js.*
 import kotlin.math.PI
 
 class SharpyVisualizer(
-    private val adapter: MovingHeadAdapter
+    adapter: MovingHeadAdapter,
+    private val units: ModelUnit
 ) {
     val group = Group()
 
@@ -19,47 +21,53 @@ class SharpyVisualizer(
     private val armBase = Mesh(BoxGeometry(), sharpyMaterial).also { armature.add(it) }
 
     private val can = Mesh(CylinderBufferGeometry(), sharpyMaterial).also { armature.add(it) }
-    private val beam = Beam.selectFor(adapter).also { can.add(it.vizObj) }
+    private val beam = Beam.selectFor(adapter, units).also { can.add(it.vizObj) }
 
     init {
         updateGeometry(adapter.visualizerInfo)
     }
 
+    private val Int.cm: Double get() = units.fromCm(this.toDouble())
+    private val Float.cm: Float get() = units.fromCm(this)
+    private val Double.cm: Double get() = units.fromCm(this)
+
     fun updateGeometry(visualizerInfo: MovingHeadAdapter.VisualizerInfo) {
-        with(visualizerInfo) {
-            can.geometry = CylinderBufferGeometry(canRadius, canRadius, canLength)
+        val canRadius = visualizerInfo.canRadius.cm
+        val canLength = visualizerInfo.canLength.cm
 
-            // TODO: All dimensions should be expressed in cm, then converted to the model's units.
-            val narrowGap = 1
-            val wideGap = 2
-            val armThickness = 1.5
-            val armWidth = 3
-            val armTopPadding = 2
-            val armLength = canLength / 2 + armTopPadding + wideGap
+        can.geometry = CylinderBufferGeometry(canRadius, canRadius, canLength)
 
-            leftArm.geometry = BoxGeometry(armThickness, armLength, armWidth).apply {
-                translate(-(canRadius + narrowGap + armThickness / 2), armTopPadding - armLength / 2, 0)
-            }
-            rightArm.geometry = BoxGeometry(armThickness, armLength, armWidth).apply {
-                translate(canRadius + narrowGap + armThickness / 2, armTopPadding - armLength / 2, 0)
-            }
+        // TODO: All dimensions should be expressed in cm, then converted to the model's units.
+        val narrowGap = 1.cm
+        val wideGap = 2.cm
+        val armThickness = 1.5.cm
+        val armWidth = 3.cm
+        val armTopPadding = 2.cm
+        val armLength = (canLength / 2 + armTopPadding + wideGap).cm
 
-            val baseSize = Vector3(
-                canRadius * 2 + armWidth,
-                4.0,
-                canRadius * 2 + armThickness
-            )
-            armBase.geometry = BoxGeometry(
-                (canRadius + narrowGap + armThickness) * 2,
-                armWidth, armWidth
-            ).apply {
-                translate(0, -(canLength / 2 + wideGap + armWidth / 2), 0)
-            }
-
-            base.geometry = BoxGeometry(baseSize.x, baseSize.y, baseSize.z).apply {
-                translate(0, -(canLength / 2 + wideGap + armWidth + narrowGap + baseSize.y / 2), 0)
-            }
+        leftArm.geometry = BoxGeometry(armThickness, armLength, armWidth).apply {
+            translate(-(canRadius + narrowGap + armThickness / 2), armTopPadding - armLength / 2, 0)
         }
+        rightArm.geometry = BoxGeometry(armThickness, armLength, armWidth).apply {
+            translate(canRadius + narrowGap + armThickness / 2, armTopPadding - armLength / 2, 0)
+        }
+
+        val baseSize = Vector3(
+            canRadius * 2 + armWidth,
+            4.0.cm,
+            canRadius * 2 + armThickness
+        )
+        armBase.geometry = BoxGeometry(
+            (canRadius + narrowGap + armThickness) * 2,
+            armWidth, armWidth
+        ).apply {
+            translate(0, -(canLength / 2 + wideGap + armWidth / 2), 0)
+        }
+
+        base.geometry = BoxGeometry(baseSize.x, baseSize.y, baseSize.z).apply {
+            translate(0, -(canLength / 2 + wideGap + armWidth + narrowGap + baseSize.y / 2), 0)
+        }
+
         group.updateMatrixWorld()
     }
 
@@ -77,5 +85,4 @@ class SharpyVisualizer(
 
         group.updateMatrixWorld()
     }
-
 }

--- a/src/jvmMain/kotlin/baaahs/visualizer/EntityAdapter.kt
+++ b/src/jvmMain/kotlin/baaahs/visualizer/EntityAdapter.kt
@@ -4,7 +4,7 @@ import baaahs.model.*
 import baaahs.sim.SimulationEnv
 
 actual class EntityAdapter actual constructor(
-    simulationEnv: SimulationEnv, isEditing: Boolean
+    simulationEnv: SimulationEnv, units: ModelUnit, isEditing: Boolean
 ) : Adapter<Model.Entity> {
     override fun createVisualizer(entity: Model.Entity): ItemVisualizer<Model.Entity> =
         TODO("not implemented")

--- a/src/jvmMain/kotlin/baaahs/visualizer/movers/Cone.kt
+++ b/src/jvmMain/kotlin/baaahs/visualizer/movers/Cone.kt
@@ -1,9 +1,14 @@
 package baaahs.visualizer.movers
 
+import baaahs.model.ModelUnit
 import baaahs.model.MovingHeadAdapter
 import baaahs.visualizer.VizObj
 
-actual class Cone actual constructor(movingHeadAdapter: MovingHeadAdapter, colorMode: ColorMode) {
+actual class Cone actual constructor(
+    movingHeadAdapter: MovingHeadAdapter,
+    units: ModelUnit,
+    colorMode: ColorMode
+) {
     actual fun addTo(parent: VizObj) {
     }
 


### PR DESCRIPTION
Stuff like LED pixel glows, 3D Sharpys, and the origin dot should be sized to fit the model's scale.