### PR TITLE
Hack to make visualizer pixels look right for BAAAHS and grids.

### DIFF
--- a/src/jsMain/kotlin/baaahs/sim/PixelArraySimulation.kt
+++ b/src/jsMain/kotlin/baaahs/sim/PixelArraySimulation.kt
@@ -25,7 +25,7 @@ actual abstract class PixelArraySimulation actual constructor(
             LightBarSimulation.pixelVisualizationNormal,
             pixelArray.transformation,
             PixelFormat.default,
-            adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
+            adapter.units.fromCm(VizPixels.undiffusedLedRangeCm)
         )
     }
 

--- a/src/jsMain/kotlin/baaahs/visualizer/LightRingVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/LightRingVisualizer.kt
@@ -82,7 +82,7 @@ class LightRingVisualizer(
             LightBarSimulation.pixelVisualizationNormal,
             item.transformation,
             remoteConfig.pixelFormat,
-            adapter.units.fromCm(VizPixels.diffusedLedRangeCm)
+            adapter.units.fromCm(VizPixels.undiffusedLedRangeCm)
         )
     }
 

--- a/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
@@ -174,6 +174,11 @@ class VizPixels(
             { println("error!") }
         )
 
-        val diffusedLedRangeCm: ClosedFloatingPointRange<Float> = 2f..5f
+        // TODO: This is dumb; instead, allow model entities to specify how their pixels appear.
+        val undiffusedLedRangeCm: ClosedFloatingPointRange<Float> =
+            2f..5f
+
+        val diffusedLedRangeCm: ClosedFloatingPointRange<Float> =
+            (2f * 2.54f)..(5f * 2.54f)
     }
 }


### PR DESCRIPTION
Use diffused pixel dimensions for surfaces (e.g. BAAAHS), and undiffused pixel dimensions for other stuff (e.g. grids). This should be configurable in the model instead of being hardcoded.