### PR TITLE
More UI optimizations

### DIFF
--- a/src/commonMain/kotlin/baaahs/client/document/EditMode.kt
+++ b/src/commonMain/kotlin/baaahs/client/document/EditMode.kt
@@ -2,6 +2,7 @@ package baaahs.client.document
 
 import baaahs.ui.Observable
 import baaahs.util.globalLaunch
+import kotlinx.coroutines.delay
 
 class EditMode(initialMode: Mode) : Observable() {
     private var mode = initialMode
@@ -17,12 +18,13 @@ class EditMode(initialMode: Mode) : Observable() {
         }
     }
 
-    fun turnOn() {
+    private fun turnOn() {
         if (mode == Mode.Never) {
             mode = Mode.Off
             notifyChanged()
 
             globalLaunch {
+                delay(10)
                 mode = Mode.On
                 notifyChanged()
             }
@@ -32,7 +34,7 @@ class EditMode(initialMode: Mode) : Observable() {
         }
     }
 
-    fun turnOff() {
+    private fun turnOff() {
         mode = Mode.Off
         notifyChanged()
     }

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/GridButtonGroupControlView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/GridButtonGroupControlView.kt
@@ -157,6 +157,7 @@ private val GridButtonGroupControlView = xComponent<GridButtonGroupProps>("GridB
                     attrs.resizeHandle = ::buildResizeHandle
                     attrs.disableDrag = !editMode.isOn
                     attrs.disableResize = !editMode.isOn
+                    attrs.isEverEditable = editMode.isAvailable
                     attrs.isDroppable = editMode.isOn
                     attrs.isBounded = false
 

--- a/src/jsMain/kotlin/baaahs/app/ui/layout/GridItemView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/layout/GridItemView.kt
@@ -1,7 +1,6 @@
 package baaahs.app.ui.layout
 
 import baaahs.app.ui.appContext
-import baaahs.app.ui.controls.Styles
 import baaahs.app.ui.controls.problemBadge
 import baaahs.show.live.ControlProps
 import baaahs.show.live.OpenControl
@@ -10,8 +9,8 @@ import baaahs.ui.and
 import baaahs.ui.unaryPlus
 import baaahs.ui.xComponent
 import kotlinx.html.js.onClickFunction
-import materialui.icon
 import kotlinx.html.org.w3c.dom.events.Event
+import materialui.icon
 import react.*
 import react.dom.div
 import react.dom.events.MouseEvent
@@ -25,6 +24,7 @@ private val GridItemView = xComponent<GridItemProps>("GridItem") { props ->
     val control = props.control
     val layout = props.controlProps.layout
     val layoutEditor = props.controlProps.layoutEditor
+    val editMode = observe(appContext.showManager.editMode)
 
     // We're inside a draggable; prevent the mousedown from starting a drag.
     val handleEditMouseDown by mouseEventHandler { e: MouseEvent<*, *> -> e.stopPropagation() }
@@ -51,22 +51,20 @@ private val GridItemView = xComponent<GridItemProps>("GridItem") { props ->
 
     problemBadge(control)
 
-    div(+styles.deleteButton and styles.deleteModeControl) {
-        attrs.onMouseDown = handleDeleteMouseDown
-        attrs.onClickFunction = handleDeleteButtonClick
+    if (editMode.isAvailable) {
+        div(+styles.deleteButton and styles.deleteModeControl) {
+            attrs.onMouseDown = handleDeleteMouseDown
+            attrs.onClickFunction = handleDeleteButtonClick
 
-        icon(mui.icons.material.Delete)
-    }
+            icon(mui.icons.material.Delete)
+        }
 
-    div(+styles.editButton and styles.editModeControl) {
-        attrs.onMouseDown = handleEditMouseDown
-        attrs.onClickFunction = handleEditButtonClick
+        div(+styles.editButton and styles.editModeControl) {
+            attrs.onMouseDown = handleEditMouseDown
+            attrs.onClickFunction = handleEditButtonClick
 
-        icon(mui.icons.material.Edit)
-    }
-
-    div(+Styles.dragHandle) {
-        icon(mui.icons.material.DragIndicator)
+            icon(mui.icons.material.Edit)
+        }
     }
 }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/layout/GridTabLayoutView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/layout/GridTabLayoutView.kt
@@ -141,6 +141,7 @@ private val GridTabLayoutView = xComponent<GridTabLayoutProps>("GridTabLayout") 
                 attrs.resizeHandle = ::buildResizeHandle
                 attrs.disableDrag = !editMode.isOn
                 attrs.disableResize = !editMode.isOn
+                attrs.isEverEditable = editMode.isAvailable
                 attrs.isDroppable = editMode.isOn
                 attrs.onDragStart = handleDragStart
                 attrs.onDragStop = handleDragStop
@@ -201,11 +202,13 @@ private val GridTabLayoutView = xComponent<GridTabLayoutProps>("GridTabLayout") 
         }
     }
 
-    Portal {
-        controlsPalette {
-            attrs.controlDisplay = controlDisplay
-            attrs.controlProps = genericControlProps
-            attrs.show = openShow
+    if (editMode.isAvailable) {
+        Portal {
+            controlsPalette {
+                attrs.controlDisplay = controlDisplay
+                attrs.controlProps = genericControlProps
+                attrs.show = openShow
+            }
         }
     }
 }

--- a/src/jsMain/kotlin/baaahs/ui/gridlayout/GridItem.kt
+++ b/src/jsMain/kotlin/baaahs/ui/gridlayout/GridItem.kt
@@ -38,6 +38,10 @@ external interface GridItemProps : Props {
 //    var maxRows: Int
     var isDraggable: Boolean
     var isResizable: Boolean
+
+    // If false, don't even render resize handles etc.
+    var isEverEditable: Boolean? // = true
+
     var static: Boolean?
     var useCSSTransforms: Boolean?
     var usePercentages: Boolean?
@@ -261,7 +265,7 @@ class GridItem(
         // This is the max possible width - doesn't go to infinity because of the width of the window
         val maxWidth = positionParams.calcGridItemPosition(0, 0, cols - x, 0).width
 
-        // Calculate min/max valraints using our min & maxes
+        // Calculate min/max constraints using our min & maxes
         val mins = positionParams.calcGridItemPosition(0, 0, minW, minH)
         val maxes = positionParams.calcGridItemPosition(0, 0, maxW, maxH)
         val minConstraints = arrayOf<Number>(mins.width, mins.height)
@@ -589,6 +593,7 @@ class GridItem(
     override fun RBuilder.render() {
         val isDraggable = props.isDraggable
         val isResizable = props.isResizable
+        val isEverEditable = props.isEverEditable ?: true
         val droppingPosition = props.droppingPosition
         val useCSSTransforms = SparkleMotion.USE_CSS_TRANSFORM // props.useCSSTransforms
 
@@ -623,11 +628,13 @@ class GridItem(
             )
         })
 
-        // Resizable support. This is usually on but the user can toggle it off.
-        newChild = mixinResizable(newChild, pos, isResizable)
+        if (isEverEditable) {
+            // Resizable support. This is usually on but the user can toggle it off.
+            newChild = mixinResizable(newChild, pos, isResizable)
 
-        // Draggable support. This is always on, except for with placeholders.
-        newChild = mixinDraggable(newChild, isDraggable)
+            // Draggable support. This is always on, except for with placeholders.
+            newChild = mixinDraggable(newChild, isDraggable)
+        }
 
         child(newChild)
     }

--- a/src/jsMain/kotlin/baaahs/ui/gridlayout/GridLayout.kt
+++ b/src/jsMain/kotlin/baaahs/ui/gridlayout/GridLayout.kt
@@ -397,6 +397,7 @@ class GridLayout(
 //                attrs.rowHeight = props.rowHeight!!
                 attrs.isDraggable = false
                 attrs.isResizable = false
+                attrs.isEverEditable = false
                 attrs.useCSSTransforms = props.useCSSTransforms
                 attrs.transformScale = props.transformScale!!
 
@@ -427,6 +428,7 @@ class GridLayout(
             }
         val disableDrag = props.disableDrag!!
         val disableResize = props.disableResize!!
+        val everEditable = props.isEverEditable
         val useCSSTransforms = props.useCSSTransforms!!
         val transformScale = props.transformScale!!
         val draggableCancel = props.draggableCancel
@@ -459,6 +461,7 @@ class GridLayout(
                 attrs.onResizeStop = ::onResizeStop
                 attrs.isDraggable = draggable
                 attrs.isResizable = resizable
+                attrs.isEverEditable = everEditable
                 attrs.useCSSTransforms = useCSSTransforms && mounted
                 attrs.usePercentages = !mounted
                 attrs.transformScale = transformScale

--- a/src/jsMain/kotlin/baaahs/ui/gridlayout/GridLayoutProps.kt
+++ b/src/jsMain/kotlin/baaahs/ui/gridlayout/GridLayoutProps.kt
@@ -84,6 +84,10 @@ external interface GridLayoutProps : PropsWithChildren {
 //
     var disableDrag: Boolean? // = true
     var disableResize: Boolean? // = true
+
+    // If false, don't even render resize handles etc.
+    var isEverEditable: Boolean? // = true
+
     var isBounded: Boolean? // = false
 
     // Uses CSS3 translate() instead of position top/left.

--- a/src/jsMain/kotlin/baaahs/ui/util.kt
+++ b/src/jsMain/kotlin/baaahs/ui/util.kt
@@ -8,6 +8,7 @@ import external.DroppableProvided
 import external.copyFrom
 import kotlinext.js.getOwnPropertyNames
 import kotlinx.css.*
+import kotlinx.html.org.w3c.dom.events.Event
 import mui.icons.material.SvgIconComponent
 import mui.material.SvgIconProps
 import mui.material.Typography
@@ -18,7 +19,6 @@ import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLInputElement
-import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.events.EventTarget
 import react.*
 import react.dom.RDOMBuilder
@@ -266,25 +266,25 @@ val Theme.paperHighContrast get() = paperContrast(.75)
 
 fun HTMLElement.fitText() {
     val parentEl = parentElement!!
-    val margin = with(window.getComputedStyle(parentEl)) {
-        marginLeft.replace("px", "").toDouble() +
-                marginRight.replace("px", "").toDouble()
-    }
-    val font = window.getComputedStyle(this).font
-    val buttonWidth = parentEl.clientWidth - margin
+    val parentStyle = window.getComputedStyle(parentEl)
+    val marginX = with(parentStyle) { marginLeft.fromPx() + marginRight.fromPx() }
+    val marginY = with(parentStyle) { marginTop.fromPx() + marginBottom.fromPx() }
+    val buttonWidth = parentEl.clientWidth - marginX
+    val buttonHeight = parentEl.clientHeight - marginY
     val canvas = document.createElement("canvas") as HTMLCanvasElement
     val ctx = canvas.context2d()
-    ctx.font = font
+    val elementStyle = window.getComputedStyle(this)
+    ctx.font = elementStyle.font
     val width = innerText.split(Regex("\\s+")).maxOf { word ->
         ctx.measureText(word).width
     }
-    style.transform =
-        if (width > buttonWidth) {
-            "scaleX(${buttonWidth / width})"
-        } else {
-            ""
-        }
+    style.transform = if (width > buttonWidth) "scaleX(${buttonWidth / width})" else ""
+
+    // This is extra dumb; we should check how many lines are likely to be rendered, not just use 2.
+    style.lineHeight = if (buttonHeight < elementStyle.lineHeight.fromPx() * 2) "1em" else ""
 }
+
+private fun String.fromPx() = replace("px", "").toDouble()
 
 fun Element.isParentOf(other: Element): Boolean {
     var current: Element? = other


### PR DESCRIPTION
* Don't render edit/delete buttons or resizable handles on controls if edit mode has never been on.
* Don't render unplaced controls palette if edit mode has never been on.
* Remove drag handle on grid items.
* Don't perform some useless work in VizPixels.
* If a button is less than twice the height of a line of text, reduce its line spacing. Yuck.