### PR TITLE
Fix henge visualization bug

### DIFF
--- a/src/jsMain/kotlin/baaahs/visualizer/LightBarVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/LightBarVisualizer.kt
@@ -155,6 +155,14 @@ abstract class PixelArrayVisualizer<T : PixelArray>(
     override val obj = Group()
 
     abstract fun getPixelLocations(): List<Vector3F>
+
+    /**
+     * Returns the segments that make up the pixel array.
+     *
+     * Note that neighboring segment vertices shouldn't coincide; that would specify
+     * that two pixels (the last and the first of their respective segments) would exist
+     * at the same point in space.
+     */
     abstract fun getSegments(): List<PolyLine.Segment>
 
     override fun applyStyle(entityStyle: EntityStyle) {

--- a/src/jsMain/kotlin/baaahs/visualizer/LightBarVisualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/LightBarVisualizer.kt
@@ -196,6 +196,10 @@ abstract class PixelArrayVisualizer<T : PixelArray>(
             lastEndVertex?.let { lastEndVertex ->
                 val connectorVector = segment.startVertex - lastEndVertex
                 val connectorLength = connectorVector.length()
+
+                // Zero-length ArrowHelpers have NaN dimensions and screw up rendering, so don't add them.
+                if (connectorLength > 0) return@let
+
                 strandGroup.add(
                     ArrowHelper(
                         connectorVector.normalize().toVector3(),


### PR DESCRIPTION
Found it!

This fixes the rendering bug, which is that an arrow drawn between the henge segments had zero length, which kicked up a `NaN` somewhere in arrow's model, which busted scene resizing, blah blah.

The underlying issue here is that the two segments of the henge have common vertices. PolyLine segments place their pixels at regular intervals from the start to end vertex, so segments like `[0,0 to 0,1], [0,1 to 1,1]` are trying to place two pixels at the same physical location `0,1`. It's kinda gross but you probably want to scooch the end vertex back by a pixel gap, or something like that.

We could definitely come up with a better way of extending `PolyLine`.