### PR TITLE
Typesafe uniforms for feeds

### DIFF
--- a/src/commonMain/kotlin/baaahs/device/PixelCountFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelCountFeed.kt
@@ -57,7 +57,7 @@ class PixelCountFeedContext(
 
     override fun bind(gl: GlContext) = object : EngineFeedContext {
         override fun bind(glslProgram: GlslProgram) = object : ProgramFeedContext {
-            private val uniform = glslProgram.getUniform(id)
+            private val uniform = glslProgram.getIntUniform(id)
 
             override val updateMode: UpdateMode
                 get() = UpdateMode.PER_FIXTURE

--- a/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
@@ -14,7 +14,6 @@ import baaahs.gl.patch.ContentType
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
-import baaahs.glsl.Uniform
 import baaahs.model.Model
 import baaahs.plugin.SerializerRegistrar
 import baaahs.plugin.classSerializer
@@ -114,7 +113,7 @@ class PixelDistanceFromEdgeFeedContext(
 
         inner class ProgramFeedContext(glslProgram: GlslProgram) : PerPixelProgramFeedContext(updateMode) {
             override val buffer: ParamBuffer get() = this@EngineFeedContext.buffer
-            override val uniform: Uniform = glslProgram.getUniform(textureUniformId)
+            override val textureUniform = glslProgram.getTextureUniform(textureUniformId)
                 ?: error("no uniform $textureUniformId")
             override val isValid: Boolean get() = true
         }

--- a/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
@@ -13,7 +13,6 @@ import baaahs.gl.patch.ContentType
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
-import baaahs.glsl.Uniform
 import baaahs.plugin.SerializerRegistrar
 import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
@@ -99,7 +98,7 @@ class PixelIndexFeedContext(
 
         inner class ProgramFeedContext(glslProgram: GlslProgram) : PerPixelProgramFeedContext(updateMode) {
             override val buffer: ParamBuffer get() = this@EngineFeedContext.buffer
-            override val uniform: Uniform = glslProgram.getUniform(textureUniformId)
+            override val textureUniform = glslProgram.getTextureUniform(textureUniformId)
                 ?: error("no uniform $textureUniformId")
             override val isValid: Boolean get() = true
         }

--- a/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
@@ -14,7 +14,6 @@ import baaahs.gl.patch.ContentType
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
-import baaahs.glsl.Uniform
 import baaahs.plugin.SerializerRegistrar
 import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
@@ -118,7 +117,7 @@ class PixelLocationFeedContext(
 
         inner class ProgramFeedContext(glslProgram: GlslProgram) : PerPixelProgramFeedContext(updateMode) {
             override val buffer: ParamBuffer get() = this@EngineFeedContext.buffer
-            override val uniform: Uniform = glslProgram.getUniform(textureUniformId)
+            override val textureUniform = glslProgram.getTextureUniform(textureUniformId)
                 ?: error("no uniform $textureUniformId")
             override val isValid: Boolean get() = true
         }

--- a/src/commonMain/kotlin/baaahs/gl/GlContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/GlContext.kt
@@ -4,7 +4,7 @@ import baaahs.gl.glsl.CompilationException
 import baaahs.gl.glsl.CompiledShader
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.ResourceAllocationException
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 import baaahs.util.Logger
 import com.danielgergely.kgl.*
 
@@ -252,7 +252,7 @@ abstract class GlContext(
             check { texParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE) }
         }
 
-        fun setUniform(uniform: Uniform) {
+        fun setUniform(uniform: GlslUniform) {
             uniform.set(unitNumber)
         }
 

--- a/src/commonMain/kotlin/baaahs/gl/data/FeedContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/data/FeedContext.kt
@@ -4,7 +4,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.param.ParamBuffer
 import baaahs.gl.render.RenderTarget
-import baaahs.glsl.Uniform
+import baaahs.glsl.TextureUniform
 import baaahs.show.UpdateMode
 import baaahs.util.RefCounted
 
@@ -85,7 +85,7 @@ abstract class PerPixelProgramFeedContext(
     override val updateMode: UpdateMode
 ) : ProgramFeedContext {
     abstract val buffer: ParamBuffer
-    abstract val uniform: Uniform
+    abstract val textureUniform: TextureUniform
 
     override val callSetEarly: Boolean get() = true
     override val callSetBeforeFrame: Boolean get() =
@@ -93,7 +93,7 @@ abstract class PerPixelProgramFeedContext(
     override val callSetBeforeFixture: Boolean get() = false
 
     final override fun setOnProgram() {
-        buffer.setTexture(uniform)
+        buffer.setTexture(textureUniform.uniform)
     }
 
     final override fun setOnProgram(renderTarget: RenderTarget) {}

--- a/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
@@ -8,10 +8,25 @@ import baaahs.util.Logger
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 
-class SingleUniformFeedContext(
+fun <T: Any> Feed.singleUniformFeedContext(
+    id: String,
+    getValue: (oldValue: T?) -> T?
+): FeedContext {
+    var oldValue: T? = null
+    return SingleUniformFeedContext(this, id) { uniform ->
+        val newValue = getValue(oldValue)
+
+        if (newValue != null && newValue != oldValue)
+            uniform.set(newValue)
+
+        oldValue = newValue
+    }
+}
+
+internal class SingleUniformFeedContext(
     feed: Feed,
-    val id: String,
-    val setUniform: (GlslUniform) -> Unit
+    private val id: String,
+    private val setUniform: (GlslUniform) -> Unit
 ) : FeedContext, RefCounted by RefCounter() {
     private val type: Any = feed.getType()
     private val varName = feed.getVarName(id)
@@ -19,6 +34,9 @@ class SingleUniformFeedContext(
     override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
         override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
             val uniform = glslProgram.getUniform(varName)
+            if (uniform == null) {
+                logger.info { "No such uniform $type $varName for $id." }
+            }
 
             return object : ProgramFeedContext {
                 override val isValid: Boolean get() = uniform != null
@@ -27,7 +45,7 @@ class SingleUniformFeedContext(
                     try {
                         uniform?.let { setUniform(it) }
                     } catch (e: Exception) {
-                        logger.error(e) { "failed to set uniform $type $varName for $id" }
+                        logger.error(e) { "Failed to set uniform $type $varName for $id." }
                     }
                 }
             }

--- a/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
@@ -1,7 +1,7 @@
 package baaahs.gl.data
 
 import baaahs.gl.glsl.GlslProgram
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 import baaahs.show.Feed
 import baaahs.util.Logger
 
@@ -9,7 +9,7 @@ class SingleUniformFeedContext(
     glslProgram: GlslProgram,
     feed: Feed,
     val id: String,
-    val setUniform: (Uniform) -> Unit
+    val setUniform: (GlslUniform) -> Unit
 ) : ProgramFeedContext {
     private val type: Any = feed.getType()
     private val varName = feed.getVarName(id)

--- a/src/commonMain/kotlin/baaahs/gl/param/FloatsParamBuffer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/param/FloatsParamBuffer.kt
@@ -7,7 +7,7 @@ import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.result.BufferView
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 import com.danielgergely.kgl.*
 import kotlin.math.min
 
@@ -52,12 +52,12 @@ class FloatsParamBuffer(val id: String, val stride: Int, private val gl: GlConte
         }
     }
 
-    override fun setTexture(uniform: Uniform) {
+    override fun setTexture(uniform: GlslUniform) {
         uniform.set(textureUnit)
     }
 
     override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
-        val uniform = glslProgram.getUniform(id)
+        val uniform = glslProgram.getTextureUniform(id)
 
         return object : ProgramFeedContext {
             override val isValid get() = uniform != null

--- a/src/commonMain/kotlin/baaahs/gl/param/ParamBuffer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/param/ParamBuffer.kt
@@ -2,12 +2,12 @@ package baaahs.gl.param
 
 import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.glsl.GlslProgram
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 
 interface ParamBuffer {
     fun resizeBuffer(width: Int, height: Int)
     fun uploadToTexture()
-    fun setTexture(uniform: Uniform)
+    fun setTexture(uniform: GlslUniform)
     fun bind(glslProgram: GlslProgram): ProgramFeedContext
     fun release()
 }

--- a/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
@@ -6,41 +6,92 @@ import baaahs.gl.glsl.GlslProgram
 import com.danielgergely.kgl.Kgl
 import com.danielgergely.kgl.UniformLocation
 
-interface Uniform {
+interface GlslUniform {
     fun set(x: Int)
     fun set(x: Int, y: Int)
     fun set(x: Int, y: Int, z: Int)
+    fun set(x: Int, y: Int, z: Int, w: Int)
+
     fun set(x: Float)
     fun set(x: Float, y: Float)
     fun set(x: Float, y: Float, z: Float)
     fun set(x: Float, y: Float, z: Float, w: Float)
+
+    fun set(vector2F: Vector2F) = set(vector2F.x, vector2F.y)
+    fun set(vector3F: Vector3F) = set(vector3F.x, vector3F.y, vector3F.z)
+    fun set(vector4F: Vector4F) = set(vector4F.x, vector4F.y, vector4F.z, vector4F.w)
+
     fun set(matrix: Matrix4F)
-    fun set(vector2F: Vector2F)
-    fun set(vector3F: Vector3F)
-    fun set(vector4F: Vector4F)
     fun set(eulerAngle: EulerAngle)
     fun set(textureUnit: GlContext.TextureUnit)
+}
+
+interface Uniform
+
+class IntUniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Int) = uniform.set(x)
+}
+
+class Int2Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Int, y: Int) = uniform.set(x, y)
+}
+
+class Int3Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Int, y: Int, z: Int) = uniform.set(x, y, z)
+}
+
+class Int4Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Int, y: Int, z: Int, w: Int) = uniform.set(x, y, z, w)
+}
+
+class FloatUniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Float) = uniform.set(x)
+}
+
+class Float2Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Float, y: Float) = uniform.set(x, y)
+    fun set(vector2F: Vector2F) = uniform.set(vector2F.x, vector2F.y)
+}
+
+class Float3Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Float, y: Float, z: Float) = uniform.set(x, y, z)
+    fun set(vector3F: Vector3F) = uniform.set(vector3F.x, vector3F.y, vector3F.z)
+}
+
+class Float4Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(x: Float, y: Float, z: Float, w: Float) = uniform.set(x, y, z, w)
+    fun set(vector4F: Vector4F) = uniform.set(vector4F.x, vector4F.y, vector4F.z, vector4F.w)
+}
+
+class Matrix4Uniform(private val uniform: GlslUniform) : Uniform {
+    fun set(matrix: Matrix4F) = uniform.set(matrix)
+}
+
+class EulerAngleUniform(private val uniform: GlslUniform) : Uniform {
+    fun set(eulerAngle: EulerAngle) = uniform.set(eulerAngle)
+}
+
+class TextureUniform(val uniform: GlslUniform) : Uniform {
+    fun set(textureUnit: GlContext.TextureUnit) = uniform.set(textureUnit)
 }
 
 class UniformImpl internal constructor(
     private val glslProgram: GlslProgram,
     private val uniformLocation: UniformLocation
-): Uniform {
+): GlslUniform {
     override fun set(x: Int) = withProgram { uniform1i(uniformLocation, x) }
     override fun set(x: Int, y: Int) = withProgram { uniform2i(uniformLocation, x, y) }
     override fun set(x: Int, y: Int, z: Int) = withProgram { uniform3i(uniformLocation, x, y, z) }
+    override fun set(x: Int, y: Int, z: Int, w: Int) = withProgram { uniform4i(uniformLocation, x, y, z, w) }
     override fun set(x: Float) = withProgram { uniform1f(uniformLocation, x) }
     override fun set(x: Float, y: Float) = withProgram { uniform2f(uniformLocation, x, y) }
     override fun set(x: Float, y: Float, z: Float) = withProgram { uniform3f(uniformLocation, x, y, z) }
     override fun set(x: Float, y: Float, z: Float, w: Float) = withProgram { uniform4f(uniformLocation, x, y, z, w) }
 
     override fun set(matrix: Matrix4F) = withProgram {
-        uniformMatrix4fv(uniformLocation, false, matrix.elements.map { it.toFloat() }.toFloatArray())
+        uniformMatrix4fv(uniformLocation, false, matrix.elements)
     }
 
-    override fun set(vector2F: Vector2F) = set(vector2F.x, vector2F.y)
-    override fun set(vector3F: Vector3F) = set(vector3F.x, vector3F.y, vector3F.z)
-    override fun set(vector4F: Vector4F) = set(vector4F.x, vector4F.y, vector4F.z, vector4F.w)
     override fun set(eulerAngle: EulerAngle) =
         set(eulerAngle.xRad.toFloat(), eulerAngle.yRad.toFloat(), eulerAngle.zRad.toFloat())
 

--- a/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
+++ b/src/commonMain/kotlin/baaahs/glsl/Uniform.kt
@@ -1,5 +1,6 @@
 package baaahs.glsl
 
+import baaahs.Color
 import baaahs.geom.*
 import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslProgram
@@ -7,10 +8,16 @@ import com.danielgergely.kgl.Kgl
 import com.danielgergely.kgl.UniformLocation
 
 interface GlslUniform {
+    fun set(value: Boolean) = set(if (value) 1 else 0)
+
     fun set(x: Int)
     fun set(x: Int, y: Int)
     fun set(x: Int, y: Int, z: Int)
     fun set(x: Int, y: Int, z: Int, w: Int)
+
+    fun set(vector2I: Vector2I) = set(vector2I.x, vector2I.y)
+//    fun set(vector3I: Vector3I) = set(vector3I.x, vector3I.y, vector3I.z)
+//    fun set(vector4I: Vector4I) = set(vector4I.x, vector4I.y, vector4I.z, vector4I.w)
 
     fun set(x: Float)
     fun set(x: Float, y: Float)
@@ -24,6 +31,29 @@ interface GlslUniform {
     fun set(matrix: Matrix4F)
     fun set(eulerAngle: EulerAngle)
     fun set(textureUnit: GlContext.TextureUnit)
+
+    fun set(value: Any) =
+        when (value) {
+            is Boolean -> set(value)
+
+            is Int -> set(value)
+            is Vector2I -> set(value)
+//            is Vector3I -> uniform.set(newValue)
+//            is Vector4I -> uniform.set(newValue)
+
+            is Float -> set(value)
+            is Vector2F -> set(value)
+            is Vector3F -> set(value)
+            is Vector4F -> set(value)
+
+            is Matrix4F -> set(value)
+            is EulerAngle -> set(value)
+            is GlContext.TextureUnit -> set(value)
+
+            is Color -> set(value.redF, value.greenF, value.blueF, value.alphaF)
+
+            else -> error("unsupported uniform type ${value::class.simpleName}")
+        }
 }
 
 interface Uniform

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
@@ -7,7 +7,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
 import baaahs.gl.data.ProgramFeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
@@ -127,8 +127,8 @@ class BeatLinkPlugin internal constructor(
         override fun getType(): GlslType = GlslType.Float
 
         override fun open(showPlayer: ShowPlayer, id: String) =
-            SingleUniformFeedContext(this, id) { uniform ->
-                uniform.set(beatSource.getBeatData().fractionTillNextBeat(clock))
+            singleUniformFeedContext<Float>(id) {
+                beatSource.getBeatData().fractionTillNextBeat(clock)
             }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
@@ -126,16 +126,10 @@ class BeatLinkPlugin internal constructor(
 
         override fun getType(): GlslType = GlslType.Float
 
-        override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-            return object : FeedContext, RefCounted by RefCounter() {
-                override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                    override fun bind(glslProgram: GlslProgram): ProgramFeedContext =
-                        SingleUniformFeedContext(glslProgram, this@BeatLinkFeed, id) { uniform ->
-                            uniform.set(beatSource.getBeatData().fractionTillNextBeat(clock))
-                        }
-                }
+        override fun open(showPlayer: ShowPlayer, id: String) =
+            SingleUniformFeedContext(this, id) { uniform ->
+                uniform.set(beatSource.getBeatData().fractionTillNextBeat(clock))
             }
-        }
     }
 
     @SerialName("baaahs.BeatLink:BeatInfo")

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
@@ -152,10 +152,10 @@ class BeatLinkPlugin internal constructor(
                 override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                     override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
                         return object : ProgramFeedContext {
-                            val beatUniform = glslProgram.getUniform("${varPrefix}.beat")
-                            val bpmUniform = glslProgram.getUniform("${varPrefix}.bpm")
-                            val intensityUniform = glslProgram.getUniform("${varPrefix}.intensity")
-                            val confidenceUniform = glslProgram.getUniform("${varPrefix}.confidence")
+                            val beatUniform = glslProgram.getFloatUniform("${varPrefix}.beat")
+                            val bpmUniform = glslProgram.getFloatUniform("${varPrefix}.bpm")
+                            val intensityUniform = glslProgram.getFloatUniform("${varPrefix}.intensity")
+                            val confidenceUniform = glslProgram.getFloatUniform("${varPrefix}.confidence")
 
                             override val isValid: Boolean
                                 get() = beatUniform != null ||
@@ -192,11 +192,11 @@ class BeatLinkPlugin internal constructor(
                 override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                     override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
                         return object : ProgramFeedContext {
-                            val measureStartTime = glslProgram.getUniform("${varPrefix}.measureStartTime")
-                            val beatIntervalMsUniform = glslProgram.getUniform("${varPrefix}.beatIntervalMs")
-                            val bpmUniform = glslProgram.getUniform("${varPrefix}.bpm")
-                            val beatsPerMeasureUniform = glslProgram.getUniform("${varPrefix}.beatsPerMeasure")
-                            val confidenceUniform = glslProgram.getUniform("${varPrefix}.confidence")
+                            val measureStartTime = glslProgram.getFloatUniform("${varPrefix}.measureStartTime")
+                            val beatIntervalMsUniform = glslProgram.getFloatUniform("${varPrefix}.beatIntervalMs")
+                            val bpmUniform = glslProgram.getFloatUniform("${varPrefix}.bpm")
+                            val beatsPerMeasureUniform = glslProgram.getFloatUniform("${varPrefix}.beatsPerMeasure")
+                            val confidenceUniform = glslProgram.getFloatUniform("${varPrefix}.confidence")
 
                             override val isValid: Boolean
                                 get() = measureStartTime != null ||

--- a/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
@@ -71,11 +71,11 @@ class FixtureInfoFeedContext(
         override fun bind(glslProgram: GlslProgram) = object : ProgramFeedContext {
             override val updateMode: UpdateMode get() = UpdateMode.PER_FIXTURE
 
-            private val positionUniform = glslProgram.getUniform("$id.position")
-            private val rotationUniform = glslProgram.getUniform("$id.rotation")
-            private val transformationUniform = glslProgram.getUniform("$id.transformation")
-            private val boundaryMinUniform = glslProgram.getUniform("$id.boundaryMin")
-            private val boundaryMaxUniform = glslProgram.getUniform("$id.boundaryMax")
+            private val positionUniform = glslProgram.getFloat3Uniform("$id.position")
+            private val rotationUniform = glslProgram.getEulerAngleUniform("$id.rotation")
+            private val transformationUniform = glslProgram.getMatrix4FUniform("$id.transformation")
+            private val boundaryMinUniform = glslProgram.getFloat3Uniform("$id.boundaryMin")
+            private val boundaryMaxUniform = glslProgram.getFloat3Uniform("$id.boundaryMax")
 
             override val isValid: Boolean get() =
                 positionUniform != null || rotationUniform != null || transformationUniform != null ||

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
@@ -4,12 +4,8 @@ import baaahs.Color
 import baaahs.ShowPlayer
 import baaahs.control.MutableColorPickerControl
 import baaahs.gadgets.ColorPicker
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.data.SingleUniformFeedContext
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -19,8 +15,6 @@ import baaahs.show.Feed
 import baaahs.show.FeedBuilder
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
-import baaahs.util.RefCounted
-import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.contentOrNull
@@ -48,15 +42,9 @@ data class ColorPickerFeed(
                 createGadget()
             }
 
-        return object : FeedContext, RefCounted by RefCounter() {
-            override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
-                    return SingleUniformFeedContext(glslProgram, this@ColorPickerFeed, id) { uniform ->
-                        val color = colorPicker.color
-                        uniform.set(color.redF, color.greenF, color.blueF, color.alphaF)
-                    }
-                }
-            }
+        return SingleUniformFeedContext(this@ColorPickerFeed, id) { uniform ->
+            val color = colorPicker.color
+            uniform.set(color.redF, color.greenF, color.blueF, color.alphaF)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
@@ -5,7 +5,7 @@ import baaahs.ShowPlayer
 import baaahs.control.MutableColorPickerControl
 import baaahs.gadgets.ColorPicker
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -42,10 +42,7 @@ data class ColorPickerFeed(
                 createGadget()
             }
 
-        return SingleUniformFeedContext(this@ColorPickerFeed, id) { uniform ->
-            val color = colorPicker.color
-            uniform.set(color.redF, color.greenF, color.blueF, color.alphaF)
-        }
+        return singleUniformFeedContext<Color>(id) { colorPicker.color }
     }
 
     companion object : FeedBuilder<ColorPickerFeed> {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/DateFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/DateFeed.kt
@@ -1,8 +1,9 @@
 package baaahs.plugin.core.feed
 
 import baaahs.ShowPlayer
+import baaahs.geom.Vector4F
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -53,9 +54,9 @@ data class DateFeed(
 
     override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
         val clock = showPlayer.toolchain.plugins.pluginContext.clock
-        return SingleUniformFeedContext(this@DateFeed, id) { uniform ->
+        return singleUniformFeedContext<Vector4F>(id) {
             val dateTime = DateTime(clock.now() * 1000)
-            uniform.set(
+            Vector4F(
                 dateTime.yearInt.toFloat(),
                 dateTime.month1.toFloat() - if (zeroBasedMonth) 1 else 0,
                 dateTime.dayOfMonth.toFloat() - if (zeroBasedDay) 1 else 0,

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
@@ -84,7 +84,7 @@ data class ImageFeed(override val title: String) : Feed {
         private val textureUnit: GlContext.TextureUnit
     ) : ProgramFeedContext {
         private val textureId = "ds_${varName}_texture"
-        private val textureUniform = glslProgram.getUniform(textureId)
+        private val textureUniform = glslProgram.getTextureUniform(textureId)
         override val isValid: Boolean
             get() = textureUniform != null
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ModelInfoFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ModelInfoFeed.kt
@@ -61,8 +61,8 @@ data class ModelInfoFeed(@Transient val `_`: Boolean = true) : Feed {
                 override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
                     return object : ProgramFeedContext {
                         override val updateMode: UpdateMode get() = UpdateMode.PER_FRAME
-                        val centerUniform = glslProgram.getUniform("${varPrefix}.center")
-                        val extentsUniform = glslProgram.getUniform("${varPrefix}.extents")
+                        val centerUniform = glslProgram.getFloat3Uniform("${varPrefix}.center")
+                        val extentsUniform = glslProgram.getFloat3Uniform("${varPrefix}.extents")
 
                         override val isValid: Boolean
                             get() = centerUniform != null && extentsUniform != null

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/PreviewResolutionFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/PreviewResolutionFeed.kt
@@ -46,7 +46,7 @@ data class PreviewResolutionFeed(@Transient val `_`: Boolean = true) : Feed {
             override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                 override fun bind(glslProgram: GlslProgram): ProgramFeedContext =
                     object : ProgramFeedContext, GlslProgram.ResolutionListener {
-                        private val uniform = glslProgram.getUniform(getVarName(id))
+                        private val uniform = glslProgram.getFloat2Uniform(getVarName(id))
                         override val isValid: Boolean = uniform != null
 
                         private var x = 1f

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
@@ -55,7 +55,7 @@ data class RasterCoordinateFeed(@Transient val `_`: Boolean = true) : Feed {
                 val offsetUniformId = "ds_${id}_offset"
                 override fun bind(glslProgram: GlslProgram): ProgramFeedContext =
                     object : ProgramFeedContext {
-                        private val uniform = glslProgram.getUniform(offsetUniformId)
+                        private val uniform = glslProgram.getFloat2Uniform(offsetUniformId)
                         override val isValid: Boolean = uniform != null
 
                         override fun setOnProgram() {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
@@ -1,12 +1,7 @@
 package baaahs.plugin.core.feed
 
 import baaahs.ShowPlayer
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeedContext
-import baaahs.gl.data.FeedContext
-import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.data.SingleUniformFeedContext
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -14,8 +9,6 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
-import baaahs.util.RefCounted
-import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -45,13 +38,8 @@ data class ResolutionFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.Resolution
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
-        object : FeedContext, RefCounted by RefCounter() {
-            override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                override fun bind(glslProgram: GlslProgram): ProgramFeedContext =
-                    SingleUniformFeedContext(glslProgram, this@ResolutionFeed, id) { uniform ->
-                        uniform.set(1f, 1f)
-                    }
-            }
+    override fun open(showPlayer: ShowPlayer, id: String) =
+        SingleUniformFeedContext(this@ResolutionFeed, id) { uniform ->
+            uniform.set(1f, 1f)
         }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
@@ -1,7 +1,8 @@
 package baaahs.plugin.core.feed
 
 import baaahs.ShowPlayer
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.geom.Vector2F
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -39,7 +40,5 @@ data class ResolutionFeed(@Transient val `_`: Boolean = true) : Feed {
         get() = ContentType.Resolution
 
     override fun open(showPlayer: ShowPlayer, id: String) =
-        SingleUniformFeedContext(this@ResolutionFeed, id) { uniform ->
-            uniform.set(1f, 1f)
-        }
+        singleUniformFeedContext<Vector2F>(id) { Vector2F.unit2d }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/SliderFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/SliderFeed.kt
@@ -4,7 +4,7 @@ import baaahs.ShowPlayer
 import baaahs.control.MutableSliderControl
 import baaahs.gadgets.Slider
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -57,20 +57,15 @@ data class SliderFeed(
         val plugin = showPlayer.toolchain.plugins.findPlugin<BeatLinkPlugin>()
         val beatSource = plugin?.beatSource
 
-        return SingleUniformFeedContext(this@SliderFeed, id) { uniform ->
+        return singleUniformFeedContext<Float>(id) {
             if (beatSource != null && slider.beatLinked) {
                 val beatData = beatSource.getBeatData()
                 if (beatData.confidence > .2f) {
-                    uniform.set(
-                        (slider.position - slider.floor) *
-                                beatData.fractionTillNextBeat(clock) +
-                                slider.floor
-                    )
-                    return@SingleUniformFeedContext
-                }
-            }
-
-            uniform.set(slider.position)
+                    (slider.position - slider.floor) *
+                            beatData.fractionTillNextBeat(clock) +
+                            slider.floor
+                } else slider.position
+            } else slider.position
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
@@ -4,12 +4,8 @@ import baaahs.ShowPlayer
 import baaahs.control.ButtonControl
 import baaahs.control.MutableButtonControl
 import baaahs.gadgets.Switch
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.data.SingleUniformFeedContext
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -20,8 +16,6 @@ import baaahs.show.FeedBuilder
 import baaahs.show.mutable.MutableControl
 import baaahs.show.mutable.MutableShow
 import baaahs.util.Logger
-import baaahs.util.RefCounted
-import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -58,14 +52,8 @@ data class SwitchFeed(
                 Switch(buttonTitle, initiallyEnabled)
             }
 
-        return object : FeedContext, RefCounted by RefCounter() {
-            override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
-                    return SingleUniformFeedContext(glslProgram, this@SwitchFeed, id) { uniform ->
-                        uniform.set(if (switch.enabled) 1 else 0)
-                    }
-                }
-            }
+        return SingleUniformFeedContext(this@SwitchFeed, id) { uniform ->
+            uniform.set(if (switch.enabled) 1 else 0)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
@@ -5,7 +5,7 @@ import baaahs.control.ButtonControl
 import baaahs.control.MutableButtonControl
 import baaahs.gadgets.Switch
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -52,9 +52,7 @@ data class SwitchFeed(
                 Switch(buttonTitle, initiallyEnabled)
             }
 
-        return SingleUniformFeedContext(this@SwitchFeed, id) { uniform ->
-            uniform.set(if (switch.enabled) 1 else 0)
-        }
+        return singleUniformFeedContext<Boolean>(id) { switch.enabled }
     }
 
     companion object : FeedBuilder<SwitchFeed> {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
@@ -2,7 +2,7 @@ package baaahs.plugin.core.feed
 
 import baaahs.ShowPlayer
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -36,9 +36,6 @@ data class TimeFeed(@Transient val `_`: Boolean = true) : Feed {
 
     override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
         val clock = showPlayer.toolchain.plugins.pluginContext.clock
-        return SingleUniformFeedContext(this@TimeFeed, id) { uniform ->
-            val thisTime = clock.now().makeSafeForGlsl()
-            uniform.set(thisTime)
-        }
+        return singleUniformFeedContext<Float>(id) { clock.now().makeSafeForGlsl() }
     }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
@@ -1,12 +1,8 @@
 package baaahs.plugin.core.feed
 
 import baaahs.ShowPlayer
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.data.SingleUniformFeedContext
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -14,8 +10,6 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
-import baaahs.util.RefCounted
-import baaahs.util.RefCounter
 import baaahs.util.makeSafeForGlsl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -40,16 +34,11 @@ data class TimeFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.Time
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
-        object : FeedContext, RefCounted by RefCounter() {
-            override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
-                    val clock = showPlayer.toolchain.plugins.pluginContext.clock
-                    return SingleUniformFeedContext(glslProgram, this@TimeFeed, id) { uniform ->
-                        val thisTime = clock.now().makeSafeForGlsl()
-                        uniform.set(thisTime)
-                    }
-                }
-            }
+    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+        val clock = showPlayer.toolchain.plugins.pluginContext.clock
+        return SingleUniformFeedContext(this@TimeFeed, id) { uniform ->
+            val thisTime = clock.now().makeSafeForGlsl()
+            uniform.set(thisTime)
         }
+    }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
@@ -5,7 +5,7 @@ import baaahs.control.MutableXyPadControl
 import baaahs.gadgets.XyPad
 import baaahs.geom.Vector2F
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.SingleUniformFeedContext
+import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -48,9 +48,7 @@ data class XyPadFeed(
                 XyPad(title, initialValue, minValue, maxValue)
             }
 
-        return SingleUniformFeedContext(this@XyPadFeed, id) { uniform ->
-            uniform.set(xyPad.position)
-        }
+        return singleUniformFeedContext<Vector2F>(id) { xyPad.position }
     }
 
     companion object : FeedBuilder<XyPadFeed> {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
@@ -4,12 +4,8 @@ import baaahs.ShowPlayer
 import baaahs.control.MutableXyPadControl
 import baaahs.gadgets.XyPad
 import baaahs.geom.Vector2F
-import baaahs.gl.GlContext
-import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
-import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.data.SingleUniformFeedContext
-import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
@@ -20,8 +16,6 @@ import baaahs.show.Feed
 import baaahs.show.FeedBuilder
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
-import baaahs.util.RefCounted
-import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -54,14 +48,8 @@ data class XyPadFeed(
                 XyPad(title, initialValue, minValue, maxValue)
             }
 
-        return object : FeedContext, RefCounted by RefCounter() {
-            override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
-                override fun bind(glslProgram: GlslProgram): ProgramFeedContext {
-                    return SingleUniformFeedContext(glslProgram, this@XyPadFeed, id) { uniform ->
-                        uniform.set(xyPad.position)
-                    }
-                }
-            }
+        return SingleUniformFeedContext(this@XyPadFeed, id) { uniform ->
+            uniform.set(xyPad.position)
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
@@ -391,10 +391,10 @@ class SoundAnalysisFeedContext(
         init { gl.checkForLinearFilteringOfFloatTextures() }
 
         override fun bind(glslProgram: GlslProgram): ProgramFeedContext = object : ProgramFeedContext {
-            val bucketCountUniform = glslProgram.getUniform("${varPrefix}.bucketCount")
-            val sampleHistoryCountUniform = glslProgram.getUniform("${varPrefix}.sampleHistoryCount")
-            val bucketsUniform = glslProgram.getUniform("${varPrefix}.buckets")
-            val maxMagnitudeUniform = glslProgram.getUniform("${varPrefix}.maxMagnitude")
+            val bucketCountUniform = glslProgram.getIntUniform("${varPrefix}.bucketCount")
+            val sampleHistoryCountUniform = glslProgram.getIntUniform("${varPrefix}.sampleHistoryCount")
+            val bucketsUniform = glslProgram.getTextureUniform("${varPrefix}.buckets")
+            val maxMagnitudeUniform = glslProgram.getFloatUniform("${varPrefix}.maxMagnitude")
 
             override val isValid: Boolean
                 get() = bucketCountUniform != null ||

--- a/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
@@ -75,7 +75,7 @@ class VideoInPlugin(private val videoProvider: VideoProvider) : OpenServerPlugin
 
                         override fun bind(glslProgram: GlslProgram): ProgramFeedContext = object : ProgramFeedContext {
                             val textureId = "ds_${getVarName(id)}_texture"
-                            val videoUniform = glslProgram.getUniform(textureId)
+                            val videoUniform = glslProgram.getTextureUniform(textureId)
                             override val isValid: Boolean
                                 get() {
                                     return videoUniform != null

--- a/src/commonMain/kotlin/baaahs/util/Time.kt
+++ b/src/commonMain/kotlin/baaahs/util/Time.kt
@@ -8,7 +8,10 @@ typealias Time = Double
 fun Interval(n: Number): Time = n.toDouble()
 
 fun Time.elapsedMs() = ((internalTimerClock.now() - this) * 10000).roundToInt() / 10.0
+
+/** Truncate time to 4 digits of seconds so we don't overflow a GLSL float. */
 fun Time.makeSafeForGlsl() = (this % 10000.0).toFloat()
+
 fun Time.isBefore(otherTime: Time) = this < otherTime
 
 interface Clock {

--- a/src/commonTest/kotlin/baaahs/gl/render/PerFixtureFeedForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerFixtureFeedForTest.kt
@@ -43,7 +43,7 @@ class PerFixtureFeedForTest(val updateMode: UpdateMode) : Feed {
     inner class TestProgramFeedContext(glslProgram: GlslProgram) : ProgramFeedContext {
         override val updateMode: UpdateMode get() = this@PerFixtureFeedForTest.updateMode
 
-        val uniform = glslProgram.getUniform("perFixtureData")
+        val uniform = glslProgram.getIntUniform("perFixtureData")
         var released = false
 
         override fun setOnProgram() = run {

--- a/src/commonTest/kotlin/baaahs/gl/render/PerPixelFeedForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerPixelFeedForTest.kt
@@ -56,7 +56,7 @@ class PerPixelFeedForTest(val updateMode: UpdateMode) : Feed {
 
         inner class TestProgramFeedContext(glslProgram: GlslProgram) : PerPixelProgramFeedContext(updateMode) {
             override val buffer: ParamBuffer get() = this@TestEngineFeedContext.buffer
-            override val uniform = glslProgram.getUniform("perPixelDataTexture") ?: error("no uniform")
+            override val textureUniform = glslProgram.getTextureUniform("perPixelDataTexture") ?: error("no uniform")
             var released = false
             override fun release() = run { super.release(); released = released.truify() }
         }

--- a/src/commonTest/kotlin/baaahs/plugin/core/feed/DateFeedSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/core/feed/DateFeedSpec.kt
@@ -7,7 +7,7 @@ import baaahs.gl.override
 import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.dialect.IsfShaderDialect
 import baaahs.gl.shader.dialect.ShaderToyShaderDialect
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeShowPlayer
 import baaahs.shows.FakeUniform
@@ -32,7 +32,7 @@ object DateFeedSpec : Spek({
             }
             val gl = FakeGlContext()
             val fakeProgram = object : StubGlslProgram() {
-                override fun getUniform(name: String): Uniform = uniform
+                override fun getUniform(name: String): GlslUniform = uniform
                 override fun <T> withProgram(fn: Kgl.() -> T): T = fn(gl.fakeKgl)
             }
 

--- a/src/commonTest/kotlin/baaahs/shows/FakeKgl.kt
+++ b/src/commonTest/kotlin/baaahs/shows/FakeKgl.kt
@@ -6,7 +6,7 @@ import baaahs.gl.GlContext
 import baaahs.gl.glsl.CompiledShader
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.render.RenderTarget
-import baaahs.glsl.Uniform
+import baaahs.glsl.GlslUniform
 import com.danielgergely.kgl.*
 
 class FakeGlContext(internal val fakeKgl: FakeKgl = FakeKgl()) : GlContext(fakeKgl, "1234") {
@@ -488,12 +488,13 @@ class FakeKgl : Kgl {
     }
 }
 
-class FakeUniform : Uniform {
+class FakeUniform : GlslUniform {
     var value: Any? = null
 
     override fun set(x: Int) { value = x }
     override fun set(x: Int, y: Int) { value = listOf(x, y) }
     override fun set(x: Int, y: Int, z: Int) { value = listOf(x, y, z) }
+    override fun set(x: Int, y: Int, z: Int, w: Int) { value = listOf(x, y, z, w) }
     override fun set(x: Float) { value = x }
     override fun set(x: Float, y: Float) { value = Vector2F(x, y) }
     override fun set(x: Float, y: Float, z: Float) { value = Vector3F(x, y, z) }
@@ -514,7 +515,7 @@ open class StubGlslProgram : GlslProgram {
     override fun aboutToRenderFrame(): Unit = TODO("not implemented")
     override fun setPixDimens(width: Int, height: Int) = TODO("not implemented")
     override fun aboutToRenderFixture(renderTarget: RenderTarget): Unit = TODO("not implemented")
-    override fun getUniform(name: String): Uniform? = TODO("not implemented")
+    override fun getUniform(name: String): GlslUniform? = TODO("not implemented")
     override fun <T> withProgram(fn: Kgl.() -> T): T = TODO("not implemented")
     override fun use(): Unit = TODO("not implemented")
     override fun release(): Unit = TODO("not implemented")
@@ -523,7 +524,7 @@ open class StubGlslProgram : GlslProgram {
 class FakeGlslProgram(
     val uniforms: MutableMap<String, FakeUniform?> = mutableMapOf()
 ) : StubGlslProgram() {
-    override fun getUniform(name: String): Uniform? {
+    override fun getUniform(name: String): GlslUniform? {
         return uniforms.getOrPut(name) { FakeUniform() }
     }
 }


### PR DESCRIPTION
Nicer uniform access for feeds.

e.g.:
<img width="677" alt="image" src="https://github.com/baaahs/sparklemotion/assets/40298/ff025c68-5e83-4e52-ad76-da8e0a264cee">