### PR TITLE
Fix bugs in use of texture units

### DIFF
--- a/src/commonMain/kotlin/baaahs/gl/data/FeedContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/data/FeedContext.kt
@@ -93,7 +93,7 @@ abstract class PerPixelProgramFeedContext(
     override val callSetBeforeFixture: Boolean get() = false
 
     final override fun setOnProgram() {
-        buffer.setTexture(textureUniform.uniform)
+        buffer.setTexture(textureUniform)
     }
 
     final override fun setOnProgram(renderTarget: RenderTarget) {}

--- a/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
+++ b/src/commonMain/kotlin/baaahs/gl/data/SingleUniformFeedContext.kt
@@ -52,9 +52,6 @@ fun <T: Matrix4F?> Feed.singleUniformFeedContext(id: String, getValue: (oldValue
 @JvmName("singleUniformFeedContextEulerAngle")
 fun <T: EulerAngle?> Feed.singleUniformFeedContext(id: String, getValue: (oldValue: T?) -> T?) =
     bindContext(id, getValue) { set(it) }
-@JvmName("singleUniformFeedContextTextureUnit")
-fun <T: GlContext.TextureUnit?> Feed.singleUniformFeedContext(id: String, getValue: (oldValue: T?) -> T?) =
-    bindContext(id, getValue) { set(it) }
 
 @JvmName("singleUniformFeedContextColor")
 fun <T: Color?> Feed.singleUniformFeedContext(id: String, getValue: (oldValue: T?) -> T?) =

--- a/src/commonMain/kotlin/baaahs/gl/param/ParamBuffer.kt
+++ b/src/commonMain/kotlin/baaahs/gl/param/ParamBuffer.kt
@@ -1,13 +1,10 @@
 package baaahs.gl.param
 
-import baaahs.gl.data.ProgramFeedContext
-import baaahs.gl.glsl.GlslProgram
-import baaahs.glsl.GlslUniform
+import baaahs.glsl.TextureUniform
 
 interface ParamBuffer {
     fun resizeBuffer(width: Int, height: Int)
     fun uploadToTexture()
-    fun setTexture(uniform: GlslUniform)
-    fun bind(glslProgram: GlslProgram): ProgramFeedContext
+    fun setTexture(uniform: TextureUniform)
     fun release()
 }

--- a/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
@@ -385,7 +385,6 @@ class SoundAnalysisFeedContext(
     override fun bind(gl: GlContext): EngineFeedContext = SoundAnalysisEngineFeedContext(gl)
 
     inner class SoundAnalysisEngineFeedContext(private val gl: GlContext) : EngineFeedContext {
-        private val textureUnit = gl.getTextureUnit(SoundAnalysisPlugin)
         private val texture = gl.check { createTexture() }
 
         init { gl.checkForLinearFilteringOfFloatTextures() }
@@ -407,19 +406,17 @@ class SoundAnalysisFeedContext(
 
                 bucketCountUniform?.set(bucketCount)
                 sampleHistoryCountUniform?.set(historySize)
-                with(textureUnit) {
-                    bindTexture(texture)
-                    configure(GL_NEAREST, GL_NEAREST)
-                    uploadTexture(0, GL_R32F, bucketCount, historySize, 0, GL_RED, GL_FLOAT, textureBuffer)
+                with(gl) {
+                    texture.configure(GL_NEAREST, GL_NEAREST)
+                    texture.upload(0, GL_R32F, bucketCount, historySize, 0, GL_RED, GL_FLOAT, textureBuffer)
                 }
-                bucketsUniform?.set(textureUnit)
+                bucketsUniform?.set(texture)
                 maxMagnitudeUniform?.set(maxMagnitude)
             }
         }
 
         override fun release() {
             gl.check { deleteTexture(texture) }
-            textureUnit.release()
         }
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
@@ -70,7 +70,6 @@ class VideoInPlugin(private val videoProvider: VideoProvider) : OpenServerPlugin
             return object : FeedContext, RefCounted by RefCounter() {
                 override fun bind(gl: GlContext): EngineFeedContext {
                     return object : EngineFeedContext {
-                        private val textureUnit = gl.getTextureUnit(VideoInPlugin)
                         private val texture = gl.check { createTexture() }
 
                         override fun bind(glslProgram: GlslProgram): ProgramFeedContext = object : ProgramFeedContext {
@@ -83,23 +82,21 @@ class VideoInPlugin(private val videoProvider: VideoProvider) : OpenServerPlugin
 
                             override fun setOnProgram() {
                                 videoUniform?.let { uniform ->
-                                    with(textureUnit) {
-                                        bindTexture(texture)
-                                        configure(GL_LINEAR, GL_LINEAR)
-                                        uploadTexture(
+                                    with(gl) {
+                                        texture.configure(GL_LINEAR, GL_LINEAR)
+                                        texture.upload(
                                             0, GL_RGBA, 0,
                                             videoProvider.getTextureResource()
                                         )
                                     }
 
-                                    uniform.set(textureUnit)
+                                    uniform.set(texture)
                                 }
                             }
                         }
 
                         override fun release() {
                             gl.check { deleteTexture(texture) }
-                            textureUnit.release()
                         }
                     }
                 }

--- a/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
@@ -22,7 +22,6 @@ import baaahs.show.live.LinkedPatch
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeShowPlayer
 import ch.tutteli.atrium.api.fluent.en_GB.containsExactly
-import ch.tutteli.atrium.api.fluent.en_GB.isEmpty
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.expect
 import com.danielgergely.kgl.*
@@ -135,7 +134,6 @@ object ModelRenderEngineSpec : Spek({
 
                     it("should release the texture") {
                         expect(texture.isDeleted).toBe(true)
-                        expect(gl.allocatedTextureUnits).isEmpty()
                     }
                 }
             }

--- a/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ModelRenderEngineSpec.kt
@@ -106,9 +106,7 @@ object ModelRenderEngineSpec : Spek({
                     expect(texture.params[GL_TEXTURE_MIN_FILTER]).toBe(GL_NEAREST)
                     expect(texture.params[GL_TEXTURE_MAG_FILTER]).toBe(GL_NEAREST)
 
-                    val buffer = texture.buffer
-                    println("buffer = $buffer")
-//                    expect(300) { buffer. }
+                    expect(texture.buffer?.size).toBe(1)
                 }
             }
 
@@ -179,7 +177,8 @@ object ModelRenderEngineSpec : Spek({
                         it("should allocate a texture to hold per-pixel data for all fixtures") {
                             expect(texture.width to texture.height)
                                 .toBe(64 to 2)
-                            expect(fakeGlProgram.renders.map { it.textureBuffers.only("texture buffer") })
+
+                            expect(fakeGlProgram.renders.map { it.findUniformTextureConfig("perPixelDataTexture").buffer })
                                 .containsExactly(
                                     listOf(10f, 11f, 12f, 13f, 14f, 15f, 16f, 17f, 18f, 19f, 20f, 21f, 22f, 23f, 24f, 25f, 26f, 27f, 28f, 29f, 30f, 31f, 32f, 33f, 34f, 35f, 36f, 37f, 38f, 39f, 40f, 41f, 42f, 43f, 44f, 45f, 46f, 47f, 48f, 49f, 50f, 51f, 52f, 53f, 54f, 55f, 56f, 57f, 58f, 59f, 60f, 61f, 62f, 63f, 64f, 65f, 66f, 67f, 68f, 69f, 70f, 71f, 72f, 73f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f),
                                     listOf(10f, 11f, 12f, 13f, 14f, 15f, 16f, 17f, 18f, 19f, 20f, 21f, 22f, 23f, 24f, 25f, 26f, 27f, 28f, 29f, 30f, 31f, 32f, 33f, 34f, 35f, 36f, 37f, 38f, 39f, 40f, 41f, 42f, 43f, 44f, 45f, 46f, 47f, 48f, 49f, 50f, 51f, 52f, 53f, 54f, 55f, 56f, 57f, 58f, 59f, 60f, 61f, 62f, 63f, 64f, 65f, 66f, 67f, 68f, 69f, 70f, 71f, 72f, 73f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f)
@@ -245,7 +244,7 @@ object ModelRenderEngineSpec : Spek({
                         it("should allocate a texture to hold per-pixel data for all fixtures") {
                             expect(texture.width to texture.height)
                                 .toBe(3 to 1)
-                            expect(fakeGlProgram.renders.map { it.textureBuffers.only("texture buffer") })
+                            expect(fakeGlProgram.renders.map { it.findUniformTextureConfig("perPixelDataTexture").buffer })
                                 .containsExactly(
                                     listOf(10f, 20f, 21f), // First frame, fixture1.
                                     listOf(10f, 20f, 21f), // First frame, fixture2.
@@ -260,7 +259,7 @@ object ModelRenderEngineSpec : Spek({
                             it("should allocate a texture to hold per-pixel data for all fixtures") {
                                 expect(texture.width to texture.height)
                                     .toBe(3 to 1)
-                                expect(fakeGlProgram.renders.map { it.textureBuffers.only("texture buffer") })
+                                expect(fakeGlProgram.renders.map { it.findUniformTextureConfig("perPixelDataTexture").buffer })
                                     .containsExactly(
                                         // 10f-41f are currently issued when the feed is first bound;
                                         // we could eliminate that overhead but probably not really worth it.
@@ -287,7 +286,7 @@ object ModelRenderEngineSpec : Spek({
                             it("should allocate a texture to hold per-pixel data for all fixtures") {
                                 expect(texture.width to texture.height)
                                     .toBe(3 to 1)
-                                expect(fakeGlProgram.renders.map { it.textureBuffers.only("texture buffer") })
+                                expect(fakeGlProgram.renders.map { it.findUniformTextureConfig("perPixelDataTexture").buffer })
                                     .containsExactly(
                                         listOf(10f, 20f, 21f), // First frame, fixture1.
                                         listOf(10f, 20f, 21f), // First frame, fixture2.

--- a/src/commonTest/kotlin/baaahs/plugin/core/feed/DateFeedSpec.kt
+++ b/src/commonTest/kotlin/baaahs/plugin/core/feed/DateFeedSpec.kt
@@ -8,6 +8,7 @@ import baaahs.gl.shader.InputPort
 import baaahs.gl.shader.dialect.IsfShaderDialect
 import baaahs.gl.shader.dialect.ShaderToyShaderDialect
 import baaahs.glsl.GlslUniform
+import baaahs.glsl.TextureUniform
 import baaahs.shows.FakeGlContext
 import baaahs.shows.FakeShowPlayer
 import baaahs.shows.FakeUniform
@@ -33,6 +34,7 @@ object DateFeedSpec : Spek({
             val gl = FakeGlContext()
             val fakeProgram = object : StubGlslProgram() {
                 override fun getUniform(name: String): GlslUniform = uniform
+                override fun getTextureUniform(name: String): TextureUniform? = null
                 override fun <T> withProgram(fn: Kgl.() -> T): T = fn(gl.fakeKgl)
             }
 

--- a/src/commonTest/kotlin/baaahs/sm/server/StageManagerSpec.kt
+++ b/src/commonTest/kotlin/baaahs/sm/server/StageManagerSpec.kt
@@ -128,7 +128,7 @@ object StageManagerSpec : Spek({
             context("port wiring") {
                 it("wires up UV texture stuff") {
                     val pixelCoordsTextureUnit = fakeProgram.getUniform("ds_pixelLocation_texture") as Int
-                    val textureConfig = fakeGlslContext.getTextureConfig(pixelCoordsTextureUnit)
+                    val textureConfig = fakeGlslContext.getTextureConfig(pixelCoordsTextureUnit, GL_TEXTURE_2D)
 
                     expect(textureConfig.width to textureConfig.height).toBe(100 to 1)
                     expect(textureConfig.internalFormat).toBe(GlContext.GL_RGB32F)


### PR DESCRIPTION
Texture units are now bound by `GlslProgram` immediately before each render.

Texture config happens on `GL_TEXTURE0` by default now.