### PR TITLE
Refactors toward projector support

### DIFF
--- a/src/commonMain/kotlin/baaahs/ShowPlayer.kt
+++ b/src/commonMain/kotlin/baaahs/ShowPlayer.kt
@@ -4,27 +4,15 @@ import baaahs.gl.Toolchain
 import baaahs.gl.data.FeedContext
 import baaahs.gl.shader.OpenShader
 import baaahs.gl.withCache
+import baaahs.plugin.Plugins
 import baaahs.scene.SceneProvider
-import baaahs.show.Feed
-import baaahs.show.Shader
-import baaahs.show.Show
-import baaahs.show.ShowState
+import baaahs.show.*
 import baaahs.show.live.OpenShow
 import baaahs.show.live.ShowOpener
+import baaahs.util.Clock
 
 interface ShowPlayer {
-    val toolchain: Toolchain
-
-    /**
-     * This is for [baaahs.plugin.core.feed.ModelInfoFeed], but we should probably find
-     * a better way to get it. Don't add more uses.
-     */
-    @Deprecated("Get it some other way", level = DeprecationLevel.WARNING)
-    val sceneProvider: SceneProvider
-
     fun <T : Gadget> registerGadget(id: String, gadget: T, controlledFeed: Feed? = null)
-    fun <T : Gadget> useGadget(id: String): T = error("override me?")
-    fun <T : Gadget> useGadget(feed: Feed): T?
 
     fun openFeed(id: String, feed: Feed): FeedContext
 
@@ -32,10 +20,15 @@ interface ShowPlayer {
 }
 
 abstract class BaseShowPlayer(
-    final override val toolchain: Toolchain,
+    val toolchain: Toolchain,
     @Deprecated("Get it some other way", level = DeprecationLevel.WARNING)
     final override val sceneProvider: SceneProvider
-) : ShowPlayer {
+) : ShowPlayer, FeedOpenContext {
+    override val clock: Clock
+        get() = toolchain.plugins.pluginContext.clock
+    override val plugins: Plugins
+        get() = toolchain.plugins
+
     private val feeds = mutableMapOf<Feed, FeedContext>()
     private val shaders = mutableMapOf<Shader, OpenShader>()
 

--- a/src/commonMain/kotlin/baaahs/control/ButtonControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/ButtonControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.editor.ButtonPropsEditor
 import baaahs.app.ui.editor.PropsEditor
 import baaahs.camelize
@@ -40,10 +39,10 @@ data class ButtonControl(
         )
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenButtonControl {
+    override fun open(id: String, openContext: OpenContext): OpenButtonControl {
         val controlledFeed = controlledFeedId?.let { openContext.getFeed(it) }
         return OpenButtonControl(id, this, openContext, controlledFeed)
-            .also { showPlayer.registerGadget(id, it.switch, controlledFeed) }
+            .also { openContext.registerGadget(id, it.switch, controlledFeed) }
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/control/ButtonGroupControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/ButtonGroupControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.ButtonGroupPropsEditor
 import baaahs.app.ui.editor.EditableManager
@@ -39,7 +38,7 @@ data class ButtonGroupControl(
             }.toMutableList(), mutableShow
         )
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenButtonGroupControl {
+    override fun open(id: String, openContext: OpenContext): OpenButtonGroupControl {
         return OpenButtonGroupControl(id, this, openContext)
     }
 }

--- a/src/commonMain/kotlin/baaahs/control/ColorPickerControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/ColorPickerControl.kt
@@ -1,7 +1,6 @@
 package baaahs.control
 
 import baaahs.Color
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -36,10 +35,10 @@ data class ColorPickerControl(
         )
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         val controlledFeed = openContext.getFeed(controlledFeedId)
         val colorPicker = ColorPicker(title, initialValue)
-        showPlayer.registerGadget(id, colorPicker, controlledFeed)
+        openContext.registerGadget(id, colorPicker, controlledFeed)
         return OpenColorPickerControl(id, colorPicker, controlledFeed)
     }
 }

--- a/src/commonMain/kotlin/baaahs/control/ImagePickerControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/ImagePickerControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.app.ui.editor.GenericPropertiesEditorPanel
@@ -33,10 +32,10 @@ data class ImagePickerControl(
         )
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         val controlledFeed = openContext.getFeed(controlledFeedId)
         val imagePicker = ImagePicker(title)
-        showPlayer.registerGadget(id, imagePicker, controlledFeed)
+        openContext.registerGadget(id, imagePicker, controlledFeed)
         return OpenImagePickerControl(id, imagePicker, controlledFeed)
     }
 }

--- a/src/commonMain/kotlin/baaahs/control/SliderControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/SliderControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.app.ui.editor.GenericPropertiesEditorPanel
@@ -46,10 +45,10 @@ data class SliderControl(
         )
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         val controlledFeed = openContext.getFeed(controlledFeedId)
         val slider = Slider(title, initialValue, minValue, maxValue, stepValue)
-        showPlayer.registerGadget(id, slider, controlledFeed)
+        openContext.registerGadget(id, slider, controlledFeed)
         return OpenSliderControl(id, slider, controlledFeed)
     }
 }

--- a/src/commonMain/kotlin/baaahs/control/VacuityControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/VacuityControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -30,7 +29,7 @@ data class VacuityControl(
     override fun createMutable(mutableShow: MutableShow): MutableVacuityControl =
         MutableVacuityControl(title)
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl =
+    override fun open(id: String, openContext: OpenContext): OpenControl =
         OpenVacuityControl(id, title)
 }
 

--- a/src/commonMain/kotlin/baaahs/control/VisualizerControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/VisualizerControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.app.ui.editor.GenericPropertiesEditorPanel
@@ -37,7 +36,7 @@ data class VisualizerControl(
         return MutableVisualizerControl(surfaceDisplayMode, rotate)
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         return OpenVisualizerControl(id, this)
     }
 }

--- a/src/commonMain/kotlin/baaahs/control/XyPadControl.kt
+++ b/src/commonMain/kotlin/baaahs/control/XyPadControl.kt
@@ -1,6 +1,5 @@
 package baaahs.control
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -38,11 +37,11 @@ data class XyPadControl(
         )
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenXyPadControl {
+    override fun open(id: String, openContext: OpenContext): OpenXyPadControl {
         val controlledFeed = openContext.getFeed(controlledFeedId)
         val xyPad = XyPad(title, initialValue, minValue, maxValue)
         return OpenXyPadControl(id, xyPad, controlledFeed)
-            .also { showPlayer.registerGadget(id, xyPad, controlledFeed) }
+            .also { openContext.registerGadget(id, xyPad, controlledFeed) }
     }
 }
 

--- a/src/commonMain/kotlin/baaahs/device/PixelCountFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelCountFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.device
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -15,6 +14,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.UpdateMode
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -31,7 +31,7 @@ data class PixelCountFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.XyzCoordinate
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
         return PixelCountFeedContext(getVarName(id))
     }
 

--- a/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
@@ -10,6 +10,7 @@ import baaahs.gl.glsl.GlslType
 import baaahs.gl.param.FloatsParamBuffer
 import baaahs.gl.param.ParamBuffer
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
@@ -41,7 +42,7 @@ data class PixelDistanceFromEdgeFeed(@Transient val `_`: Boolean = true) : Feed 
         return PixelDistanceFromEdgeFeedContext(getVarName(id), "ds_${id}_texture")
     }
 
-    override fun appendDeclaration(buf: StringBuilder, id: String) {
+    override fun appendDeclaration(buf: ProgramBuilder, id: String) {
         val textureUniformId = "ds_${id}_texture"
         val varName = getVarName(id)
         buf.append("""

--- a/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelDistanceFromEdgeFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.device
 
-import baaahs.ShowPlayer
 import baaahs.geom.Vector3F
 import baaahs.gl.GlContext
 import baaahs.gl.data.FeedContext
@@ -20,6 +19,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.Logger
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -37,7 +37,7 @@ data class PixelDistanceFromEdgeFeed(@Transient val `_`: Boolean = true) : Feed 
     override val contentType: ContentType
         get() = ContentType.Float
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
         return PixelDistanceFromEdgeFeedContext(getVarName(id), "ds_${id}_texture")
     }
 

--- a/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.device
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.FeedContext
 import baaahs.gl.data.PerPixelEngineFeedContext
@@ -18,6 +17,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.Logger
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -34,7 +34,7 @@ data class PixelIndexFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.XyzCoordinate
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
         return PixelIndexFeedContext(getVarName(id), "ds_${id}_texture")
     }
 

--- a/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelIndexFeed.kt
@@ -9,6 +9,7 @@ import baaahs.gl.glsl.GlslType
 import baaahs.gl.param.FloatsParamBuffer
 import baaahs.gl.param.ParamBuffer
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
@@ -38,7 +39,7 @@ data class PixelIndexFeed(@Transient val `_`: Boolean = true) : Feed {
         return PixelIndexFeedContext(getVarName(id), "ds_${id}_texture")
     }
 
-    override fun appendDeclaration(buf: StringBuilder, id: String) {
+    override fun appendDeclaration(buf: ProgramBuilder, id: String) {
         val textureUniformId = "ds_${id}_texture"
         val varName = getVarName(id)
         buf.append("""

--- a/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
@@ -10,6 +10,7 @@ import baaahs.gl.glsl.GlslType
 import baaahs.gl.param.FloatsParamBuffer
 import baaahs.gl.param.ParamBuffer
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.render.FixtureRenderTarget
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.shader.InputPort
@@ -43,7 +44,7 @@ data class PixelLocationFeed(@Transient val `_`: Boolean = true) : Feed {
     override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         PixelLocationFeedContext(getVarName(id), "ds_${id}_texture")
 
-    override fun appendDeclaration(buf: StringBuilder, id: String) {
+    override fun appendDeclaration(buf: ProgramBuilder, id: String) {
         val textureUniformId = "ds_${id}_texture"
         val varName = getVarName(id)
 

--- a/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
+++ b/src/commonMain/kotlin/baaahs/device/PixelLocationFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.device
 
-import baaahs.ShowPlayer
 import baaahs.geom.Vector3F
 import baaahs.gl.GlContext
 import baaahs.gl.data.FeedContext
@@ -20,6 +19,7 @@ import baaahs.plugin.core.CorePlugin
 import baaahs.plugin.core.FixtureInfoFeed
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.Logger
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -40,9 +40,8 @@ data class PixelLocationFeed(@Transient val `_`: Boolean = true) : Feed {
     override val dependencies: Map<String, Feed>
         get() = mapOf("fixtureInfo" to FixtureInfoFeed())
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        return PixelLocationFeedContext(getVarName(id), "ds_${id}_texture")
-    }
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
+        PixelLocationFeedContext(getVarName(id), "ds_${id}_texture")
 
     override fun appendDeclaration(buf: StringBuilder, id: String) {
         val textureUniformId = "ds_${id}_texture"

--- a/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
+++ b/src/commonMain/kotlin/baaahs/fixtures/FixtureManager.kt
@@ -82,8 +82,8 @@ class FixtureManagerImpl(
         return anyChanges
     }
 
-    private fun clearRenderTargets() {
-        renderTargets.values.forEach { it.release() }
+    private fun clearRenderPlan() {
+        renderTargets.values.forEach { it.clearRenderPlan() }
     }
 
     private fun getFixtureCount(): Int = renderTargets.size
@@ -109,8 +109,7 @@ class FixtureManagerImpl(
 
     private fun removeFixture(fixture: Fixture) {
         renderTargets.remove(fixture)?.let { renderTarget ->
-            logger.debug { "Removing fixture ${fixture.title}" }
-            renderManager.removeRenderTarget(renderTarget)
+            logger.debug { "Releasing fixture ${fixture.title}" }
             renderTarget.release()
             // TODO: remove from RemoteVisualizers
         } ?: throw IllegalStateException("huh? can't remove unknown fixture $fixture")
@@ -145,7 +144,7 @@ class FixtureManagerImpl(
         }
 
         if (remapFixtures) {
-            clearRenderTargets()
+            clearRenderPlan()
 
             currentRenderPlan?.let { renderPlan ->
                 renderManager.setRenderPlan(renderPlan)

--- a/src/commonMain/kotlin/baaahs/gl/patch/Component.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/Component.kt
@@ -11,10 +11,10 @@ interface Component {
 
     val invokeFromMain: Boolean
 
-    fun appendStructs(buf: StringBuilder)
-    fun appendDeclarations(buf: StringBuilder)
-    fun appendInvokeAndSet(buf: StringBuilder, injectionParams: Map<String, ContentType> = emptyMap())
-    fun appendInvokeAndReturn(buf: StringBuilder, inputPort: InputPort) = Unit
+    fun appendStructs(buf: ProgramBuilder)
+    fun appendDeclarations(buf: ProgramBuilder)
+    fun appendInvokeAndSet(buf: ProgramBuilder, injectionParams: Map<String, ContentType> = emptyMap())
+    fun appendInvokeAndReturn(buf: ProgramBuilder, inputPort: InputPort) = Unit
 
     fun getExpression(prefix: String): GlslExpr
 

--- a/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ContentType.kt
@@ -39,7 +39,7 @@ class ContentType(
     /**
      * OpenGL doesn't support struct buffers directly, so emit any struct results to scalar arrays.
      */
-    fun appendResultAsScalars(buf: StringBuilder, varName: String) {
+    fun appendResultAsScalars(buf: ProgramBuilder, varName: String) {
         buf.append(glslType.outputRepresentationGlsl(varName));
     }
 

--- a/src/commonMain/kotlin/baaahs/gl/patch/FeedComponent.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/FeedComponent.kt
@@ -19,24 +19,24 @@ class FeedComponent(
     override val invokeFromMain: Boolean
         get() = true
 
-    override fun appendStructs(buf: StringBuilder) {
+    override fun appendStructs(buf: ProgramBuilder) {
         val glslType = feed.contentType.glslType
         if (glslType is GlslType.Struct) {
             buf.append(glslType.toGlsl(null, emptySet()))
         }
     }
 
-    override fun appendDeclarations(buf: StringBuilder) {
+    override fun appendDeclarations(buf: ProgramBuilder) {
         buf.append("// Feed: ", feed.title, "\n")
         feed.appendDeclaration(buf, varName)
         buf.append("\n")
     }
 
-    override fun appendInvokeAndSet(buf: StringBuilder, injectionParams: Map<String, ContentType>) {
+    override fun appendInvokeAndSet(buf: ProgramBuilder, injectionParams: Map<String, ContentType>) {
         feed.appendInvokeAndSet(buf, varName)
     }
 
-    override fun appendInvokeAndReturn(buf: StringBuilder, inputPort: InputPort) {
+    override fun appendInvokeAndReturn(buf: ProgramBuilder, inputPort: InputPort) {
         buf.append("    return ")
         feed.appendInvoke(buf, varName, inputPort)
         buf.append(";\n")

--- a/src/commonMain/kotlin/baaahs/gl/patch/LinkedProgram.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/LinkedProgram.kt
@@ -11,7 +11,7 @@ class LinkedProgram(
     internal val linkNodes: Map<ProgramNode, LinkNode> // For diagnostics only.
 ) {
     fun toGlsl(): String {
-        val buf = StringBuilder()
+        val buf = ProgramBuilder()
         buf.append("#ifdef GL_ES\n")
         buf.append("precision mediump float;\n")
         buf.append("#endif\n")
@@ -39,7 +39,7 @@ class LinkedProgram(
         return buf.toString()
     }
 
-    private fun appendMain(buf: StringBuilder) {
+    private fun appendMain(buf: ProgramBuilder) {
         buf.append("\n#line 10001\n")
         buf.append("void main() {\n")
 
@@ -64,4 +64,10 @@ class LinkedProgram(
     fun toFullGlsl(glslVersion: String): String {
         return "#version ${glslVersion}\n\n${toGlsl()}\n"
     }
+}
+
+class ProgramBuilder(
+    private val buf: StringBuilder = StringBuilder()
+) : Appendable by buf {
+    override fun toString(): String = buf.toString()
 }

--- a/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ProgramLinker.kt
@@ -126,13 +126,13 @@ data class DefaultValueNode(
 
     override fun getNodeId(programLinker: ProgramLinker): String = "n/a"
 
-    override fun appendStructs(buf: StringBuilder) {
+    override fun appendStructs(buf: ProgramBuilder) {
     }
 
-    override fun appendDeclarations(buf: StringBuilder) {
+    override fun appendDeclarations(buf: ProgramBuilder) {
     }
 
-    override fun appendInvokeAndSet(buf: StringBuilder, injectionParams: Map<String, ContentType>) {
+    override fun appendInvokeAndSet(buf: ProgramBuilder, injectionParams: Map<String, ContentType>) {
     }
 
     override fun getExpression(prefix: String): GlslExpr {
@@ -169,9 +169,9 @@ abstract class ExprNode : ProgramNode, Component {
         return this
     }
 
-    override fun appendStructs(buf: StringBuilder) {}
-    override fun appendDeclarations(buf: StringBuilder) {}
-    override fun appendInvokeAndSet(buf: StringBuilder, injectionParams: Map<String, ContentType>) {}
+    override fun appendStructs(buf: ProgramBuilder) {}
+    override fun appendDeclarations(buf: ProgramBuilder) {}
+    override fun appendInvokeAndSet(buf: ProgramBuilder, injectionParams: Map<String, ContentType>) {}
 }
 
 data class ConstNode(val glsl: String, override val outputPort: OutputPort) : ExprNode() {

--- a/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
+++ b/src/commonMain/kotlin/baaahs/gl/patch/ShaderComponent.kt
@@ -61,7 +61,7 @@ class ShaderComponent(
 
     private val substitutions = ShaderSubstitutions(linkedPatch.shader, namespace, resolvedPortMap)
 
-    override fun appendStructs(buf: StringBuilder) {
+    override fun appendStructs(buf: ProgramBuilder) {
         val openShader = linkedPatch.shader
         val portStructs = openShader.portStructs
         openShader.glslCode.structs.forEach { struct ->
@@ -71,7 +71,7 @@ class ShaderComponent(
         }
     }
 
-    override fun appendDeclarations(buf: StringBuilder) {
+    override fun appendDeclarations(buf: ProgramBuilder) {
         val openShader = linkedPatch.shader
 
         buf.append("// Shader: ", openShader.title, "; namespace: ", prefix, "\n")
@@ -87,7 +87,7 @@ class ShaderComponent(
         buf.append(openShader.toGlsl(index, substitutions), "\n")
     }
 
-    private fun appendInjectionCode(buf: StringBuilder) {
+    private fun appendInjectionCode(buf: ProgramBuilder) {
         linkedPatch.incomingLinks.forEach { (portId, link) ->
             val inputPort = linkedPatch.shader.findInputPort(portId)
 
@@ -102,7 +102,7 @@ class ShaderComponent(
     }
 
     private fun appendInjectionAssignment(
-        buf: StringBuilder,
+        buf: ProgramBuilder,
         inputPort: InputPort,
         portId: String
     ) {
@@ -112,7 +112,7 @@ class ShaderComponent(
     }
 
     private fun appendAbstractFunctionImpl(
-        buf: StringBuilder,
+        buf: ProgramBuilder,
         inputPort: InputPort,
         link: ProgramNode
     ) {
@@ -126,7 +126,7 @@ class ShaderComponent(
         buf.append("}\n")
     }
 
-    override fun appendInvokeAndSet(buf: StringBuilder, injectionParams: Map<String, ContentType>) {
+    override fun appendInvokeAndSet(buf: ProgramBuilder, injectionParams: Map<String, ContentType>) {
         buf.append("    // Invoke ", title, "\n")
 
         injectionParams.forEach { (paramName, contentType) ->
@@ -142,7 +142,7 @@ class ShaderComponent(
         buf.append("\n")
     }
 
-    override fun appendInvokeAndReturn(buf: StringBuilder, inputPort: InputPort) {
+    override fun appendInvokeAndReturn(buf: ProgramBuilder, inputPort: InputPort) {
         appendInvokeAndSet(buf, inputPort.injectedData)
         buf.append("    return ", outputVar, ";\n")
     }

--- a/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
@@ -17,7 +17,7 @@ import com.danielgergely.kgl.GL_DEPTH_BUFFER_BIT
 import kotlin.math.max
 import kotlin.math.min
 
-class ModelRenderEngine(
+class ComponentRenderEngine(
     gl: GlContext,
     private val fixtureType: FixtureType,
     private val minTextureWidth: Int = 16,
@@ -66,7 +66,7 @@ class ModelRenderEngine(
         )
         val renderTarget = FixtureRenderTarget(
             fixture, nextRectOffset, rects, fixture.componentCount, nextComponentOffset, resultStorage,
-            this@ModelRenderEngine
+            this@ComponentRenderEngine
         )
         nextComponentOffset += fixture.componentCount
         nextRectOffset += rects.size
@@ -227,7 +227,7 @@ class ModelRenderEngine(
     }
 
     companion object {
-        private val logger = Logger<ModelRenderEngine>()
+        private val logger = Logger<ComponentRenderEngine>()
         private const val fbMaxPixWidth = 1024
 
         /** Resulting Rect is in pixel coordinates starting at (0,0) with Y increasing. */

--- a/src/commonMain/kotlin/baaahs/gl/render/FixtureRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/FixtureRenderEngine.kt
@@ -1,0 +1,8 @@
+package baaahs.gl.render
+
+import baaahs.fixtures.Fixture
+import baaahs.gl.GlContext
+
+abstract class FixtureRenderEngine(gl: GlContext) : RenderEngine(gl) {
+    abstract fun addFixture(fixture: Fixture): FixtureRenderTarget
+}

--- a/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ModelRenderEngine.kt
@@ -23,12 +23,12 @@ class ModelRenderEngine(
     private val minTextureWidth: Int = 16,
     private val maxFramebufferWidth: Int = fbMaxPixWidth,
     private val resultDeliveryStrategy: ResultDeliveryStrategy = SyncResultDeliveryStrategy()
-) : RenderEngine(gl) {
+) : FixtureRenderEngine(gl) {
     private val renderTargetsToAdd: MutableList<FixtureRenderTarget> = mutableListOf()
     private val renderTargetsToRemove: MutableList<FixtureRenderTarget> = mutableListOf()
     var componentCount: Int = 0
-    var nextComponentOffset: Int = 0
-    var nextRectOffset: Int = 0
+    private var nextComponentOffset: Int = 0
+    private var nextRectOffset: Int = 0
 
     private val renderTargets: MutableList<FixtureRenderTarget> = mutableListOf()
     private var renderPlan: FixtureTypeRenderPlan? = null
@@ -52,7 +52,7 @@ class ModelRenderEngine(
     // Workaround for compile error on case-insensitive FS:
     init { arrangement = gl.runInContext { Arrangement(0, emptyList()) } }
 
-    fun addFixture(fixture: Fixture): FixtureRenderTarget {
+    override fun addFixture(fixture: Fixture): FixtureRenderTarget {
         if (fixture.fixtureType != fixtureType) {
             throw IllegalArgumentException(
                 "This RenderEngine can't accept ${fixture.fixtureType} devices, only $fixtureType."
@@ -65,7 +65,8 @@ class ModelRenderEngine(
             fixture
         )
         val renderTarget = FixtureRenderTarget(
-            fixture, nextRectOffset, rects, fixture.componentCount, nextComponentOffset, resultStorage
+            fixture, nextRectOffset, rects, fixture.componentCount, nextComponentOffset, resultStorage,
+            this@ModelRenderEngine
         )
         nextComponentOffset += fixture.componentCount
         nextRectOffset += rects.size

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
@@ -8,8 +8,8 @@ import baaahs.util.CacheBuilder
 import baaahs.util.Logger
 
 class RenderManager(glContext: GlContext) {
-    private val renderEngines = CacheBuilder<FixtureType, ModelRenderEngine> { fixtureType ->
-        ModelRenderEngine(
+    private val renderEngines = CacheBuilder<FixtureType, ComponentRenderEngine> { fixtureType ->
+        ComponentRenderEngine(
             glContext, fixtureType, resultDeliveryStrategy = glContext.pickResultDeliveryStrategy()
         )
     }

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderManager.kt
@@ -4,9 +4,6 @@ import baaahs.device.FixtureType
 import baaahs.fixtures.Fixture
 import baaahs.fixtures.RenderPlan
 import baaahs.gl.GlContext
-import baaahs.gl.glsl.FeedResolver
-import baaahs.gl.glsl.GlslProgram
-import baaahs.gl.patch.LinkedProgram
 import baaahs.util.CacheBuilder
 import baaahs.util.Logger
 
@@ -17,7 +14,7 @@ class RenderManager(glContext: GlContext) {
         )
     }
 
-    private fun engineFor(fixtureType: FixtureType): ModelRenderEngine =
+    private fun engineFor(fixtureType: FixtureType): FixtureRenderEngine =
         renderEngines.getBang(fixtureType, "render engine")
 
     suspend fun draw() {
@@ -30,14 +27,6 @@ class RenderManager(glContext: GlContext) {
 
     fun addFixture(fixture: Fixture): FixtureRenderTarget {
         return engineFor(fixture.fixtureType).addFixture(fixture)
-    }
-
-    fun removeRenderTarget(renderTarget: FixtureRenderTarget) {
-        engineFor(renderTarget.fixture.fixtureType).removeRenderTarget(renderTarget)
-    }
-
-    fun compile(fixtureType: FixtureType, linkedProgram: LinkedProgram, feedResolver: FeedResolver): GlslProgram {
-        return engineFor(fixtureType).compile(linkedProgram, feedResolver).bind()
     }
 
     fun setRenderPlan(renderPlan: RenderPlan) {

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
@@ -22,7 +22,7 @@ class FixtureRenderTarget(
     override val componentCount: Int,
     val component0Index: Int,
     resultStorage: ResultStorage,
-    override val renderEngine: ModelRenderEngine
+    override val renderEngine: ComponentRenderEngine
 ) : RenderTarget {
     var program: GlslProgram? = null
         private set

--- a/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/RenderTarget.kt
@@ -8,8 +8,10 @@ import baaahs.visualizer.remote.RemoteVisualizers
 interface RenderTarget {
     val fixture: Fixture
     val componentCount: Int
+    val renderEngine: RenderEngine
 
     fun sendFrame(remoteVisualizers: RemoteVisualizers)
+    fun clearRenderPlan()
     fun release()
 }
 
@@ -19,7 +21,8 @@ class FixtureRenderTarget(
     val rects: List<Quad.Rect>, // these are in pixels, (0,0) at top left
     override val componentCount: Int,
     val component0Index: Int,
-    resultStorage: ResultStorage
+    resultStorage: ResultStorage,
+    override val renderEngine: ModelRenderEngine
 ) : RenderTarget {
     var program: GlslProgram? = null
         private set
@@ -30,8 +33,12 @@ class FixtureRenderTarget(
         fixtureResults.send(remoteVisualizers)
     }
 
-    override fun release() {
+    override fun clearRenderPlan() {
         program = null
+    }
+
+    override fun release() {
+        renderEngine.removeRenderTarget(this)
     }
 
     /** Only call me from [RenderEngine]! */

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkControl.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkControl.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.beatlink
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -27,7 +26,7 @@ data class BeatLinkControl(@Transient private val `_`: Boolean = false) : Contro
         return MutableBeatLinkControl()
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         return OpenBeatLinkControl(id)
     }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/beatlink/BeatLinkPlugin.kt
@@ -1,7 +1,6 @@
 package baaahs.plugin.beatlink
 
 import baaahs.PubSub
-import baaahs.ShowPlayer
 import baaahs.app.ui.CommonIcons
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
@@ -15,6 +14,7 @@ import baaahs.gl.shader.InputPort
 import baaahs.plugin.*
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.sim.BridgeClient
 import baaahs.ui.Observable
 import baaahs.ui.addObserver
@@ -126,7 +126,7 @@ class BeatLinkPlugin internal constructor(
 
         override fun getType(): GlslType = GlslType.Float
 
-        override fun open(showPlayer: ShowPlayer, id: String) =
+        override fun open(feedOpenContext: FeedOpenContext, id: String) =
             singleUniformFeedContext<Float>(id) {
                 beatSource.getBeatData().fractionTillNextBeat(clock)
             }
@@ -140,7 +140,7 @@ class BeatLinkPlugin internal constructor(
         override val contentType: ContentType
             get() = beatInfoContentType
 
-        override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+        override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
             val varPrefix = getVarName(id)
             return object : FeedContext, RefCounted by RefCounter() {
                 override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
@@ -180,7 +180,7 @@ class BeatLinkPlugin internal constructor(
         override val contentType: ContentType
             get() = rawBeatInfoContentType
 
-        override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+        override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
             val varPrefix = getVarName(id)
             return object : FeedContext, RefCounted by RefCounter() {
                 override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {

--- a/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/FixtureInfo.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core
 
-import baaahs.ShowPlayer
 import baaahs.geom.EulerAngle
 import baaahs.geom.Matrix4F
 import baaahs.geom.Vector3F
@@ -18,6 +17,7 @@ import baaahs.model.Model
 import baaahs.plugin.classSerializer
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.UpdateMode
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -46,7 +46,7 @@ data class FixtureInfoFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = fixtureInfoContentType
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
         return FixtureInfoFeedContext(getVarName(id))
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/Transition.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/Transition.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -28,7 +27,7 @@ data class TransitionControl(@Transient private val `_`: Boolean = false) : Cont
         return MutableTransitionControl()
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         return OpenTransitionControl(id)
     }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ColorPickerFeed.kt
@@ -1,7 +1,6 @@
 package baaahs.plugin.core.feed
 
 import baaahs.Color
-import baaahs.ShowPlayer
 import baaahs.control.MutableColorPickerControl
 import baaahs.gadgets.ColorPicker
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
 import kotlinx.serialization.SerialName
@@ -33,10 +33,10 @@ data class ColorPickerFeed(
         return MutableColorPickerControl(colorPickerTitle, initialValue, this)
     }
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
 //        val channel = showPlayer.useChannel<Float>(id)
-        val colorPicker = showPlayer.useGadget(this)
-            ?: showPlayer.useGadget(id)
+        val colorPicker = feedOpenContext.useGadget(this)
+            ?: feedOpenContext.useGadget(id)
             ?: run {
                 logger.debug { "No control gadget registered for feed $id, creating one. This is probably busted." }
                 createGadget()

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/DateFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/DateFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.geom.Vector4F
 import baaahs.gl.data.FeedContext
 import baaahs.gl.data.singleUniformFeedContext
@@ -11,6 +10,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import com.soywiz.klock.DateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -52,8 +52,8 @@ data class DateFeed(
     override val contentType: ContentType
         get() = ContentType.Date
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val clock = showPlayer.toolchain.plugins.pluginContext.clock
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val clock = feedOpenContext.clock
         return singleUniformFeedContext<Vector4F>(id) {
             val dateTime = DateTime(clock.now() * 1000)
             Vector4F(

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.control.MutableImagePickerControl
 import baaahs.gadgets.ImagePicker
 import baaahs.gadgets.ImageRef
@@ -18,6 +17,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
 import baaahs.util.RefCounted
@@ -57,9 +57,9 @@ data class ImageFeed(override val title: String) : Feed {
         buf.append("texture($textureUniformId, vec2($uvParamName.x, 1. - $uvParamName.y))")
     }
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val imagePicker = showPlayer.useGadget(this)
-            ?: showPlayer.useGadget(id)
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val imagePicker = feedOpenContext.useGadget(this)
+            ?: feedOpenContext.useGadget(id)
             ?: run {
                 logger.debug { "No control gadget registered for feed $id, creating one. This is probably busted." }
                 createGadget()

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ImageFeed.kt
@@ -11,6 +11,7 @@ import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.shader.InputPort
 import baaahs.imaging.Image
 import baaahs.plugin.classSerializer
@@ -43,13 +44,13 @@ data class ImageFeed(override val title: String) : Feed {
     override fun buildControl(): MutableControl =
         MutableImagePickerControl(title, this)
 
-    override fun appendDeclaration(buf: StringBuilder, id: String) {
+    override fun appendDeclaration(buf: ProgramBuilder, id: String) {
         val textureUniformId = "ds_${getVarName(id)}_texture"
         /**language=glsl*/
         buf.append("uniform sampler2D $textureUniformId;\n")
     }
 
-    override fun appendInvoke(buf: StringBuilder, varName: String, inputPort: InputPort) {
+    override fun appendInvoke(buf: ProgramBuilder, varName: String, inputPort: InputPort) {
         val fn = inputPort.glslArgSite as GlslCode.GlslFunction
 
         val textureUniformId = "ds_${getVarName(varName)}_texture"

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ModelInfoFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ModelInfoFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.geom.Vector3F
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
@@ -14,6 +13,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.UpdateMode
 import baaahs.ui.addObserver
 import baaahs.util.RefCounted
@@ -43,8 +43,8 @@ data class ModelInfoFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.ModelInfo
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val sceneProvider = showPlayer.sceneProvider
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val sceneProvider = feedOpenContext.sceneProvider
 
         return object : FeedContext, RefCounted by RefCounter() {
             var center: Vector3F? = null

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/PixelCoordsTextureFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/PixelCoordsTextureFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
@@ -43,7 +43,7 @@ data class PixelCoordsTextureFeed(@Transient val `_`: Boolean = true) : Feed {
         get() = ContentType.PixelCoordinatesTexture
     override fun suggestId(): String = "pixelCoordsTexture"
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         object : FeedContext, RefCounted by RefCounter() {
             override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                 override fun bind(glslProgram: GlslProgram): ProgramFeedContext = object : ProgramFeedContext {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/PreviewResolutionFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/PreviewResolutionFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
@@ -41,7 +41,7 @@ data class PreviewResolutionFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.PreviewResolution
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         object : FeedContext, RefCounted by RefCounter() {
             override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                 override fun bind(glslProgram: GlslProgram): ProgramFeedContext =

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/RadioButtonStripFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/RadioButtonStripFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.gadgets.RadioButtonStrip
 import baaahs.gl.data.FeedContext
 import baaahs.gl.glsl.GlslType
@@ -10,6 +9,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.int
@@ -23,7 +23,7 @@ data class RadioButtonStripFeed(
     val options: List<String>,
     val initialSelectionIndex: Int
 ) : Feed {
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
         TODO("not implemented")
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
@@ -7,6 +7,7 @@ import baaahs.gl.data.ProgramFeedContext
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.shader.InputPort
 import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
@@ -68,7 +69,7 @@ data class RasterCoordinateFeed(@Transient val `_`: Boolean = true) : Feed {
 
     override fun isImplicit(): Boolean = true
 
-    override fun appendDeclaration(buf: StringBuilder, id: String) {
+    override fun appendDeclaration(buf: ProgramBuilder, id: String) {
         val offsetUniformId = "ds_${id}_offset"
         val varName = getVarName(id)
         buf.append("""

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/RasterCoordinateFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 import kotlinx.serialization.SerialName
@@ -23,7 +23,7 @@ import kotlinx.serialization.Transient
  * This feed provides `gl_FragColor` for quad previews.
  *
  * Because `gl_FragColor` is always given as absolute pixels relative to the bottom-left
- * of the screen/canvas, _not_ relative to the the viewport, and we might be rendering
+ * of the screen/canvas, _not_ relative to the viewport, and we might be rendering
  * into a `SharedGlContext` (which adjusts the viewport to a rectangle within the shared
  * canvas), we need to adjust `gl_FragColor` to account for any offset.
  */
@@ -49,7 +49,7 @@ data class RasterCoordinateFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.RasterCoordinate
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         object : FeedContext, RefCounted by RefCounter() {
             override fun bind(gl: GlContext): EngineFeedContext = object : EngineFeedContext {
                 val offsetUniformId = "ds_${id}_offset"

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/ResolutionFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.geom.Vector2F
 import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
@@ -10,6 +9,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -39,6 +39,6 @@ data class ResolutionFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.Resolution
 
-    override fun open(showPlayer: ShowPlayer, id: String) =
+    override fun open(feedOpenContext: FeedOpenContext, id: String) =
         singleUniformFeedContext<Vector2F>(id) { Vector2F.unit2d }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/SliderFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/SliderFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.control.MutableSliderControl
 import baaahs.gadgets.Slider
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
 import kotlinx.serialization.SerialName
@@ -44,17 +44,17 @@ data class SliderFeed(
     override fun buildControl(): MutableControl =
         MutableSliderControl(sliderTitle, initialValue, minValue, maxValue, stepValue, this)
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val clock = showPlayer.toolchain.plugins.pluginContext.clock
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val clock = feedOpenContext.clock
 //        val channel = showPlayer.useChannel<Float>(id)
-        val slider = showPlayer.useGadget(this)
-            ?: showPlayer.useGadget(id)
+        val slider = feedOpenContext.useGadget(this)
+            ?: feedOpenContext.useGadget(id)
             ?: run {
                 logger.debug { "No control gadget registered for feed $id, creating one. This is probably busted." }
                 createGadget()
             }
 
-        val plugin = showPlayer.toolchain.plugins.findPlugin<BeatLinkPlugin>()
+        val plugin = feedOpenContext.plugins.findPlugin<BeatLinkPlugin>()
         val beatSource = plugin?.beatSource
 
         return singleUniformFeedContext<Float>(id) {

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/SwitchFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.control.ButtonControl
 import baaahs.control.MutableButtonControl
 import baaahs.gadgets.Switch
@@ -13,6 +12,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.mutable.MutableControl
 import baaahs.show.mutable.MutableShow
 import baaahs.util.Logger
@@ -44,9 +44,9 @@ data class SwitchFeed(
         return MutableButtonControl(createGadget(), MutableShow("Temp Show"), this)
     }
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val switch = showPlayer.useGadget(this)
-            ?: showPlayer.useGadget(id)
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val switch = feedOpenContext.useGadget(this)
+            ?: feedOpenContext.useGadget(id)
             ?: run {
                 logger.debug { "No control gadget registered for feed $id, creating one. This is probably busted." }
                 Switch(buttonTitle, initiallyEnabled)

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/TimeFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.gl.data.FeedContext
 import baaahs.gl.data.singleUniformFeedContext
 import baaahs.gl.glsl.GlslType
@@ -10,6 +9,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.makeSafeForGlsl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -34,8 +34,8 @@ data class TimeFeed(@Transient val `_`: Boolean = true) : Feed {
     override val contentType: ContentType
         get() = ContentType.Time
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val clock = showPlayer.toolchain.plugins.pluginContext.clock
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val clock = feedOpenContext.clock
         return singleUniformFeedContext<Float>(id) { clock.now().makeSafeForGlsl() }
     }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/core/feed/XyPadFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.core.feed
 
-import baaahs.ShowPlayer
 import baaahs.control.MutableXyPadControl
 import baaahs.gadgets.XyPad
 import baaahs.geom.Vector2F
@@ -14,6 +13,7 @@ import baaahs.plugin.classSerializer
 import baaahs.plugin.core.CorePlugin
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.show.mutable.MutableControl
 import baaahs.util.Logger
 import kotlinx.serialization.SerialName
@@ -40,9 +40,9 @@ data class XyPadFeed(
     override fun buildControl(): MutableControl =
         MutableXyPadControl(title, initialValue, minValue, maxValue, this)
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
-        val xyPad = showPlayer.useGadget(this)
-            ?: showPlayer.useGadget(id)
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
+        val xyPad = feedOpenContext.useGadget(this)
+            ?: feedOpenContext.useGadget(id)
             ?: run {
                 logger.debug { "No control gadget registered for feed $id, creating one. This is probably busted." }
                 XyPad(title, initialValue, minValue, maxValue)

--- a/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisControl.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisControl.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.sound_analysis
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
 import baaahs.camelize
@@ -27,7 +26,7 @@ data class SoundAnalysisControl(@Transient private val `_`: Boolean = false) : C
         return MutableSoundAnalysisControl()
     }
 
-    override fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl {
+    override fun open(id: String, openContext: OpenContext): OpenControl {
         return OpenSoundAnalysisControl(id)
     }
 }

--- a/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/sound_analysis/SoundAnalysisPlugin.kt
@@ -1,7 +1,6 @@
 package baaahs.plugin.sound_analysis
 
 import baaahs.PubSub
-import baaahs.ShowPlayer
 import baaahs.app.ui.CommonIcons
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.clamp
@@ -18,6 +17,7 @@ import baaahs.plugin.*
 import baaahs.show.Control
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.sim.BridgeClient
 import baaahs.util.*
 import com.danielgergely.kgl.*
@@ -69,7 +69,7 @@ class SoundAnalysisPlugin internal constructor(
         override val contentType: ContentType get() = soundAnalysisContentType
         override fun getType(): GlslType = soundAnalysisStruct
 
-        override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+        override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
             SoundAnalysisFeedContext(getVarName(id), soundAnalyzer, historySize)
     }
 

--- a/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
@@ -8,6 +8,7 @@ import baaahs.gl.glsl.GlslCode
 import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.shader.InputPort
 import baaahs.plugin.*
 import baaahs.show.Feed
@@ -52,13 +53,13 @@ class VideoInPlugin(private val videoProvider: VideoProvider) : OpenServerPlugin
         override fun getType(): GlslType = GlslType.Sampler2D
         override val contentType: ContentType get() = ContentType.Color
 
-        override fun appendDeclaration(buf: StringBuilder, id: String) {
+        override fun appendDeclaration(buf: ProgramBuilder, id: String) {
             val textureUniformId = "ds_${getVarName(id)}_texture"
             /**language=glsl*/
             buf.append("uniform sampler2D $textureUniformId;\n")
         }
 
-        override fun appendInvoke(buf: StringBuilder, varName: String, inputPort: InputPort) {
+        override fun appendInvoke(buf: ProgramBuilder, varName: String, inputPort: InputPort) {
             val fn = inputPort.glslArgSite as GlslCode.GlslFunction
 
             val textureUniformId = "ds_${getVarName(varName)}_texture"

--- a/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
+++ b/src/commonMain/kotlin/baaahs/plugin/webcam/VideoInPlugin.kt
@@ -1,6 +1,5 @@
 package baaahs.plugin.webcam
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -13,6 +12,7 @@ import baaahs.gl.shader.InputPort
 import baaahs.plugin.*
 import baaahs.show.Feed
 import baaahs.show.FeedBuilder
+import baaahs.show.FeedOpenContext
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 import com.danielgergely.kgl.GL_LINEAR
@@ -66,7 +66,7 @@ class VideoInPlugin(private val videoProvider: VideoProvider) : OpenServerPlugin
             buf.append("texture($textureUniformId, vec2($uvParamName.x, 1. - $uvParamName.y))")
         }
 
-        override fun open(showPlayer: ShowPlayer, id: String): FeedContext {
+        override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext {
             return object : FeedContext, RefCounted by RefCounter() {
                 override fun bind(gl: GlContext): EngineFeedContext {
                     return object : EngineFeedContext {

--- a/src/commonMain/kotlin/baaahs/show/Control.kt
+++ b/src/commonMain/kotlin/baaahs/show/Control.kt
@@ -1,6 +1,5 @@
 package baaahs.show
 
-import baaahs.ShowPlayer
 import baaahs.app.ui.editor.Editable
 import baaahs.camelize
 import baaahs.show.live.OpenContext
@@ -18,5 +17,5 @@ interface Control : Editable {
     /** Don't call this directly; use [MutableShow.findControl]. */
     fun createMutable(mutableShow: MutableShow): MutableControl
 
-    fun open(id: String, openContext: OpenContext, showPlayer: ShowPlayer): OpenControl
+    fun open(id: String, openContext: OpenContext): OpenControl
 }

--- a/src/commonMain/kotlin/baaahs/show/Feed.kt
+++ b/src/commonMain/kotlin/baaahs/show/Feed.kt
@@ -6,6 +6,7 @@ import baaahs.camelize
 import baaahs.gl.data.FeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
+import baaahs.gl.patch.ProgramBuilder
 import baaahs.gl.shader.InputPort
 import baaahs.plugin.Plugins
 import baaahs.plugin.SerializerRegistrar
@@ -98,14 +99,14 @@ interface Feed {
 
     fun buildControl(): MutableControl? = null
 
-    fun appendDeclaration(buf: StringBuilder, id: String) {
+    fun appendDeclaration(buf: ProgramBuilder, id: String) {
         if (!isImplicit())
             buf.append("uniform ${getType().glslLiteral} ${getVarName(id)};\n")
     }
 
     fun invocationGlsl(varName: String): String? = null
 
-    fun appendInvokeAndSet(buf: StringBuilder, varName: String) {
+    fun appendInvokeAndSet(buf: ProgramBuilder, varName: String) {
         val invocationGlsl = invocationGlsl(varName)
         if (invocationGlsl != null) {
             buf.append("    // Invoke ", title, "\n")
@@ -114,7 +115,7 @@ interface Feed {
         }
     }
 
-    fun appendInvoke(buf: StringBuilder, varName: String, inputPort: InputPort) = Unit
+    fun appendInvoke(buf: ProgramBuilder, varName: String, inputPort: InputPort) = Unit
 }
 
 interface FeedOpenContext {

--- a/src/commonMain/kotlin/baaahs/show/Feed.kt
+++ b/src/commonMain/kotlin/baaahs/show/Feed.kt
@@ -1,17 +1,20 @@
 package baaahs.show
 
-import baaahs.ShowPlayer
+import baaahs.Gadget
 import baaahs.app.ui.editor.PortLinkOption
 import baaahs.camelize
 import baaahs.gl.data.FeedContext
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.gl.shader.InputPort
+import baaahs.plugin.Plugins
 import baaahs.plugin.SerializerRegistrar
+import baaahs.scene.SceneProvider
 import baaahs.show.live.OpenPatch
 import baaahs.show.mutable.MutableControl
 import baaahs.show.mutable.MutableFeedPort
 import baaahs.ui.Markdown
+import baaahs.util.Clock
 import baaahs.util.Logger
 import kotlinx.serialization.Polymorphic
 
@@ -87,7 +90,7 @@ interface Feed {
     fun getType(): GlslType
     fun getVarName(id: String): String = "in_$id"
 
-    fun open(showPlayer: ShowPlayer, id: String): FeedContext
+    fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext
 
     fun link(varName: String) = OpenPatch.FeedLink(this, varName, emptyMap())
 
@@ -112,6 +115,21 @@ interface Feed {
     }
 
     fun appendInvoke(buf: StringBuilder, varName: String, inputPort: InputPort) = Unit
+}
+
+interface FeedOpenContext {
+    val clock: Clock
+    val plugins: Plugins
+
+    /**
+     * This is for [baaahs.plugin.core.feed.ModelInfoFeed], but we should probably find
+     * a better way to get it. Don't add more uses.
+     */
+    @Deprecated("Get it some other way", level = DeprecationLevel.WARNING)
+    val sceneProvider: SceneProvider
+
+    fun <T : Gadget> useGadget(id: String): T = error("override me?")
+    fun <T : Gadget> useGadget(feed: Feed): T?
 }
 
 enum class UpdateMode {

--- a/src/commonMain/kotlin/baaahs/show/UnknownFeed.kt
+++ b/src/commonMain/kotlin/baaahs/show/UnknownFeed.kt
@@ -1,6 +1,5 @@
 package baaahs.show
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -25,7 +24,7 @@ data class UnknownFeed(
 
     override fun getType(): GlslType = GlslType.Void
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         UnknownFeedContext()
 
     class UnknownFeedContext : FeedContext, RefCounted by RefCounter() {

--- a/src/commonMain/kotlin/baaahs/show/live/OpenShow.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/OpenShow.kt
@@ -1,5 +1,6 @@
 package baaahs.show.live
 
+import baaahs.Gadget
 import baaahs.ShowPlayer
 import baaahs.app.ui.dialog.DialogPanel
 import baaahs.app.ui.editor.EditableManager
@@ -21,7 +22,7 @@ import baaahs.util.Logger
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
 
-interface OpenContext {
+interface OpenContext : GadgetProvider {
     val allControls: List<OpenControl>
     val allPatchModFeeds: List<Feed>
 
@@ -47,6 +48,9 @@ object EmptyOpenContext : OpenContext {
     override fun getPanel(id: String): Panel = error("not really an open context")
 
     override fun getPatch(it: String): OpenPatch = error("not really an open context")
+
+    override fun <T : Gadget> registerGadget(id: String, gadget: T, controlledFeed: Feed?) =
+        error("not really an open context")
 
     override fun release() {
     }

--- a/src/commonMain/kotlin/baaahs/show/live/ShowOpener.kt
+++ b/src/commonMain/kotlin/baaahs/show/live/ShowOpener.kt
@@ -25,7 +25,7 @@ open class ShowOpener(
 
     private val openControlCache = CacheBuilder<String, OpenControl> { controlId ->
         (implicitControls[controlId] ?: show.getControl(controlId))
-            .open(controlId, this, showPlayer)
+            .open(controlId, this)
     }
 
     override val allControls: List<OpenControl> get() = openControlCache.all.values.toList()
@@ -43,8 +43,6 @@ open class ShowOpener(
             override fun <T : Gadget> registerGadget(id: String, gadget: T, controlledFeed: Feed?) =
                 showPlayer.registerGadget(id, gadget)
 
-            override fun <T : Gadget> useGadget(id: String): T =
-                showPlayer.useGadget(id)
         }
     )
 
@@ -80,6 +78,10 @@ open class ShowOpener(
     open fun openShader(shader: Shader) =
         toolchain.openShader(shader)
 
+    override fun <T : Gadget> registerGadget(id: String, gadget: T, controlledFeed: Feed?) {
+        showPlayer.registerGadget(id, gadget, controlledFeed)
+    }
+
     override fun release() {
 //        allControls.forEach { it.release() }
 //        openShaders.forEach { it.release() }
@@ -93,5 +95,4 @@ open class ShowOpener(
 
 interface GadgetProvider {
     fun <T : Gadget> registerGadget(id: String, gadget: T, controlledFeed: Feed? = null)
-    fun <T : Gadget> useGadget(id: String): T = error("override me?")
 }

--- a/src/commonMain/kotlin/baaahs/sm/server/StageManager.kt
+++ b/src/commonMain/kotlin/baaahs/sm/server/StageManager.kt
@@ -31,7 +31,7 @@ class StageManager(
     private val pubSub: PubSub.Server,
     private val storage: Storage,
     private val fixtureManager: FixtureManager,
-    private val clock: Clock,
+    override val clock: Clock,
     private val gadgetManager: GadgetManager,
     private val serverNotices: ServerNotices,
     private val sceneMonitor: SceneMonitor

--- a/src/commonTest/kotlin/baaahs/TestUtil.kt
+++ b/src/commonTest/kotlin/baaahs/TestUtil.kt
@@ -11,7 +11,7 @@ import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.openShader
 import baaahs.gl.patch.ProgramLinker
 import baaahs.gl.patch.ProgramNode
-import baaahs.gl.render.ModelRenderEngine
+import baaahs.gl.render.ComponentRenderEngine
 import baaahs.gl.render.RenderTarget
 import baaahs.gl.testToolchain
 import baaahs.model.FakeModelEntity
@@ -108,7 +108,7 @@ class TestRenderContext(
     val model = fakeModel(modelEntities.toList())
     val fixtureType = modelEntities.map { it.fixtureType }.distinct().only("fixture type")
     val gl = FakeGlContext()
-    val renderEngine = ModelRenderEngine(gl, fixtureType, minTextureWidth = 1,)
+    val renderEngine = ComponentRenderEngine(gl, fixtureType, minTextureWidth = 1,)
     val showPlayer = FakeShowPlayer()
     val renderTargets = mutableListOf<RenderTarget>()
 

--- a/src/commonTest/kotlin/baaahs/gl/render/ComponentRenderEngineSpec.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/ComponentRenderEngineSpec.kt
@@ -28,8 +28,8 @@ import com.danielgergely.kgl.*
 import org.spekframework.spek2.Spek
 
 @Suppress("unused")
-object ModelRenderEngineSpec : Spek({
-    describe<ModelRenderEngine> {
+object ComponentRenderEngineSpec : Spek({
+    describe<ComponentRenderEngine> {
         val gl by value { FakeGlContext() }
         val updateMode by value { UpdateMode.ONCE }
         val fixtureFeed by value { PerFixtureFeedForTest(updateMode) }
@@ -38,7 +38,7 @@ object ModelRenderEngineSpec : Spek({
         val fixtureType by value { FixtureTypeForTest(feed) }
         val maxFramebufferWidth by value { 64 }
         val renderEngine by value {
-            ModelRenderEngine(gl, fixtureType, minTextureWidth = 1, maxFramebufferWidth)
+            ComponentRenderEngine(gl, fixtureType, minTextureWidth = 1, maxFramebufferWidth)
         }
         val texture by value { gl.textures.only("texture") }
 

--- a/src/commonTest/kotlin/baaahs/gl/render/PerFixtureFeedForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerFixtureFeedForTest.kt
@@ -1,6 +1,5 @@
 package baaahs.gl.render
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -9,6 +8,7 @@ import baaahs.gl.glsl.GlslProgram
 import baaahs.gl.glsl.GlslType
 import baaahs.gl.patch.ContentType
 import baaahs.show.Feed
+import baaahs.show.FeedOpenContext
 import baaahs.show.UpdateMode
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -25,7 +25,7 @@ class PerFixtureFeedForTest(val updateMode: UpdateMode) : Feed {
 
     var counter = 0
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         TestFeedContext(id).also { feeds.add(it) }
 
     inner class TestFeedContext(val id: String) : FeedContext, RefCounted by RefCounter() {

--- a/src/commonTest/kotlin/baaahs/gl/render/PerPixelFeedForTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/PerPixelFeedForTest.kt
@@ -1,6 +1,5 @@
 package baaahs.gl.render
 
-import baaahs.ShowPlayer
 import baaahs.gl.GlContext
 import baaahs.gl.data.EngineFeedContext
 import baaahs.gl.data.FeedContext
@@ -12,6 +11,7 @@ import baaahs.gl.param.FloatsParamBuffer
 import baaahs.gl.param.ParamBuffer
 import baaahs.gl.patch.ContentType
 import baaahs.show.Feed
+import baaahs.show.FeedOpenContext
 import baaahs.show.UpdateMode
 import baaahs.util.RefCounted
 import baaahs.util.RefCounter
@@ -28,7 +28,7 @@ class PerPixelFeedForTest(val updateMode: UpdateMode) : Feed {
 
     var counter = 0f
 
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext =
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext =
         TestFeedContext(id).also { feeds.add(it) }
 
     inner class TestFeedContext(val id: String) : FeedContext, RefCounted by RefCounter() {

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderEngineTest.kt
@@ -26,14 +26,14 @@ class RenderEngineTest {
 //    fun verifyGlslAvailable() = assumeTrue(GlslBase.manager.available)
 
     private lateinit var glContext: GlContext
-    private lateinit var renderEngine: ModelRenderEngine
+    private lateinit var renderEngine: ComponentRenderEngine
     private lateinit var fakeShowPlayer: FakeShowPlayer
 
     @BeforeTest
     fun setUp() {
         if (glslAvailable()) {
             glContext = GlBase.manager.createContext()
-            renderEngine = ModelRenderEngine(glContext, PixelArrayDevice,)
+            renderEngine = ComponentRenderEngine(glContext, PixelArrayDevice,)
             fakeShowPlayer = FakeShowPlayer()
         }
     }
@@ -201,7 +201,7 @@ class RenderEngineTest {
         // xxx.
         expect(listOf(
             Quad.Rect(1f, 0f, 2f, 3f)
-        )) { ModelRenderEngine.mapFixtureComponentsToRects(4, 4, createSurface("A", 3)) }
+        )) { ComponentRenderEngine.mapFixtureComponentsToRects(4, 4, createSurface("A", 3)) }
 
         // ...x
         // xxxx
@@ -210,7 +210,7 @@ class RenderEngineTest {
             Quad.Rect(0f, 3f, 1f, 4f),
             Quad.Rect(1f, 0f, 2f, 4f),
             Quad.Rect(2f, 0f, 3f, 2f)
-        )) { ModelRenderEngine.mapFixtureComponentsToRects(3, 4, createSurface("A", 7)) }
+        )) { ComponentRenderEngine.mapFixtureComponentsToRects(3, 4, createSurface("A", 7)) }
     }
 
     private fun fakeSurface(name: String = "xyz", pixelCount: Int = 3): Fixture {

--- a/src/commonTest/kotlin/baaahs/gl/render/RenderManagerTest.kt
+++ b/src/commonTest/kotlin/baaahs/gl/render/RenderManagerTest.kt
@@ -75,12 +75,14 @@ class RenderManagerTest {
 
         val renderTarget1 = renderManager.addFixture(pixelArrayFixture(null, 2, transport = NullTransport))
         val linkedProgram1 = resolve(program1, ContentType.Color)
-        val glslProgram1 = renderManager.compile(PixelArrayDevice, linkedProgram1) { _, _ -> error("none") }
+        val glslProgram1 = renderTarget1.renderEngine.compile(linkedProgram1) { _, _ -> error("none") }
+            .bind()
 
         val movingHead = MovingHead("mover", adapter = Shenzarpy, baseDmxChannel = 1)
         val renderTarget2 = renderManager.addFixture(movingHeadFixture(movingHead, 2, transport = NullTransport, adapter = Shenzarpy))
         val linkedProgram2 = resolve(program2, MovingHeadDevice.resultContentType)
-        val glslProgram2 = renderManager.compile(MovingHeadDevice, linkedProgram2) { _, _ -> error("none") }
+        val glslProgram2 = renderTarget2.renderEngine.compile(linkedProgram2) { _, _ -> error("none") }
+            .bind()
 
         renderManager.setRenderPlan(
             RenderPlan(mapOf(

--- a/src/commonTest/kotlin/baaahs/shows/FakeShowPlayer.kt
+++ b/src/commonTest/kotlin/baaahs/shows/FakeShowPlayer.kt
@@ -8,19 +8,26 @@ import baaahs.gl.data.FeedContext
 import baaahs.gl.testToolchain
 import baaahs.gl.withCache
 import baaahs.model.ModelInfo
+import baaahs.plugin.Plugins
 import baaahs.scene.SceneMonitor
 import baaahs.scene.SceneProvider
 import baaahs.show.Feed
+import baaahs.show.FeedOpenContext
 import baaahs.show.Show
 import baaahs.show.ShowState
 import baaahs.show.live.OpenShow
 import baaahs.show.live.ShowOpener
+import baaahs.util.Clock
 
 class FakeShowPlayer(
     @Deprecated("Get it some other way", level = DeprecationLevel.WARNING)
     override val sceneProvider: SceneProvider = SceneMonitor(ModelInfo.EmptyScene),
-    override val toolchain: Toolchain = testToolchain
-) : ShowPlayer {
+    val toolchain: Toolchain = testToolchain
+) : ShowPlayer, FeedOpenContext {
+    override val clock: Clock
+        get() = toolchain.plugins.pluginContext.clock
+    override val plugins: Plugins
+        get() = toolchain.plugins
     val feeds = mutableMapOf<Feed, FeedContext>()
     val gadgets: MutableMap<String, Gadget> = mutableMapOf()
     private val feedGadgets: MutableMap<Feed, Gadget> = mutableMapOf()

--- a/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
+++ b/src/commonTest/kotlin/baaahs/shows/ShowSerializationSpec.kt
@@ -1,6 +1,5 @@
 package baaahs.shows
 
-import baaahs.ShowPlayer
 import baaahs.control.*
 import baaahs.device.PixelLocationFeed
 import baaahs.gl.data.FeedContext
@@ -370,7 +369,7 @@ class FakeFeed(
     override val contentType: ContentType = ContentType.Unknown
 
     override fun getType(): GlslType = TODO("not implemented")
-    override fun open(showPlayer: ShowPlayer, id: String): FeedContext = TODO("not implemented")
+    override fun open(feedOpenContext: FeedOpenContext, id: String): FeedContext = TODO("not implemented")
 
     object Builder : FeedBuilder<FakeFeed> {
         override val title: String get() = TODO("not implemented")

--- a/src/jsMain/kotlin/baaahs/gl/preview/MovingHeadPreview.kt
+++ b/src/jsMain/kotlin/baaahs/gl/preview/MovingHeadPreview.kt
@@ -8,7 +8,7 @@ import baaahs.fixtures.ProgramRenderPlan
 import baaahs.fixtures.movingHeadFixture
 import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslProgram
-import baaahs.gl.render.ModelRenderEngine
+import baaahs.gl.render.ComponentRenderEngine
 import baaahs.gl.render.pickResultDeliveryStrategy
 import baaahs.model.Model
 import baaahs.model.MovingHead
@@ -39,7 +39,7 @@ class MovingHeadPreview(
 ) : ShaderPreview {
     private var running = false
     private val fixtureType = MovingHeadDevice
-    override val renderEngine = ModelRenderEngine(
+    override val renderEngine = ComponentRenderEngine(
         gl, fixtureType, resultDeliveryStrategy = gl.pickResultDeliveryStrategy()
     )
     private var movingHeadProgram: GlslProgram? = null

--- a/src/jsMain/kotlin/baaahs/gl/preview/ProjectionPreview.kt
+++ b/src/jsMain/kotlin/baaahs/gl/preview/ProjectionPreview.kt
@@ -11,8 +11,8 @@ import baaahs.geom.Vector2D
 import baaahs.geom.Vector3F
 import baaahs.gl.GlContext
 import baaahs.gl.glsl.GlslProgram
+import baaahs.gl.render.ComponentRenderEngine
 import baaahs.gl.render.FixtureRenderTarget
-import baaahs.gl.render.ModelRenderEngine
 import baaahs.gl.render.pickResultDeliveryStrategy
 import baaahs.gl.result.Vec2ResultType
 import baaahs.model.Model
@@ -36,7 +36,7 @@ class ProjectionPreview(
 ) : ShaderPreview {
     private var running = false
     private val fixtureType = ProjectionPreviewDevice
-    override val renderEngine = ModelRenderEngine(
+    override val renderEngine = ComponentRenderEngine(
         gl, fixtureType, resultDeliveryStrategy = gl.pickResultDeliveryStrategy()
     )
     private var projectionProgram: GlslProgram? = null


### PR DESCRIPTION
* [Refactor `RenderManager`/`RenderEngine`s so `RenderTarget`s can direct their own compilation and release, without the `RenderManager` involved.](https://github.com/baaahs/sparklemotion/commit/01e051e11781215ded8149334f57ad70b73a0afb)
* [Rename `ModelRenderEngine` to `ComponentRenderEngine`.](https://github.com/baaahs/sparklemotion/commit/bfd50df9942605b350f13fd622682b8071839fb9)
* [Remove ShowPlayer from feed/control open phase.](https://github.com/baaahs/sparklemotion/commit/4918af53d9d8d6098c6d8190c60306744cc506c4)
* [Use a ProgramBuilder to build GLSL code.](https://github.com/baaahs/sparklemotion/commit/0ba295d70a9e2c63106a8c08b92b90124015ea9a)