### PR TITLE
Improved first-use experience

### DIFF
--- a/src/commonMain/kotlin/baaahs/client/ClientStageManager.kt
+++ b/src/commonMain/kotlin/baaahs/client/ClientStageManager.kt
@@ -2,6 +2,7 @@ package baaahs.client
 
 import baaahs.*
 import baaahs.gl.Toolchain
+import baaahs.scene.OpenScene
 import baaahs.scene.SceneProvider
 import baaahs.show.Feed
 import baaahs.show.Show
@@ -14,7 +15,7 @@ class ClientStageManager(
     toolchain: Toolchain,
     private val pubSub: PubSub.Client,
     sceneProvider: SceneProvider
-) : BaseShowPlayer(toolchain, sceneProvider) {
+) : BaseShowPlayer(toolchain, SceneProviderWithFallback(sceneProvider)) {
     private val gadgets: MutableMap<String, ClientGadget> = mutableMapOf()
     private val listeners = mutableListOf<Listener>()
     private var openShow: OpenShow? = null
@@ -78,6 +79,11 @@ class ClientStageManager(
             channel.onChange(g.state)
             checkForChanges()
         }
+    }
+
+    class SceneProviderWithFallback(private val delegate: SceneProvider) : SceneProvider by delegate {
+        override val openScene: OpenScene
+            get() = openSceneOrFallback
     }
 
     interface Listener {

--- a/src/commonMain/kotlin/baaahs/scene/OpenScene.kt
+++ b/src/commonMain/kotlin/baaahs/scene/OpenScene.kt
@@ -12,7 +12,8 @@ import baaahs.util.Logger
 
 class OpenScene(
     val model: Model,
-    val controllers: Map<ControllerId, ControllerConfig> = emptyMap()
+    val controllers: Map<ControllerId, ControllerConfig> = emptyMap(),
+    val isFallback: Boolean = false
 ) : OpenDocument {
     override val title: String
         get() = model.name

--- a/src/commonMain/kotlin/baaahs/scene/Scene.kt
+++ b/src/commonMain/kotlin/baaahs/scene/Scene.kt
@@ -5,8 +5,10 @@ import baaahs.PubSub
 import baaahs.controller.ControllerId
 import baaahs.fixtures.*
 import baaahs.io.RemoteFsSerializer
+import baaahs.model.GridData
 import baaahs.model.Model
 import baaahs.model.ModelData
+import baaahs.model.ModelUnit
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -26,6 +28,13 @@ data class Scene(
 
     companion object {
         val Empty: Scene = Scene(ModelData("Untitled", emptyList()))
+
+        val Fallback = Scene(
+            ModelData("Fallback Scene", listOf(
+                GridData("Grid", columns = 320, rows = 240, columnGap = 1.25f, rowGap = 1.25f, zigZag = true)
+            ), ModelUnit.Centimeters),
+            emptyMap()
+        )
 
         fun createTopic(
             serializersModule: SerializersModule,

--- a/src/commonMain/kotlin/baaahs/scene/SceneMonitor.kt
+++ b/src/commonMain/kotlin/baaahs/scene/SceneMonitor.kt
@@ -12,6 +12,11 @@ class SceneMonitor(
     override var openScene: OpenScene? = openScene
         private set
 
+    private val fallbackScene by lazy { OpenScene(Scene.Fallback.model.open(), isFallback = true) }
+
+    override val openSceneOrFallback: OpenScene
+        get() = openScene ?: fallbackScene
+
     override fun addBeforeChangeListener(callback: SceneChangeListener) {
         beforeChangeListeners.add(callback)
     }

--- a/src/commonMain/kotlin/baaahs/scene/SceneProvider.kt
+++ b/src/commonMain/kotlin/baaahs/scene/SceneProvider.kt
@@ -4,6 +4,7 @@ import baaahs.ui.IObservable
 
 interface SceneProvider : IObservable {
     val openScene: OpenScene?
+    val openSceneOrFallback: OpenScene
 
     fun addBeforeChangeListener(callback: SceneChangeListener)
 }

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -23,17 +23,13 @@ import baaahs.window
 import external.ErrorBoundary
 import js.core.jso
 import materialui.icon
-import mui.icons.material.NotificationImportant
-import mui.material.*
+import mui.material.CssBaseline
+import mui.material.Paper
 import mui.material.styles.ThemeProvider
-import mui.system.sx
 import react.Props
 import react.RBuilder
 import react.RHandler
 import react.dom.div
-import react.dom.p
-import web.cssom.Display
-import web.cssom.ZIndex
 
 val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
     val webClient = props.webClient
@@ -199,6 +195,8 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
         }
     }
 
+    val appState = AppState.getState(webClient, show, props.sceneManager.scene)
+
     appContext.Provider {
         attrs.value = myAppContext
 
@@ -236,106 +234,45 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
                         }
 
                         div(+themeStyles.appContent) {
-                            if (!webClient.isConnected) {
-                                Paper {
-                                    attrs.classes = jso { root = -themeStyles.noShowLoadedPaper }
-                                    CircularProgress {}
-                                    icon(NotificationImportant)
-                                    typographyH6 { +"Connecting…" }
-                                    +"Attempting to connect to Sparkle Motion."
-                                }
-                            } else if (!webClient.serverIsOnline) {
-                                Paper {
-                                    attrs.classes = jso { root = -themeStyles.noShowLoadedPaper }
-                                    CircularProgress {}
-                                    icon(NotificationImportant)
-                                    typographyH6 { +"Connecting…" }
-                                    +"Sparkle Motion is initializing."
-                                }
-                            } else {
-                                ErrorBoundary {
-                                    attrs.FallbackComponent = ErrorDisplay
+                            ErrorBoundary {
+                                attrs.FallbackComponent = ErrorDisplay
 
-                                    when (appMode) {
-                                        AppMode.Show -> {
-                                            if (!webClient.showManagerIsReady) {
-                                                Paper {
-                                                    attrs.classes = jso { root = -themeStyles.noShowLoadedPaper }
-                                                    CircularProgress {}
-                                                    NotificationImportant {}
-                                                    typographyH6 { +"Connecting…" }
-                                                    +"Show manager is initializing."
-                                                }
-                                            } else if (show == null) {
-                                                Paper {
-                                                    attrs.classes = jso { root = -themeStyles.noShowLoadedPaper }
-                                                    NotificationImportant {}
-                                                    typographyH6 { +"No open show." }
-                                                    p { +"Maybe you'd like to open one? " }
-                                                }
-                                            } else if (props.webClient.isMapping) {
-                                                Backdrop {
-                                                    attrs.open = true
-                                                    Container {
-                                                        CircularProgress {}
-                                                        icon(NotificationImportant)
+                                if (appState is AppState.FullScreenMessage) {
+                                    Paper {
+                                        attrs.classes = js.core.jso { root = -themeStyles.fullScreenMessagePaper }
+                                        if (appState.isInProgress)
+                                            mui.material.CircularProgress {}
+                                        icon(mui.icons.material.NotificationImportant)
+                                        typographyH6 { +appState.title }
+                                        +appState.message
+                                    }
+                                } else if (appState == AppState.ShowView) {
+                                    showUi {
+                                        attrs.show = showManager.openShow!!
+                                        attrs.onShowStateChange = handleShowStateChange
+                                        attrs.onLayoutEditorDialogToggle = handleLayoutEditorDialogToggle
+                                        attrs.onShaderLibraryDialogToggle = handleShaderLibraryDialogToggle
+                                    }
 
-                                                        typographyH6 { +"Mapper Running…" }
-                                                        +"Please wait."
-                                                    }
-                                                }
-                                            } else if (webClient.sceneProvider.openScene == null) {
-                                                Backdrop {
-                                                    attrs.open = true
-                                                    attrs.sx { zIndex = 100 as ZIndex; display = Display.grid }
-                                                    Container {
-                                                        icon(NotificationImportant)
-
-                                                        typographyH6 { +"No scene loaded." }
-                                                        +"Maybe you'd like to open one?"
-                                                    }
-                                                }
-                                            } else {
-                                                showUi {
-                                                    attrs.show = showManager.openShow!!
-                                                    attrs.onShowStateChange = handleShowStateChange
-                                                    attrs.onLayoutEditorDialogToggle = handleLayoutEditorDialogToggle
-                                                    attrs.onShaderLibraryDialogToggle = handleShaderLibraryDialogToggle
-                                                }
-
-                                                if (showLayoutEditorDialog) {
-                                                    // Layout Editor dialog
-                                                    layoutEditorDialog {
-                                                        attrs.open = showLayoutEditorDialog
-                                                        attrs.show = show
-                                                        attrs.onApply = handleLayoutEditorChange
-                                                        attrs.onClose = handleLayoutEditorDialogClose
-                                                    }
-                                                }
-                                                if (showShaderLibraryDialog) {
-                                                    shaderLibraryDialog {
-                                                        attrs.devWarning = true
-                                                    }
-                                                }
-                                            }
+                                    if (showLayoutEditorDialog) {
+                                        // Layout Editor dialog
+                                        layoutEditorDialog {
+                                            attrs.open = showLayoutEditorDialog
+                                            attrs.show = show!!
+                                            attrs.onApply = handleLayoutEditorChange
+                                            attrs.onClose = handleLayoutEditorDialogClose
                                         }
-
-                                        AppMode.Scene -> {
-                                            if (props.sceneManager.scene == null) {
-                                                Paper {
-                                                    attrs.classes = jso { root = -themeStyles.noShowLoadedPaper }
-                                                    icon(NotificationImportant)
-                                                    typographyH6 { +"No open scene." }
-                                                    p { +"Maybe you'd like to open one? " }
-                                                }
-                                            } else {
-                                                sceneEditor {
-                                                    attrs.sceneEditorClient = props.sceneEditorClient
-                                                    attrs.mapper = props.mapper
-                                                    attrs.sceneManager = sceneManager
-                                                }
-                                            }
+                                    }
+                                    if (showShaderLibraryDialog) {
+                                        shaderLibraryDialog {
+                                            attrs.devWarning = true
                                         }
+                                    }
+                                } else if (appState == AppState.SceneView) {
+                                    sceneEditor {
+                                        attrs.sceneEditorClient = props.sceneEditorClient
+                                        attrs.mapper = props.mapper
+                                        attrs.sceneManager = sceneManager
                                     }
                                 }
                             }

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -285,6 +285,17 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
                                                         +"Please wait."
                                                     }
                                                 }
+                                            } else if (webClient.sceneProvider.openScene == null) {
+                                                Backdrop {
+                                                    attrs.open = true
+                                                    attrs.sx { zIndex = 100 as ZIndex; display = Display.grid }
+                                                    Container {
+                                                        icon(NotificationImportant)
+
+                                                        typographyH6 { +"No scene loaded." }
+                                                        +"Maybe you'd like to open one?"
+                                                    }
+                                                }
                                             } else {
                                                 showUi {
                                                     attrs.show = showManager.openShow!!
@@ -305,19 +316,6 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
                                                 if (showShaderLibraryDialog) {
                                                     shaderLibraryDialog {
                                                         attrs.devWarning = true
-                                                    }
-                                                }
-                                            }
-
-                                            if (webClient.sceneProvider.openScene == null) {
-                                                Backdrop {
-                                                    attrs.open = true
-                                                    attrs.sx { zIndex = 100 as ZIndex; display = Display.grid }
-                                                    Container {
-                                                        icon(NotificationImportant)
-
-                                                        typographyH6 { +"No scene loaded." }
-                                                        +"Maybe you'd like to open one?"
                                                     }
                                                 }
                                             }

--- a/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppIndex.kt
@@ -11,7 +11,6 @@ import baaahs.app.ui.settings.settingsDialog
 import baaahs.client.ClientStageManager
 import baaahs.client.SceneEditorClient
 import baaahs.client.WebClient
-import baaahs.client.document.DocumentManager
 import baaahs.client.document.SceneManager
 import baaahs.client.document.ShowManager
 import baaahs.gl.withCache
@@ -371,22 +370,6 @@ val AppIndex = xComponent<AppIndexProps>("AppIndex") { props ->
             }
         }
     }
-}
-
-enum class AppMode {
-    Show {
-        override val otherOne: AppMode get() = Scene
-        override fun getDocumentManager(appContext: AppContext): ShowManager.Facade =
-            appContext.showManager
-    },
-    Scene {
-        override val otherOne: AppMode get() = Show
-        override fun getDocumentManager(appContext: AppContext): SceneManager.Facade =
-            appContext.sceneManager
-    };
-
-    abstract val otherOne: AppMode
-    abstract fun getDocumentManager(appContext: AppContext): DocumentManager<*, *>.Facade
 }
 
 external interface AppIndexProps : Props {

--- a/src/jsMain/kotlin/baaahs/app/ui/AppMode.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppMode.kt
@@ -1,0 +1,21 @@
+package baaahs.app.ui
+
+import baaahs.client.document.DocumentManager
+import baaahs.client.document.SceneManager
+import baaahs.client.document.ShowManager
+
+enum class AppMode {
+    Show {
+        override val otherOne: AppMode get() = Scene
+        override fun getDocumentManager(appContext: AppContext): ShowManager.Facade =
+            appContext.showManager
+    },
+    Scene {
+        override val otherOne: AppMode get() = Show
+        override fun getDocumentManager(appContext: AppContext): SceneManager.Facade =
+            appContext.sceneManager
+    };
+
+    abstract val otherOne: AppMode
+    abstract fun getDocumentManager(appContext: AppContext): DocumentManager<*, *>.Facade
+}

--- a/src/jsMain/kotlin/baaahs/app/ui/AppState.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppState.kt
@@ -1,0 +1,43 @@
+package baaahs.app.ui
+
+import baaahs.client.WebClient
+import baaahs.scene.Scene
+import baaahs.show.Show
+
+interface AppState {
+    class FullScreenMessage(
+        val title: String,
+        val message: String,
+        val isInProgress: Boolean = true
+    ) : AppState
+
+    object ShowView : AppState
+    object SceneView : AppState
+
+    companion object {
+        fun getState(webClient: WebClient.Facade, show: Show?, scene: Scene?): AppState {
+            val uiSettings = webClient.uiSettings
+            val appMode = uiSettings.appMode
+
+            return if (!webClient.isConnected) {
+                FullScreenMessage("Connecting…", "Attempting to connect to Sparkle Motion.")
+            } else if (!webClient.serverIsOnline) {
+                FullScreenMessage("Connecting…", "Sparkle Motion is initializing.")
+            } else if (appMode == AppMode.Show) {
+                if (!webClient.showManagerIsReady) {
+                    FullScreenMessage("Connecting…", "Show is initializing.")
+                } else if (show == null) {
+                    FullScreenMessage("No open show.", "Maybe you'd like to open one?", isInProgress = false)
+                } else if (webClient.isMapping) {
+                    FullScreenMessage("Mapper Running…", "Please wait.")
+                } else if (scene == null) {
+                    FullScreenMessage("No scene loaded.", "Maybe you'd like to open one?", isInProgress = false)
+                } else ShowView
+            } else if (appMode == AppMode.Scene) {
+                if (scene == null) {
+                    FullScreenMessage("No open scene.", "Maybe you'd like to open one?", isInProgress = false)
+                } else SceneView
+            } else error("Unknown app mode: $appMode")
+        }
+    }
+}

--- a/src/jsMain/kotlin/baaahs/app/ui/AppState.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/AppState.kt
@@ -30,8 +30,6 @@ interface AppState {
                     FullScreenMessage("No open show.", "Maybe you'd like to open one?", isInProgress = false)
                 } else if (webClient.isMapping) {
                     FullScreenMessage("Mapper Running…", "Please wait.")
-                } else if (scene == null) {
-                    FullScreenMessage("No scene loaded.", "Maybe you'd like to open one?", isInProgress = false)
                 } else ShowView
             } else if (appMode == AppMode.Scene) {
                 if (scene == null) {

--- a/src/jsMain/kotlin/baaahs/app/ui/ShaderPreviewView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/ShaderPreviewView.kt
@@ -52,16 +52,6 @@ private val ShaderPreviewView = xComponent<ShaderPreviewProps>("ShaderPreview") 
     val previewContainer = helper.container
     val sceneProvider = appContext.sceneProvider
     observe(sceneProvider)
-    val model = sceneProvider.openScene?.model
-//    var model by state { sceneManager.openScene?.model }
-//    onMount {
-//        val listener = sceneManager.addSceneChangeListener { newScene ->
-//            model = newScene?.model
-//        }
-//        withCleanup { sceneManager.removeSceneChangeListener(listener) }
-//    }
-
-    var gl by state<GlContext?> { null }
 
     onMount(canvasParent.current, previewContainer, shaderPreview) {
         canvasParent.current?.let { parent ->
@@ -75,28 +65,28 @@ private val ShaderPreviewView = xComponent<ShaderPreviewProps>("ShaderPreview") 
         withCleanup { canvasParent.current?.removeChild(previewContainer) }
     }
 
+    val model = sceneProvider.openSceneOrFallback.model
+    var gl by state<GlContext?> { null }
     onChange("shader type", helper, shaderType, model) {
-        model?.let { model ->
-            val preview = helper.bootstrap(model, preRenderHook)
-//            console.log("Rememoize preview for ${props.shader?.title ?: props.previewShaderBuilder?.openShader?.title}")
+        val preview = helper.bootstrap(model, preRenderHook)
+        //            console.log("Rememoize preview for ${props.shader?.title ?: props.previewShaderBuilder?.openShader?.title}")
 
-            gl = preview.renderEngine.gl
+        gl = preview.renderEngine.gl
 
-            val intersectionObserver = IntersectionObserver(callback = { entries ->
-                if (entries.any { it.isIntersecting }) {
-                    preview.start()
-                } else {
-                    preview.stop()
-                }
-            })
-            intersectionObserver.observe(previewContainer)
-
-            shaderPreview = preview
-
-            withCleanup {
-                intersectionObserver.disconnect()
-                preview.destroy()
+        val intersectionObserver = IntersectionObserver(callback = { entries ->
+            if (entries.any { it.isIntersecting }) {
+                preview.start()
+            } else {
+                preview.stop()
             }
+        })
+        intersectionObserver.observe(previewContainer)
+
+        shaderPreview = preview
+
+        withCleanup {
+            intersectionObserver.disconnect()
+            preview.destroy()
         }
     }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -29,10 +29,6 @@ fun linearRepeating(
 class ThemeStyles(val theme: Theme) : StyleSheet("app-ui-theme", isStatic = true) {
     private val drawerWidth = 260.px
 
-    val help by css {
-
-    }
-
     val global = CssBuilder().apply {
         "header" {
             color = Color(theme.palette.primary.contrastText.asDynamic())
@@ -44,7 +40,7 @@ class ThemeStyles(val theme: Theme) : StyleSheet("app-ui-theme", isStatic = true
             paddingRight = 16.px
             position = Position.relative
 
-            child(this@ThemeStyles, ::help) {
+            child(baaahs.ui.Styles, baaahs.ui.Styles::help) {
                 fontSize = 1.rem
                 position = Position.absolute
                 top = .5.em

--- a/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/Styles.kt
@@ -286,7 +286,7 @@ class ThemeStyles(val theme: Theme) : StyleSheet("app-ui-theme", isStatic = true
         minWidth = 0.px
     }
 
-    val noShowLoadedPaper by css {
+    val fullScreenMessagePaper by css {
         height = 100.pct
         display = Display.flex
         flexDirection = FlexDirection.column

--- a/src/jsMain/kotlin/baaahs/app/ui/controls/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/controls/Styles.kt
@@ -6,6 +6,7 @@ import baaahs.show.live.FeedOpenControl
 import baaahs.ui.*
 import kotlinx.css.*
 import kotlinx.css.properties.Timing
+import kotlinx.css.properties.lh
 import kotlinx.css.properties.s
 import mui.material.styles.Theme
 import styled.StyleSheet
@@ -75,11 +76,28 @@ object Styles : StyleSheet("app-ui-controls", isStatic = true) {
     val visualizerMenuAffordance by css {
         position = Position.absolute
         padding = Padding(2.px)
+        borderRadius = 3.px
         backgroundColor = Color.white.withAlpha(.5)
         width = 2.em
         height = 2.em
         right = .5.em
         bottom = .5.em
+    }
+
+    val visualizerWarning by css {
+        display = Display.flex
+        lineHeight = 1.em.lh
+        alignItems = Align.center
+        position = Position.absolute
+        padding = Padding(2.px, .5.em)
+        borderRadius = 3.px
+        backgroundColor = Color.darkRed.withAlpha(.5)
+        left = .5.em
+        bottom = .5.em
+
+        svg { // Margin on the (?) help icon.
+            marginLeft = .3.em
+        }
     }
 
     val dragHandle by css {

--- a/src/jsMain/kotlin/baaahs/app/ui/document/DocumentMenuView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/document/DocumentMenuView.kt
@@ -41,6 +41,8 @@ private val DocumentMenuView = xComponent<DocumentMenuProps>("DocumentMenu") { p
                             DialogTitle { +title }
                             DialogContent {
                                 List {
+                                    attrs.dense = true
+
                                     options.forEach { option ->
                                         when (option) {
                                             is Divider -> {

--- a/src/jsMain/kotlin/baaahs/client/WebClient.kt
+++ b/src/jsMain/kotlin/baaahs/client/WebClient.kt
@@ -4,6 +4,7 @@ import baaahs.PinkyState
 import baaahs.PubSub
 import baaahs.app.settings.UiSettings
 import baaahs.app.ui.AppIndex
+import baaahs.app.ui.AppMode
 import baaahs.app.ui.dialog.FileDialog
 import baaahs.client.document.SceneManager
 import baaahs.client.document.ShowManager
@@ -39,7 +40,7 @@ class WebClient(
     private val sceneManager: SceneManager,
     private val stageManager: ClientStageManager
 ) : HostedWebApp {
-    private val facade = Facade()
+    val facade = Facade()
 
     private val pubSubListener = { facade.notifyChanged() }.also {
         pubSub.addStateChangeListener(it)
@@ -138,6 +139,12 @@ class WebClient(
 
         val uiSettings: UiSettings
             get() = this@WebClient.uiSettings
+
+        var appMode: AppMode
+            get() = this@WebClient.uiSettings.appMode
+            set(value) {
+                updateUiSettings(uiSettings.copy(appMode = value), saveToStorage = true)
+            }
 
         fun updateUiSettings(newSettings: UiSettings, saveToStorage: Boolean) {
             this@WebClient.updateUiSettings(newSettings, saveToStorage)

--- a/src/jsMain/kotlin/baaahs/sim/FixturesSimulator.kt
+++ b/src/jsMain/kotlin/baaahs/sim/FixturesSimulator.kt
@@ -69,7 +69,6 @@ class FixturesSimulator(
                     }
 
                     val entityAdapter = EntityAdapter(simulationEnv, newOpenScene.model.units)
-                    visualizer.facade.clear()
                     visualizer.facade.units = entityAdapter.units
                     visualizer.initialViewingAngle = newOpenScene.model.initialViewingAngle
                     buildMap {
@@ -85,6 +84,7 @@ class FixturesSimulator(
                 visualizer.add(it.itemVisualizer)
             }
             visualizer.fitCameraToObject()
+            visualizer.facade.notifyChanged()
 
             simMappingManager.mappingData =
                 newOpenScene?.let {

--- a/src/jsMain/kotlin/baaahs/sim/ui/SimulatorAppView.kt
+++ b/src/jsMain/kotlin/baaahs/sim/ui/SimulatorAppView.kt
@@ -106,6 +106,7 @@ val SimulatorAppView = xComponent<SimulatorAppProps>("SimulatorApp") { props ->
                             when (window) {
                                 SimulatorWindows.Visualizer -> createElement(ModelSimulationView, jso {
                                     this.simulator = props.simulator
+                                    this.hostedWebApp = props.hostedWebApp
                                 })
                                 SimulatorWindows.Console -> createElement(StatusPanelView, jso {
                                     this.simulator = props.simulator

--- a/src/jsMain/kotlin/baaahs/sim/ui/SimulatorStyles.kt
+++ b/src/jsMain/kotlin/baaahs/sim/ui/SimulatorStyles.kt
@@ -100,6 +100,10 @@ object SimulatorStyles : StyleSheet("sim-ui", isStatic = true) {
         padding = Padding(0.px, 16.px)
     }
 
+    val vizWarning by css(baaahs.app.ui.controls.Styles.visualizerWarning) {
+        zIndex = 10
+    }
+
     val statusPanel by css {
         display = Display.flex
 

--- a/src/jsMain/kotlin/baaahs/ui/Help.kt
+++ b/src/jsMain/kotlin/baaahs/ui/Help.kt
@@ -1,26 +1,35 @@
 package baaahs.ui
 
-import baaahs.app.ui.appContext
+import kotlinx.css.LinearDimension
+import kotlinx.css.fontSize
 import materialui.icon
 import mui.material.*
 import org.w3c.dom.events.Event
 import react.*
 import react.dom.div
+import styled.inlineStyles
+import web.html.HTMLElement
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 val Help = xComponent<HelpProps>("Help", isPure = true) { props ->
-    val styles = useContext(appContext).allStyles.appUi
-
     var open by state { false }
 
     val toggleHelp = callback { open = !open }
     val closeHelp = callback { _: Event, _: String -> open = false }
 
-    div("${styles.help.name} ${props.divClass}") {
+    div("${Styles.help.name} ${props.divClass ?: ""}") {
+        props.iconSize?.let { iconSize ->
+            inlineStyles { fontSize = iconSize }
+        }
+
         Link {
             attrs.onClick = toggleHelp.withMouseEvent()
-            icon(mui.icons.material.HelpOutline)
+            icon(mui.icons.material.HelpOutline) {
+                if (props.iconSize != null) {
+                    fontSize = SvgIconSize.inherit
+                }
+            }
         }
     }
 
@@ -34,6 +43,12 @@ val Help = xComponent<HelpProps>("Help", isPure = true) { props ->
             }
 
             DialogContent {
+                attrs.onClick = {
+                    val classList = (it.target as? HTMLElement)?.classList
+                    if (classList?.contains(Styles.helpAutoClose.name) == true) {
+                        open = false
+                    }
+                }
                 props.children?.forEach { child(it) }
             }
         }
@@ -49,6 +64,7 @@ val Help = xComponent<HelpProps>("Help", isPure = true) { props ->
 }
 
 external interface HelpProps : Props {
+    var iconSize: LinearDimension?
     var divClass: String?
     var children: Array<ReactElement<*>>?
 }

--- a/src/jsMain/kotlin/baaahs/ui/Styles.kt
+++ b/src/jsMain/kotlin/baaahs/ui/Styles.kt
@@ -76,6 +76,11 @@ object Styles : StyleSheet("ui", isStatic = true) {
         border = Border(1.px, groove)
     }
 
+    val help by css {
+    }
+    val helpAutoClose by css {
+    }
+
     val helpInline by css {
         display = Display.inline
         padding = Padding(0.em, .5.em)

--- a/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/Visualizer.kt
@@ -36,6 +36,8 @@ class Visualizer(
 
     private val selectionSpan = document.createElement("span") as HTMLSpanElement
 
+    var haveScene: Boolean = false
+
     var selectedEntity: ItemVisualizer<*>? = null
 
     private var container: HTMLElement? = null
@@ -112,6 +114,7 @@ class Visualizer(
     }
 
     inner class Facade : BaseVisualizer.Facade() {
+        val haveScene get() = this@Visualizer.haveScene
         val selectedEntity get() = this@Visualizer.selectedEntity
 
         var container: HTMLElement?

--- a/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
+++ b/src/jsMain/kotlin/baaahs/visualizer/VizPixels.kt
@@ -37,6 +37,7 @@ class VizPixels(
     private val colorsAsInts = IntArray(size) // store colors as an int array too for Pixels.get()
 
     private val pixelsMesh = Mesh(BufferGeometry(), MeshBasicMaterial().apply {
+        name = "VizPixels"
         side = if (bothSides) DoubleSide else FrontSide
         transparent = true
         blending = AdditiveBlending


### PR DESCRIPTION
Show UI works without scene loaded
* Client automatically uses a simple generic fallback scene when no scene is open.
* Hardware simulation and client preview visualizers have help guidance when no scene is loaded.
* First time users can get to a functional show UI in two clicks now, rather than six (**New Show** -> **BRC 2023** vs **New Show** -> **BRC 2023** -> **Scene** -> **New Scene** -> **Hi Res** -> **Show**).