### PR TITLE
Fixing what looks like a Kotlin 2.0 JS compiler issue

### DIFF
--- a/src/commonMain/kotlin/baaahs/sm/brain/BrainManager.kt
+++ b/src/commonMain/kotlin/baaahs/sm/brain/BrainManager.kt
@@ -117,7 +117,9 @@ class BrainManager(
             brainAddress, brainId, msg,
             config?.defaultFixtureOptions,
             config?.defaultTransportConfig,
-            isSimulatedBrain
+            isSimulatedBrain,
+            // TODO: Remove. Works around bug in Kotlin 2.0 when calculating default param values on inner cosntructors.
+            startedAt = clock.now()
         )
         activeBrains[brainId] = controller
         notifyListeners { onAdd(controller) }


### PR DESCRIPTION
When constructing an inner class with a default constructor parameter which references a member of an outer class, generated code to invoke methods on that member is broken.

No such method `clock.now()` from `BrainController` constructor for `startedAt`.