### PR TITLE
Use in param for MoverShader upstream overrides

### DIFF
--- a/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
+++ b/src/commonMain/kotlin/baaahs/gl/shader/type/MoverShader.kt
@@ -23,6 +23,8 @@ object MoverShader : ShaderType {
             vec3 position;
             vec3 rotation;
             mat4 transformation;
+            vec3 boundaryMin;
+            vec3 boundaryMax;
         };
 
         struct MovingHeadParams {
@@ -37,13 +39,11 @@ object MoverShader : ShaderType {
         uniform FixtureInfo fixtureInfo;
 
         // @param params moving-head-params
-        void main(out MovingHeadParams params) {
-            params.pan = 0.;
-            params.tilt = .5;
-            params.colorWheel = 0.;
-            params.dimmer = 1.;
-            params.prism = false;
-            params.prismRotation = 0.;
+        void main(in MovingHeadParams upstream, out MovingHeadParams params) {
+            params = upstream;
+            // Override values below
+            // params.tilt = sin(time);
+
         }
     """.trimIndent()
 

--- a/src/commonMain/kotlin/baaahs/show/SampleData.kt
+++ b/src/commonMain/kotlin/baaahs/show/SampleData.kt
@@ -143,6 +143,8 @@ object SampleData {
                     vec3 position;
                     vec3 rotation;
                     mat4 transformation;
+                    vec3 boundaryMin;
+                    vec3 boundaryMax;
                 };
 
                 struct MovingHeadParams {


### PR DESCRIPTION
The existing implementation just used an outparam, which was passing unitialized memory if not every field was explicitly set. We also update the template to demonstrate using the in param.

PAIR: xian + tarqin