### PR TITLE
Slider beatlink cleanup

### DIFF
--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
@@ -67,10 +67,8 @@ private val handle = xComponent<HandleProps>("Handle") { props ->
         when (variant) {
             HandleVariant.FULL ->
                 img(src = "/assets/slider-handle-full.svg", classes = +styles.handleNormal) {}
-
             HandleVariant.MIN ->
                 img(src = "/assets/slider-handle-min.svg", classes = +styles.handleNormal) {}
-
             HandleVariant.MAX ->
                 img(src = "/assets/slider-handle-max.svg", classes = +styles.handleNormal) {}
         }

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
@@ -48,7 +48,13 @@ private val handle = xComponent<HandleProps>("Handle") { props ->
 
     val value = handle.value
     val percent = sliderContext.scale.getValue(value)
-    div(+styles.handleTouchArea) {
+    val variant = props.variant ?: HandleVariant.FULL
+    val touchAreaClass = when (variant) {
+        HandleVariant.FULL -> styles.handleTouchArea
+        HandleVariant.MIN -> styles.handleTouchAreaMin
+        HandleVariant.MAX -> styles.handleTouchAreaMax
+    }
+    div(+touchAreaClass) {
         ref = touchAreaRef
         inlineStyles {
             top = percent.pct
@@ -58,12 +64,26 @@ private val handle = xComponent<HandleProps>("Handle") { props ->
         attrs.onPointerDown = sliderContext.getPointerDownHandlerFor(handle)
         attrs.onKeyDown = sliderContext.getKeyDownHandlerFor(handle)
 
-        img(src = "/assets/slider-handle-full.svg", classes = +styles.handleNormal) {}
+        when (variant) {
+            HandleVariant.FULL ->
+                img(src = "/assets/slider-handle-full.svg", classes = +styles.handleNormal) {}
+
+            HandleVariant.MIN ->
+                img(src = "/assets/slider-handle-min.svg", classes = +styles.handleNormal) {}
+
+            HandleVariant.MAX ->
+                img(src = "/assets/slider-handle-max.svg", classes = +styles.handleNormal) {}
+        }
     }
 }
 
 external interface HandleProps : Props {
     var handle: Handle
+    var variant: HandleVariant?
+}
+
+enum class HandleVariant {
+    FULL, MIN, MAX
 }
 
 fun RBuilder.handle(handler: RHandler<HandleProps>) =

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/HandleView.kt
@@ -1,7 +1,6 @@
 package baaahs.app.ui.gadgets.slider
 
 import baaahs.app.ui.appContext
-import baaahs.ui.and
 import baaahs.ui.slider.*
 import baaahs.ui.unaryPlus
 import baaahs.ui.xComponent
@@ -13,14 +12,14 @@ import react.RHandler
 import react.dom.div
 import react.dom.events.KeyboardEvent
 import react.dom.events.PointerEvent
+import react.dom.img
 import react.dom.onKeyDown
 import react.dom.onPointerDown
-import react.dom.setProp
 import react.useContext
 import styled.inlineStyles
 import web.html.HTMLElement
 
-val handle = xComponent<HandleProps>("Handle") { props ->
+private val handle = xComponent<HandleProps>("Handle") { props ->
     val appContext = useContext(appContext)
     val styles = appContext.allStyles.gadgetsSlider
     val sliderContext = useContext(sliderContext)
@@ -58,25 +57,8 @@ val handle = xComponent<HandleProps>("Handle") { props ->
 
         attrs.onPointerDown = sliderContext.getPointerDownHandlerFor(handle)
         attrs.onKeyDown = sliderContext.getKeyDownHandlerFor(handle)
-    }
 
-    div(+styles.handleWrapper) {
-        ref = handleRef
-        setProp("role", "slider")
-        setProp("aria-valuemin", sliderContext.domain.start)
-        setProp("aria-valuemax", sliderContext.domain.endInclusive)
-        setProp("aria-valuenow", value)
-        inlineStyles {
-            top = percent.pct
-        }
-
-        div(+styles.handleNotch) {}
-        div(+styles.handleNotch) {}
-        div(+styles.handleNotch) {}
-        div(+styles.handleNotch and styles.handleNotchMiddle) {}
-        div(+styles.handleNotch and styles.handleNotchLower) {}
-        div(+styles.handleNotch and styles.handleNotchLower) {}
-        div(+styles.handleNotch and styles.handleNotchLower) {}
+        img(src = "/assets/slider-handle-full.svg", classes = +styles.handleNormal) {}
     }
 }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderBackgroundView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderBackgroundView.kt
@@ -1,6 +1,7 @@
 package baaahs.app.ui.gadgets.slider
 
 import baaahs.app.ui.appContext
+import baaahs.ui.slider.Handle
 import baaahs.ui.slider.Location
 import baaahs.ui.slider.sliderContext
 import baaahs.ui.unaryPlus
@@ -13,21 +14,30 @@ import react.dom.events.PointerEvent
 import react.dom.onPointerDown
 import react.useContext
 
-private val sliderRail = xComponent<Props>("SliderRail") { props ->
+private val sliderRail = xComponent<SliderRailProps>("SliderRail") { props ->
     val appContext = useContext(appContext)
     val styles = appContext.allStyles.gadgetsSlider
     val sliderContext = useContext(sliderContext)
 
     val handlePointerDown = callback(sliderContext.emitPointer) { e: PointerEvent<*> ->
-        sliderContext.emitPointer(e, Location.Rail, null)
+        sliderContext.emitPointer(e, Location.Rail, props.handle?.id)
     }
 
-    div(+styles.railBackground) {
+    val railBackgroundClass = when (props.variant ?: HandleVariant.FULL) {
+        HandleVariant.FULL -> styles.railBackground
+        HandleVariant.MIN -> styles.railBackgroundMin
+        HandleVariant.MAX -> styles.railBackgroundMax
+    }
+
+    div(+railBackgroundClass) {
         attrs.onPointerDown = handlePointerDown
     }
-
-    div(+styles.railChannel) {}
 }
 
-fun RBuilder.sliderRail(handler: RHandler<Props>) =
+external interface SliderRailProps : Props {
+    var handle: Handle?
+    var variant: HandleVariant?
+}
+
+fun RBuilder.sliderBackground(handler: RHandler<SliderRailProps>) =
     child(sliderRail, handler = handler)

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderView.kt
@@ -77,11 +77,13 @@ private val slider = xComponent<SliderProps>("Slider") { props ->
 
             handle {
                 attrs.handle = positionHandle
+                attrs.variant = if (isBeatLinked) HandleVariant.MAX else HandleVariant.FULL
             }
 
             if (isBeatLinked) {
-                altHandle {
+                handle {
                     attrs.handle = floorHandle
+                    attrs.variant = HandleVariant.MIN
                 }
             }
 

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderView.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/SliderView.kt
@@ -65,7 +65,19 @@ private val slider = xComponent<SliderProps>("Slider") { props ->
             attrs.onSlideStart = disableScroll.asDynamic()
             attrs.onSlideEnd = enableScroll.asDynamic()
 
-            sliderRail {}
+            if (isBeatLinked) {
+                sliderBackground {
+                    attrs.handle = floorHandle
+                    attrs.variant = HandleVariant.MIN
+                }
+                sliderBackground {
+                    attrs.variant = HandleVariant.MAX
+                }
+            } else {
+                sliderBackground {}
+            }
+
+            div(+styles.railChannel) {}
 
             div(+styles.tracks) {
                 tracks {

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
@@ -103,25 +103,6 @@ class ThemedStyles(val theme: Theme) : StyleSheet("app-ui-gadgets-Slider", isSta
         filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
     }
 
-    val handleMin by css {
-        width = 20.px
-        height = 40.px
-        position = Position.relative
-        top = 2.px
-        left = 11.px
-
-        filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
-    }
-    val handleMax by css {
-        width = 20.px
-        height = 40.px
-        position = Position.relative
-        top = 2.px
-        left = 11.px
-
-        filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
-    }
-
     val handleNotch by css {
         height = 1.px
         backgroundColor = Color.black
@@ -168,6 +149,14 @@ class ThemedStyles(val theme: Theme) : StyleSheet("app-ui-gadgets-Slider", isSta
         transform.translateX((-50).pct)
         borderRadius = 7.px
         cursor = Cursor.pointer
+    }
+    val railBackgroundMin by css(railBackground) {
+        width = 32.px
+        left = -17.px
+    }
+    val railBackgroundMax by css(railBackground) {
+        width = 38.px
+        left = 21.px
     }
 
     val railChannel by css {

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
@@ -53,6 +53,17 @@ class ThemedStyles(val theme: Theme) : StyleSheet("app-ui-gadgets-Slider", isSta
         width = 42.px
         height = 45.px
         cursor = Cursor.pointer
+
+        img {
+            width = 20.px
+            height = 40.px
+            position = Position.relative
+            top = 2.px
+            left = 11.px
+
+            filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
+            pointerEvents = PointerEvents.none
+        }
     }
 
     val handleWrapper by css {
@@ -68,6 +79,35 @@ class ThemedStyles(val theme: Theme) : StyleSheet("app-ui-gadgets-Slider", isSta
         flexDirection = FlexDirection.column
         justifyContent = JustifyContent.spaceBetween
         alignItems = Align.center
+    }
+
+    val handleNormal by css {
+        width = 20.px
+        height = 40.px
+        position = Position.relative
+        top = 2.px
+        left = 11.px
+
+        filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
+    }
+
+    val handleMin by css {
+        width = 20.px
+        height = 40.px
+        position = Position.relative
+        top = 2.px
+        left = 11.px
+
+        filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
+    }
+    val handleMax by css {
+        width = 20.px
+        height = 40.px
+        position = Position.relative
+        top = 2.px
+        left = 11.px
+
+        filter = "drop-shadow(1px 1px 1px rgba(0, 0, 0, .3))"
     }
 
     val handleNotch by css {

--- a/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
+++ b/src/jsMain/kotlin/baaahs/app/ui/gadgets/slider/ThemedStyles.kt
@@ -65,6 +65,18 @@ class ThemedStyles(val theme: Theme) : StyleSheet("app-ui-gadgets-Slider", isSta
             pointerEvents = PointerEvents.none
         }
     }
+    val handleTouchAreaMin by css(handleTouchArea) {
+        width = 24.px
+        left = -12.px
+    }
+    val handleTouchAreaMax by css(handleTouchArea) {
+        width = 24.px
+        left = 12.px
+
+        img {
+            left = (-7).px
+        }
+    }
 
     val handleWrapper by css {
         position = Position.absolute

--- a/src/jsMain/kotlin/baaahs/ui/slider/SliderView.kt
+++ b/src/jsMain/kotlin/baaahs/ui/slider/SliderView.kt
@@ -166,6 +166,7 @@ private val Slider = xComponent<BetterSliderProps>("Slider") { props ->
             pointerDownOffset.current = null
             pointerDownOffset.current = handle.value - getEventValue(e)
             activeHandle = handle
+            println("active handle.id = ${handle.id}")
             props.onSlideStart?.invoke(handle)
         } else {
             pointerDownOffset.current = null

--- a/src/jsMain/resources/assets/slider-handle-full.svg
+++ b/src/jsMain/resources/assets/slider-handle-full.svg
@@ -15,9 +15,9 @@
     </defs>
     <mask id="led">
         <rect x="0" y="0" width="25" height="64" fill="white"/>
-        <rect x="1" y="30" width="23" height="5" rx="2" fill="black" stroke="#0040ff"/>
+        <rect x="3" y="30" width="19" height="5" rx="2" fill="black" stroke="#0040ff"/>
     </mask>
-    <rect x="1" y="30" width="25" height="5" fill="#00FF28"/>
+    <rect x="3" y="30" width="19" height="5" fill="#00FF28"/>
     <rect x="0" y="0" width="25" height="64" fill="url(#gradient)" mask="url(#led)"/>
     <path stroke="#007DA9" d="M 0 6.5 L 25 6.5" opacity=".25"/>
     <path stroke="#007DA9" d="M 0 13.5 L 25 13.5"/>
@@ -31,5 +31,5 @@
     <path stroke="#B8D5CF" d="M 0 58 L 25 58" opacity=".25"/>
     <path stroke="#007DA9" fill="none" opacity=".75" d="M 24.5 0.5 L 24.5 63.5 L .5 63.5"/>
     <path stroke="#B8D5CF" fill="none" opacity=".75" d="M 25 0.5 L .5 0 L .5 64"/>
-    <rect x="1" y="30" width="23" height="5" rx="2" fill="none" stroke="#0040ff"/>
+    <rect x="3" y="30" width="19" height="5" rx="2" fill="none" stroke="#0040ff"/>
 </svg>

--- a/src/jsMain/resources/assets/slider-handle-full.svg
+++ b/src/jsMain/resources/assets/slider-handle-full.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" focusable="false"
+     viewBox="0 0 25 64" width="25" height="64"
+     preserveAspectRatio="none">
+    <defs>
+        <linearGradient id="gradient" gradientUnits="userSpaceOnUse" x1="12.5" y1="0" x2="12.5" y2="50"
+                        gradientTransform="matrix(1, 0, 0, 1.281417, 0.854204, 0.000001)">
+            <stop offset="0" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#00A4D1"/>
+            <stop offset="0.9" stop-color="#6ABBC0"/>
+            <stop offset="0.9" stop-color="#00A4D1"/>
+            <stop offset="1" stop-color="#00A4D1"/>
+        </linearGradient>
+    </defs>
+    <mask id="led">
+        <rect x="0" y="0" width="25" height="64" fill="white"/>
+        <rect x="1" y="30" width="23" height="5" rx="2" fill="black" stroke="#0040ff"/>
+    </mask>
+    <rect x="1" y="30" width="25" height="5" fill="#00FF28"/>
+    <rect x="0" y="0" width="25" height="64" fill="url(#gradient)" mask="url(#led)"/>
+    <path stroke="#007DA9" d="M 0 6.5 L 25 6.5" opacity=".25"/>
+    <path stroke="#007DA9" d="M 0 13.5 L 25 13.5"/>
+    <path stroke="#B8D5CF" d="M 0 14.5 L 25 14.5"/>
+    <path stroke="#007DA9" d="M 0 22 L 25 22"/>
+    <path stroke="#B8D5CF" d="M 0 23 L 25 23"/>
+    <path stroke="#007DA9" d="M 0 41 L 25 41"/>
+    <path stroke="#B8D5CF" d="M 0 42 L 25 42"/>
+    <path stroke="#007DA9" d="M 0 50 L 25 50"/>
+    <path stroke="#B8D5CF" d="M 0 51 L 25 51"/>
+    <path stroke="#B8D5CF" d="M 0 58 L 25 58" opacity=".25"/>
+    <path stroke="#007DA9" fill="none" opacity=".75" d="M 24.5 0.5 L 24.5 63.5 L .5 63.5"/>
+    <path stroke="#B8D5CF" fill="none" opacity=".75" d="M 25 0.5 L .5 0 L .5 64"/>
+    <rect x="1" y="30" width="23" height="5" rx="2" fill="none" stroke="#0040ff"/>
+</svg>

--- a/src/jsMain/resources/assets/slider-handle-max.svg
+++ b/src/jsMain/resources/assets/slider-handle-max.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" focusable="false"
+     viewBox="0 0 25 64" width="25" height="64"
+     preserveAspectRatio="none">
+    <defs>
+        <linearGradient id="gradient" gradientUnits="userSpaceOnUse" x1="12" y1="0" x2="12" y2="50"
+                        gradientTransform="matrix(1, 0, 0, 1.281417, 0.854204, 0.000001)">
+            <stop offset="0" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#00A4D1"/>
+            <stop offset="0.9" stop-color="#6ABBC0"/>
+            <stop offset="0.9" stop-color="#00A4D1"/>
+            <stop offset="1" stop-color="#00A4D1"/>
+        </linearGradient>
+    </defs>
+    <mask id="led">
+        <rect x="0" y="0" width="25" height="64" fill="white"/>
+        <rect x="3" y="30" width="19" height="5" rx="2" fill="black" stroke="#0040ff"/>
+<!--        <rect x="0" y="37" width="25" height="28" fill=""/>-->
+    </mask>
+    <rect x="3" y="30" width="19" height="5" fill="#00FF28"/>
+    <rect x="13" y="0" width="25" height="64" fill="url(#gradient)" mask="url(#led)"/>
+    <path stroke="#007DA9" d="M 13 6.5 L 25 6.5" opacity=".25"/>
+    <path stroke="#007DA9" d="M 13 13.5 L 25 13.5"/>
+    <path stroke="#B8D5CF" d="M 13 14.5 L 25 14.5"/>
+    <path stroke="#007DA9" d="M 13 22 L 25 22"/>
+    <path stroke="#B8D5CF" d="M 13 23 L 25 23"/>
+    <path stroke="#007DA9" d="M 13 41 L 25 41" opacity=".5"/>
+    <path stroke="#B8D5CF" d="M 13 42 L 25 42" opacity=".5"/>
+    <path stroke="#007DA9" d="M 13 50 L 25 50" opacity=".5"/>
+    <path stroke="#B8D5CF" d="M 13 51 L 25 51" opacity=".5"/>
+    <path stroke="#B8D5CF" d="M 13 58 L 25 58" opacity=".25" mask="url(#led)"/>
+    <path stroke="#007DA9" fill="none" opacity=".75" d="M 24.5 0.5 L 24.5 37.5 L 12.5 37.5"/>
+    <path stroke="#B8D5CF" fill="none" opacity=".75" d="M 25 0.5 L 13 0 L 13 64"/>
+    <rect x="3" y="30" width="19" height="5" rx="2" fill="none" stroke="#0040ff"/>
+    <path fill="#000000" d="M 15 43 L 19 49 L 23 43" opacity=".5"/>
+</svg>

--- a/src/jsMain/resources/assets/slider-handle-min.svg
+++ b/src/jsMain/resources/assets/slider-handle-min.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" focusable="false"
+     viewBox="0 0 25 64" width="25" height="64"
+     preserveAspectRatio="none">
+    <defs>
+        <linearGradient id="gradient" gradientUnits="userSpaceOnUse" x1="12" y1="0" x2="12" y2="50"
+                        gradientTransform="matrix(1, 0, 0, 1.281417, 0.854204, 0.000001)">
+            <stop offset="0" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#6ABBC0"/>
+            <stop offset="0.1" stop-color="#00A4D1"/>
+            <stop offset="0.9" stop-color="#6ABBC0"/>
+            <stop offset="0.9" stop-color="#00A4D1"/>
+            <stop offset="1" stop-color="#00A4D1"/>
+        </linearGradient>
+    </defs>
+    <mask id="led">
+        <rect x="0" y="0" width="25" height="64" fill="white"/>
+        <rect x="3" y="30" width="19" height="5" rx="2" fill="black" stroke="#0040ff"/>
+<!--        <rect x="0" y="0" width="23" height="27" fill=""/>-->
+    </mask>
+    <rect x="3" y="30" width="19" height="5" fill="#00FF28"/>
+    <rect x="0" y="0" width="12" height="64" fill="url(#gradient)" mask="url(#led)"/>
+    <path stroke="#007DA9" d="M 0 6.5 L 12 6.5" opacity=".25"/>
+    <path stroke="#007DA9" d="M 0 13.5 L 12 13.5" opacity=".5"/>
+    <path stroke="#B8D5CF" d="M 0 14.5 L 12 14.5" opacity=".5"/>
+    <path stroke="#007DA9" d="M 0 22 L 12 22" opacity=".5"/>
+    <path stroke="#B8D5CF" d="M 0 23 L 12 23" opacity=".5"/>
+    <path stroke="#007DA9" d="M 0 41 L 12 41"/>
+    <path stroke="#B8D5CF" d="M 0 42 L 12 42"/>
+    <path stroke="#007DA9" d="M 0 50 L 12 50"/>
+    <path stroke="#B8D5CF" d="M 0 51 L 12 51"/>
+    <path stroke="#B8D5CF" d="M 0 58 L 12 58" opacity=".25"/>
+    <path stroke="#007DA9" fill="none" opacity=".75" d="M 12 0 L 12 63.5 L .5 63.5"/>
+    <path stroke="#B8D5CF" fill="none" opacity=".75" d="M 12 0.5 L .5 0 L .5 64"/>
+    <path stroke="#B8D5CF" fill="none" opacity=".75" d="M 12 0 L 0 0 L 0 64"/>
+    <rect x="3" y="30" width="19" height="5" rx="2" fill="none" stroke="#0040ff"/>
+    <path fill="#000000" d="M 2 21 L 6 15 L 10 21" opacity=".5"/>
+</svg>


### PR DESCRIPTION
Prettier beatlink-mode sliders, better touch areas, SVG.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/1166cf96-c90a-475b-a09a-1f957ab44cc8">

There's still a bug that you can't tap to move the floor/min slider, you have to drag it (unlike the position/max slider, which moves to where you tapped).