### PR TITLE
recover from brain losing network

### DIFF
--- a/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
@@ -126,7 +126,8 @@ class ComponentRenderEngine(
     // This must be run from within a GL context.
     private fun incorporateNewFixtures() {
         if (renderTargetsToRemove.isNotEmpty()) {
-//            TODO("remove TBD")
+//            TODO(question for xian): ("remove TBD"), how do we do this?
+//            renderTargets.removeAll(renderTargetsToRemove)
         }
 
         if (renderTargetsToAdd.isNotEmpty()) {

--- a/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
+++ b/src/commonMain/kotlin/baaahs/gl/render/ComponentRenderEngine.kt
@@ -128,6 +128,7 @@ class ComponentRenderEngine(
         if (renderTargetsToRemove.isNotEmpty()) {
 //            TODO(question for xian): ("remove TBD"), how do we do this?
 //            renderTargets.removeAll(renderTargetsToRemove)
+//            context: https://github.com/baaahs/sparklemotion/pull/613/files#r1748974029
         }
 
         if (renderTargetsToAdd.isNotEmpty()) {

--- a/src/commonMain/kotlin/baaahs/sm/brain/BrainManager.kt
+++ b/src/commonMain/kotlin/baaahs/sm/brain/BrainManager.kt
@@ -106,7 +106,7 @@ class BrainManager(
         }
 
         val existingController = activeBrains[brainId]
-        if (existingController != null && existingController.lastError == null) {
+        if (existingController != null && existingController.lastError == null && existingController.brainAddress == brainAddress) {
             // Duplicate packet?
             logger.warn { "Ignore hello from ${existingController.controllerId} @ $brainAddress, duplicate packet?" }
             return
@@ -134,7 +134,7 @@ class BrainManager(
     }
 
     inner class BrainController(
-        private val brainAddress: Network.Address,
+        public val brainAddress: Network.Address,
         private val brainId: BrainId,
         private val helloMessage: BrainHelloMessage,
         override val defaultFixtureOptions: FixtureOptions?,
@@ -172,6 +172,9 @@ class BrainManager(
                 null,
                 BrainManager.defaultFixtureOptions
             ))
+        }
+        public fun getAddress(): Network.Address {
+          return this.brainAddress
         }
     }
 


### PR DESCRIPTION
Problem: If pinky fails to send to a brain, it appears to stop sending messages to it altogether (requiring a restart of sparklemotion). We also currently cannot handle a brain changing IP address, as we do not overwrite any state for an existing brainid.

This WIP PR clears out brain state if a new Hello is received _and_ we have errored on sending to this brain. This results in a failure on the first hello since reconnect, but then the second one successfully re-initializes the brain. We still end up with duplicate fixtures as remove appears to not be implemented, as shown by the log below where the brain has reconnected twice, resulting in 3 Pixel Array Fixtures.

```
2024-09-07 11:32:57.403 [DefaultDispatcher-worker-6] INFO  ComponentRenderEngine - Rendering 6144 components for 3 Pixel Array fixtures.
2024-09-07 11:32:57.411 [DefaultDispatcher-worker-6] INFO  ControllersManager - 1 controllers online (Brain=1).
```

I'm looking for feedback on whether fixture removal is simple, otherwise we could consider a more fault-tolerant transport strategy where we track the latest ip of the brain and use it in the transport.